### PR TITLE
feat: add utility layer for PowerShell, registry, and WMI access

### DIFF
--- a/src/winposture/exceptions.py
+++ b/src/winposture/exceptions.py
@@ -1,0 +1,11 @@
+"""Custom exceptions for WinPosture."""
+
+from __future__ import annotations
+
+
+class WinPostureError(Exception):
+    """Raised when a WinPosture utility operation fails in an expected way.
+
+    Examples: PowerShell non-zero exit, timeout, JSON parse failure,
+    access-denied registry read, or running on a non-Windows platform.
+    """

--- a/src/winposture/utils.py
+++ b/src/winposture/utils.py
@@ -1,22 +1,232 @@
 """Shared helper utilities for WinPosture.
 
 All PowerShell, WMI, and registry access goes through this module so that
-check modules stay clean and testable (mock these helpers, not subprocess).
+check modules stay clean and testable (mock subprocess.run in tests, not
+internal helpers).
 """
 
 from __future__ import annotations
 
 import ctypes
+import json
 import logging
 import subprocess
 import sys
-from typing import Any
+
+from winposture.exceptions import WinPostureError
 
 log = logging.getLogger(__name__)
 
+# Base PowerShell invocation flags shared by every helper
+_PS_CMD = [
+    "powershell.exe",
+    "-NonInteractive",
+    "-NoProfile",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-Command",
+]
+
+
+# ---------------------------------------------------------------------------
+# Core PowerShell runner
+# ---------------------------------------------------------------------------
+
+
+def run_powershell(command: str, timeout: int = 30) -> str:
+    """Run a PowerShell command and return its stdout as a string.
+
+    Args:
+        command: The PowerShell command or script block to execute.
+        timeout: Seconds before the subprocess is killed (default 30).
+
+    Returns:
+        stdout stripped of leading/trailing whitespace.
+
+    Raises:
+        WinPostureError: On non-zero exit code, timeout, or launch failure.
+    """
+    log.debug("run_powershell: %s", command[:200])
+    try:
+        result = subprocess.run(
+            [*_PS_CMD, command],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise WinPostureError(
+            f"PowerShell command timed out after {timeout}s: {command[:80]}"
+        ) from exc
+    except FileNotFoundError as exc:
+        raise WinPostureError("powershell.exe not found — is this Windows?") from exc
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        raise WinPostureError(
+            f"PowerShell exited {result.returncode}: {stderr}"
+        )
+
+    return result.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# JSON variant
+# ---------------------------------------------------------------------------
+
+
+def run_powershell_json(command: str, timeout: int = 30) -> dict | list:
+    """Run a PowerShell command whose output is JSON and parse it.
+
+    The command is responsible for piping through ``ConvertTo-Json``.
+
+    Args:
+        command: PowerShell command that writes valid JSON to stdout.
+        timeout: Seconds before the subprocess is killed (default 30).
+
+    Returns:
+        Parsed Python ``dict`` or ``list``.
+
+    Raises:
+        WinPostureError: On PowerShell failure, empty output, or invalid JSON.
+    """
+    output = run_powershell(command, timeout=timeout)
+
+    if not output:
+        raise WinPostureError(
+            "PowerShell command returned empty output (expected JSON)"
+        )
+
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise WinPostureError(
+            f"Failed to parse PowerShell JSON output: {exc}"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Registry reader
+# ---------------------------------------------------------------------------
+
+
+def read_registry(hive: str, path: str, value_name: str) -> str | int | None:
+    """Read a single Windows registry value via PowerShell.
+
+    Uses ``Get-ItemProperty`` so the implementation is fully testable by
+    mocking ``subprocess.run`` — no ``winreg`` import required.
+
+    Args:
+        hive:       Registry hive abbreviation: ``HKLM``, ``HKCU``, or ``HKU``.
+        path:       Key path below the hive, e.g.
+                    ``SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion``.
+        value_name: Name of the registry value to read.
+
+    Returns:
+        The value data as ``str`` or ``int``, or ``None`` if the key or
+        value does not exist or access is denied.
+
+    Raises:
+        WinPostureError: If *hive* is not one of the supported abbreviations.
+    """
+    _SUPPORTED_HIVES = {"HKLM", "HKCU", "HKU"}
+    hive_upper = hive.upper()
+    if hive_upper not in _SUPPORTED_HIVES:
+        raise WinPostureError(
+            f"Unsupported registry hive {hive!r}. "
+            f"Supported: {', '.join(sorted(_SUPPORTED_HIVES))}"
+        )
+
+    ps_path = f"{hive_upper}:\\{path}"
+    # Emit nothing (exit 0) when key/value is absent; print the value otherwise
+    script = (
+        f"$p = Get-ItemProperty -LiteralPath '{ps_path}' "
+        f"-Name '{value_name}' -ErrorAction SilentlyContinue; "
+        f"if ($null -ne $p) {{ $p.'{value_name}' }}"
+    )
+
+    try:
+        output = run_powershell(script)
+    except WinPostureError as exc:
+        log.warning(
+            "Registry read failed (%s\\%s\\%s): %s", hive, path, value_name, exc
+        )
+        return None
+
+    if not output:
+        log.debug("Registry value not found: %s\\%s\\%s", hive, path, value_name)
+        return None
+
+    # Preserve integer type when the value looks like a plain integer
+    try:
+        return int(output)
+    except ValueError:
+        return output
+
+
+# ---------------------------------------------------------------------------
+# WMI / CIM query
+# ---------------------------------------------------------------------------
+
+
+def get_wmi_object(
+    wmi_class: str,
+    namespace: str = "root\\cimv2",
+    properties: list[str] | None = None,
+) -> list[dict]:
+    """Query WMI via ``Get-CimInstance`` and return a list of property dicts.
+
+    Args:
+        wmi_class:  WMI class name, e.g. ``Win32_OperatingSystem``.
+        namespace:  WMI namespace (default ``root\\cimv2``).
+        properties: Specific property names to select; ``None`` selects all.
+
+    Returns:
+        A list of dicts, one per WMI instance.  Returns an empty list on
+        access-denied, class-not-found, or any other error — callers should
+        treat an empty list as "could not retrieve data" and produce an
+        appropriate ``Status.ERROR`` result.
+    """
+    select = ", ".join(properties) if properties else "*"
+    script = (
+        f"Get-CimInstance -ClassName '{wmi_class}' -Namespace '{namespace}' "
+        f"| Select-Object {select} "
+        f"| ConvertTo-Json -Depth 3 -Compress"
+    )
+
+    try:
+        output = run_powershell(script)
+    except WinPostureError as exc:
+        log.warning("WMI query failed for %s: %s", wmi_class, exc)
+        return []
+
+    if not output:
+        return []
+
+    try:
+        data = json.loads(output)
+    except json.JSONDecodeError as exc:
+        log.warning("Failed to parse WMI JSON for %s: %s", wmi_class, exc)
+        return []
+
+    # ConvertTo-Json emits a bare object (dict) when only one instance exists
+    if isinstance(data, dict):
+        return [data]
+    if isinstance(data, list):
+        return data
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Platform / privilege helpers
+# ---------------------------------------------------------------------------
+
 
 def is_admin() -> bool:
-    """Return True if the current process is running with administrator privileges."""
+    """Return ``True`` if the current process has administrator privileges.
+
+    Always returns ``False`` on non-Windows platforms.
+    """
     if sys.platform != "win32":
         return False
     try:
@@ -25,89 +235,33 @@ def is_admin() -> bool:
         return False
 
 
-def run_powershell(script: str, timeout: int = 30) -> str:
-    """Run a PowerShell snippet and return stdout as a string.
+def require_windows() -> None:
+    """Raise ``WinPostureError`` if not running on Windows.
 
-    Args:
-        script:  The PowerShell script text to execute.
-        timeout: Maximum seconds to wait for the process (default 30).
-
-    Returns:
-        The combined stdout output, stripped of leading/trailing whitespace.
+    Call once at startup or at the top of any check that is Windows-only.
 
     Raises:
-        RuntimeError: If the process exits with a non-zero return code.
-    """
-    log.debug("run_powershell: %s", script[:120])
-    result = subprocess.run(
-        [
-            "powershell.exe",
-            "-NonInteractive",
-            "-NoProfile",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-Command",
-            script,
-        ],
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(
-            f"PowerShell exited {result.returncode}: {result.stderr.strip()}"
-        )
-    return result.stdout.strip()
-
-
-def read_registry(hive: str, key: str, value: str) -> Any:
-    """Read a single Windows registry value.
-
-    Args:
-        hive:  Registry hive abbreviation, e.g. "HKLM" or "HKCU".
-        key:   Registry key path, e.g. r"SOFTWARE\\Policies\\Microsoft\\Windows".
-        value: Value name to read.
-
-    Returns:
-        The registry value data, or None if the key/value does not exist.
+        WinPostureError: When ``sys.platform`` is not ``"win32"``.
     """
     if sys.platform != "win32":
-        log.warning("read_registry called on non-Windows platform — returning None")
-        return None
-
-    import winreg  # type: ignore[import]
-
-    hive_map: dict[str, int] = {
-        "HKLM": winreg.HKEY_LOCAL_MACHINE,
-        "HKCU": winreg.HKEY_CURRENT_USER,
-        "HKCR": winreg.HKEY_CLASSES_ROOT,
-        "HKU": winreg.HKEY_USERS,
-        "HKCC": winreg.HKEY_CURRENT_CONFIG,
-    }
-    hive_handle = hive_map.get(hive.upper())
-    if hive_handle is None:
-        raise ValueError(f"Unknown registry hive: {hive!r}")
-
-    try:
-        with winreg.OpenKey(hive_handle, key) as reg_key:
-            data, _ = winreg.QueryValueEx(reg_key, value)
-            return data
-    except FileNotFoundError:
-        log.debug("Registry key/value not found: %s\\%s\\%s", hive, key, value)
-        return None
-    except PermissionError:
-        log.warning("Permission denied reading registry: %s\\%s\\%s", hive, key, value)
-        return None
+        raise WinPostureError(
+            f"WinPosture requires Windows. Current platform: {sys.platform!r}"
+        )
 
 
-def ps_bool(script: str) -> bool:
-    """Run a PowerShell script that returns 'True' or 'False' and parse the result.
+# ---------------------------------------------------------------------------
+# Convenience
+# ---------------------------------------------------------------------------
+
+
+def ps_bool(command: str) -> bool:
+    """Run a PowerShell command and parse a ``True``/``False`` string result.
 
     Args:
-        script: PowerShell script whose last output is a boolean string.
+        command: PowerShell command whose last output line is ``True`` or
+                 ``False`` (case-insensitive).
 
     Returns:
-        True if output is "True", False otherwise.
+        ``True`` if the output is ``"true"`` (case-insensitive), else ``False``.
     """
-    output = run_powershell(script)
-    return output.strip().lower() == "true"
+    return run_powershell(command).lower() == "true"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,392 @@
+"""Tests for winposture.utils.
+
+All subprocess.run calls are mocked so the suite runs on any platform.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from winposture.exceptions import WinPostureError
+from winposture import utils
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_ps(stdout: str = "", returncode: int = 0, stderr: str = "") -> MagicMock:
+    """Return a mock CompletedProcess-like object."""
+    m = MagicMock()
+    m.stdout = stdout
+    m.stderr = stderr
+    m.returncode = returncode
+    return m
+
+
+# ---------------------------------------------------------------------------
+# run_powershell
+# ---------------------------------------------------------------------------
+
+
+class TestRunPowershell:
+    def test_returns_stripped_stdout(self):
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("  hello  ")):
+            assert utils.run_powershell("echo hello") == "hello"
+
+    def test_passes_correct_flags(self):
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("ok")) as mock_run:
+            utils.run_powershell("Get-Date")
+            args = mock_run.call_args[0][0]
+            assert "-NonInteractive" in args
+            assert "-NoProfile" in args
+            assert "-ExecutionPolicy" in args
+            assert "Bypass" in args
+            assert "Get-Date" in args
+
+    def test_nonzero_exit_raises_winposture_error(self):
+        with patch(
+            "winposture.utils.subprocess.run",
+            return_value=_mock_ps("", returncode=1, stderr="Access denied"),
+        ):
+            with pytest.raises(WinPostureError, match="PowerShell exited 1"):
+                utils.run_powershell("some-command")
+
+    def test_stderr_included_in_error(self):
+        with patch(
+            "winposture.utils.subprocess.run",
+            return_value=_mock_ps("", returncode=1, stderr="Some specific error text"),
+        ):
+            with pytest.raises(WinPostureError, match="Some specific error text"):
+                utils.run_powershell("bad-command")
+
+    def test_timeout_raises_winposture_error(self):
+        with patch(
+            "winposture.utils.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="powershell.exe", timeout=30),
+        ):
+            with pytest.raises(WinPostureError, match="timed out after 30s"):
+                utils.run_powershell("Start-Sleep 999")
+
+    def test_powershell_not_found_raises_winposture_error(self):
+        with patch(
+            "winposture.utils.subprocess.run",
+            side_effect=FileNotFoundError("powershell.exe not found"),
+        ):
+            with pytest.raises(WinPostureError, match="powershell.exe not found"):
+                utils.run_powershell("anything")
+
+    def test_empty_output_returns_empty_string(self):
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("")):
+            assert utils.run_powershell("Write-Host ''") == ""
+
+    def test_logs_command_at_debug(self, caplog):
+        import logging
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("out")):
+            with caplog.at_level(logging.DEBUG, logger="winposture.utils"):
+                utils.run_powershell("Get-Process")
+        assert "Get-Process" in caplog.text
+
+    def test_long_command_truncated_in_log(self, caplog):
+        import logging
+        long_cmd = "X" * 500
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("out")):
+            with caplog.at_level(logging.DEBUG, logger="winposture.utils"):
+                utils.run_powershell(long_cmd)
+        # The log message should be truncated to 200 chars, not the full 500
+        log_entry = next(r for r in caplog.records if "winposture.utils" in r.name)
+        assert len(log_entry.getMessage()) < len(long_cmd)
+
+    def test_custom_timeout_passed_to_subprocess(self):
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("ok")) as mock_run:
+            utils.run_powershell("Get-Date", timeout=5)
+            _, kwargs = mock_run.call_args
+            assert kwargs["timeout"] == 5
+
+
+# ---------------------------------------------------------------------------
+# run_powershell_json
+# ---------------------------------------------------------------------------
+
+
+class TestRunPowershellJson:
+    def test_parses_json_object(self):
+        payload = json.dumps({"Name": "Defender", "Enabled": True})
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps(payload)):
+            result = utils.run_powershell_json("... | ConvertTo-Json")
+        assert result == {"Name": "Defender", "Enabled": True}
+
+    def test_parses_json_array(self):
+        payload = json.dumps([{"Port": 80}, {"Port": 443}])
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps(payload)):
+            result = utils.run_powershell_json("... | ConvertTo-Json")
+        assert result == [{"Port": 80}, {"Port": 443}]
+
+    def test_empty_output_raises(self):
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("")):
+            with pytest.raises(WinPostureError, match="empty output"):
+                utils.run_powershell_json("Get-Nothing | ConvertTo-Json")
+
+    def test_malformed_json_raises(self):
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("{not valid json}")):
+            with pytest.raises(WinPostureError, match="Failed to parse"):
+                utils.run_powershell_json("some-command")
+
+    def test_powershell_failure_propagates(self):
+        with patch(
+            "winposture.utils.subprocess.run",
+            return_value=_mock_ps("", returncode=1, stderr="Access is denied"),
+        ):
+            with pytest.raises(WinPostureError, match="Access is denied"):
+                utils.run_powershell_json("Get-Something | ConvertTo-Json")
+
+    def test_single_item_array(self):
+        payload = json.dumps([{"Key": "Value"}])
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps(payload)):
+            result = utils.run_powershell_json("cmd")
+        assert result == [{"Key": "Value"}]
+
+    def test_nested_json(self):
+        payload = json.dumps({"outer": {"inner": [1, 2, 3]}})
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps(payload)):
+            result = utils.run_powershell_json("cmd")
+        assert result["outer"]["inner"] == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# read_registry
+# ---------------------------------------------------------------------------
+
+
+class TestReadRegistry:
+    def test_returns_string_value(self):
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("Windows 11 Pro")):
+            result = utils.read_registry("HKLM", "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", "ProductName")
+        assert result == "Windows 11 Pro"
+
+    def test_returns_integer_when_value_is_numeric(self):
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("1")):
+            result = utils.read_registry("HKLM", "SYSTEM\\CurrentControlSet\\Services\\LanmanServer\\Parameters", "SMB1")
+        assert result == 1
+        assert isinstance(result, int)
+
+    def test_returns_none_for_missing_key(self):
+        # PS emits empty output when key doesn't exist
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("")):
+            result = utils.read_registry("HKLM", "SOFTWARE\\DoesNotExist", "Value")
+        assert result is None
+
+    def test_returns_none_on_ps_error(self):
+        # Access denied scenario — PS exits non-zero
+        with patch(
+            "winposture.utils.subprocess.run",
+            return_value=_mock_ps("", returncode=1, stderr="Access denied"),
+        ):
+            result = utils.read_registry("HKCU", "SomePath", "SomeValue")
+        assert result is None
+
+    def test_unsupported_hive_raises(self):
+        with pytest.raises(WinPostureError, match="Unsupported registry hive"):
+            utils.read_registry("HKCR", "path", "value")
+
+    def test_hklm_hive_accepted(self):
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("data")):
+            assert utils.read_registry("HKLM", "path", "val") == "data"
+
+    def test_hkcu_hive_accepted(self):
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("data")):
+            assert utils.read_registry("HKCU", "path", "val") == "data"
+
+    def test_hku_hive_accepted(self):
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("data")):
+            assert utils.read_registry("HKU", "path", "val") == "data"
+
+    def test_hive_is_case_insensitive(self):
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("data")):
+            assert utils.read_registry("hklm", "path", "val") == "data"
+
+    def test_zero_value_returns_int_zero(self):
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("0")):
+            result = utils.read_registry("HKLM", "path", "val")
+        assert result == 0
+        assert isinstance(result, int)
+
+    def test_ps_path_built_correctly(self):
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("")) as mock_run:
+            utils.read_registry("HKLM", "SOFTWARE\\Test", "MyValue")
+            called_command = mock_run.call_args[0][0][-1]
+        assert "HKLM:\\SOFTWARE\\Test" in called_command
+        assert "MyValue" in called_command
+
+
+# ---------------------------------------------------------------------------
+# get_wmi_object
+# ---------------------------------------------------------------------------
+
+
+class TestGetWmiObject:
+    def test_returns_list_of_dicts_for_array(self):
+        payload = json.dumps([
+            {"Caption": "Windows 11 Pro", "BuildNumber": "22621"},
+            {"Caption": "Windows 11 Pro", "BuildNumber": "22621"},
+        ])
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps(payload)):
+            result = utils.get_wmi_object("Win32_OperatingSystem")
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["Caption"] == "Windows 11 Pro"
+
+    def test_wraps_single_dict_in_list(self):
+        """PS ConvertTo-Json emits a bare object when only one instance exists."""
+        payload = json.dumps({"Caption": "Windows 11 Pro", "BuildNumber": "22621"})
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps(payload)):
+            result = utils.get_wmi_object("Win32_OperatingSystem")
+        assert isinstance(result, list)
+        assert len(result) == 1
+
+    def test_returns_empty_list_on_ps_error(self):
+        """Access denied or class-not-found: return [] not raise."""
+        with patch(
+            "winposture.utils.subprocess.run",
+            return_value=_mock_ps("", returncode=1, stderr="Access is denied"),
+        ):
+            result = utils.get_wmi_object("Win32_Tpm")
+        assert result == []
+
+    def test_returns_empty_list_on_empty_output(self):
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("")):
+            result = utils.get_wmi_object("Win32_SomethingEmpty")
+        assert result == []
+
+    def test_returns_empty_list_on_invalid_json(self):
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("not json at all")):
+            result = utils.get_wmi_object("Win32_BadOutput")
+        assert result == []
+
+    def test_property_filter_included_in_script(self):
+        payload = json.dumps([{"Name": "svchost"}])
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps(payload)) as mock_run:
+            utils.get_wmi_object("Win32_Process", properties=["Name", "ProcessId"])
+            called_command = mock_run.call_args[0][0][-1]
+        assert "Name" in called_command
+        assert "ProcessId" in called_command
+
+    def test_custom_namespace(self):
+        payload = json.dumps({"IsActivated_InitialValue": True})
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps(payload)) as mock_run:
+            utils.get_wmi_object("SoftwareLicensingProduct", namespace="root\\cimv2")
+            called_command = mock_run.call_args[0][0][-1]
+        assert "root\\cimv2" in called_command
+
+    def test_class_not_found_returns_empty_list(self):
+        with patch(
+            "winposture.utils.subprocess.run",
+            return_value=_mock_ps(
+                "", returncode=1, stderr="Invalid class \"Win32_NoSuchClass\""
+            ),
+        ):
+            result = utils.get_wmi_object("Win32_NoSuchClass")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# is_admin
+# ---------------------------------------------------------------------------
+
+
+class TestIsAdmin:
+    def test_returns_false_on_non_windows(self):
+        with patch.object(sys, "platform", "linux"):
+            assert utils.is_admin() is False
+
+    def test_returns_false_on_darwin(self):
+        with patch.object(sys, "platform", "darwin"):
+            assert utils.is_admin() is False
+
+    def test_returns_true_when_ctypes_reports_admin(self):
+        with patch.object(sys, "platform", "win32"):
+            mock_windll = MagicMock()
+            mock_windll.shell32.IsUserAnAdmin.return_value = 1
+            with patch("winposture.utils.ctypes.windll", mock_windll):
+                assert utils.is_admin() is True
+
+    def test_returns_false_when_ctypes_reports_non_admin(self):
+        with patch.object(sys, "platform", "win32"):
+            mock_windll = MagicMock()
+            mock_windll.shell32.IsUserAnAdmin.return_value = 0
+            with patch("winposture.utils.ctypes.windll", mock_windll):
+                assert utils.is_admin() is False
+
+    def test_returns_false_when_ctypes_raises(self):
+        with patch.object(sys, "platform", "win32"):
+            mock_windll = MagicMock()
+            mock_windll.shell32.IsUserAnAdmin.side_effect = OSError("access denied")
+            with patch("winposture.utils.ctypes.windll", mock_windll):
+                assert utils.is_admin() is False
+
+
+# ---------------------------------------------------------------------------
+# require_windows
+# ---------------------------------------------------------------------------
+
+
+class TestRequireWindows:
+    def test_raises_on_linux(self):
+        with patch.object(sys, "platform", "linux"):
+            with pytest.raises(WinPostureError, match="requires Windows"):
+                utils.require_windows()
+
+    def test_raises_on_darwin(self):
+        with patch.object(sys, "platform", "darwin"):
+            with pytest.raises(WinPostureError, match="requires Windows"):
+                utils.require_windows()
+
+    def test_error_includes_platform_name(self):
+        with patch.object(sys, "platform", "freebsd"):
+            with pytest.raises(WinPostureError, match="freebsd"):
+                utils.require_windows()
+
+    def test_passes_on_win32(self):
+        with patch.object(sys, "platform", "win32"):
+            utils.require_windows()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# ps_bool
+# ---------------------------------------------------------------------------
+
+
+class TestPsBool:
+    def test_true_string_returns_true(self):
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("True")):
+            assert utils.ps_bool("some-command") is True
+
+    def test_false_string_returns_false(self):
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("False")):
+            assert utils.ps_bool("some-command") is False
+
+    def test_case_insensitive_true(self):
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("TRUE")):
+            assert utils.ps_bool("some-command") is True
+
+    def test_unexpected_output_returns_false(self):
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("1")):
+            assert utils.ps_bool("some-command") is False
+
+    def test_empty_output_returns_false(self):
+        with patch("winposture.utils.subprocess.run", return_value=_mock_ps("")):
+            assert utils.ps_bool("some-command") is False
+
+    def test_ps_failure_propagates(self):
+        with patch(
+            "winposture.utils.subprocess.run",
+            return_value=_mock_ps("", returncode=1, stderr="err"),
+        ):
+            with pytest.raises(WinPostureError):
+                utils.ps_bool("broken-command")


### PR DESCRIPTION
Introduces WinPostureError (exceptions.py) as the single error type raised by all utility helpers. Rewrites utils.py with five testable helpers:

- run_powershell: subprocess wrapper with timeout/error handling
- run_powershell_json: PS → JSON parse with empty/malformed output guards
- read_registry: HKLM/HKCU/HKU reads via Get-ItemProperty (PS-backed, no winreg import, mockable in tests); returns str | int | None
- get_wmi_object: Get-CimInstance wrapper; gracefully returns [] on access-denied or class-not-found
- require_windows: startup guard that raises WinPostureError on non-Windows

Adds 51 unit tests (test_utils.py) covering success paths, empty output, timeout, access denied, malformed JSON, missing registry keys, and platform guards. All 78 tests pass.