### PR TITLE
feat: implement critical security checks (OS, updates, firewall, AV, …

### DIFF
--- a/src/winposture/checks/antivirus.py
+++ b/src/winposture/checks/antivirus.py
@@ -1,31 +1,177 @@
-"""Check: Windows Defender / antivirus status."""
+"""Check: Antivirus and Windows Defender status."""
 
 from __future__ import annotations
 
 import logging
 
+from winposture.exceptions import WinPostureError
 from winposture.models import CheckResult, Severity, Status
+from winposture.utils import run_powershell_json
 
 log = logging.getLogger(__name__)
 
 CATEGORY = "Antivirus"
 
+_SIGNATURE_WARN_DAYS = 7
+
+# Try Defender first; catch handles Server SKUs where Get-MpComputerStatus is absent.
+_PS_DEFENDER = (
+    "try { "
+    "Get-MpComputerStatus | Select-Object "
+    "AMServiceEnabled, RealTimeProtectionEnabled, AntivirusEnabled, "
+    "TamperProtectionEnabled, AntivirusSignatureAge "
+    "| ConvertTo-Json -Compress "
+    "} catch { '{\"AMServiceEnabled\":false,\"RealTimeProtectionEnabled\":false,"
+    "\"AntivirusEnabled\":false,\"TamperProtectionEnabled\":false,\"AntivirusSignatureAge\":999}' }"
+)
+
+# SecurityCenter2 lists all registered AV products (requires desktop SKU).
+_PS_SECURITY_CENTER = (
+    "Get-CimInstance -Namespace root\\SecurityCenter2 "
+    "-ClassName AntiVirusProduct "
+    "| Select-Object displayName, productState "
+    "| ConvertTo-Json -Compress"
+)
+
 
 def run() -> list[CheckResult]:
-    """Return antivirus / Windows Defender status checks.
+    """Return antivirus status checks.
 
     Returns:
-        list[CheckResult]: Results about AV enablement and definition age.
+        list[CheckResult]: Results for Defender RTP, signature age, tamper
+        protection, and registered AV products.
     """
-    # TODO: implement via Get-MpComputerStatus PowerShell cmdlet
-    return [
-        CheckResult(
+    results: list[CheckResult] = []
+    results.extend(_check_defender())
+    results.extend(_check_security_center())
+    return results
+
+
+def _check_defender() -> list[CheckResult]:
+    """Check Windows Defender via Get-MpComputerStatus."""
+    try:
+        data = run_powershell_json(_PS_DEFENDER)
+    except WinPostureError as exc:
+        return [_error("Windows Defender", str(exc))]
+
+    if isinstance(data, list):
+        data = data[0] if data else {}
+
+    am_enabled = bool(data.get("AMServiceEnabled", False))
+    rtp_enabled = bool(data.get("RealTimeProtectionEnabled", False))
+    av_enabled = bool(data.get("AntivirusEnabled", False))
+    tamper = bool(data.get("TamperProtectionEnabled", False))
+    sig_age = int(data.get("AntivirusSignatureAge") or 0)
+
+    results: list[CheckResult] = []
+
+    # Real-time protection (most critical AV check)
+    results.append(CheckResult(
+        category=CATEGORY,
+        check_name="Defender Real-Time Protection",
+        status=Status.PASS if rtp_enabled else Status.FAIL,
+        severity=Severity.CRITICAL,
+        description="Checks whether Windows Defender real-time protection is active.",
+        details=(
+            f"RealTimeProtectionEnabled: {rtp_enabled} | "
+            f"AMServiceEnabled: {am_enabled} | "
+            f"AntivirusEnabled: {av_enabled}"
+        ),
+        remediation=(
+            "" if rtp_enabled else
+            "Enable real-time protection: "
+            "Set-MpPreference -DisableRealtimeMonitoring $false. "
+            "Or: Windows Security → Virus & threat protection → Real-time protection: On"
+        ),
+    ))
+
+    # Signature age
+    sig_ok = sig_age <= _SIGNATURE_WARN_DAYS
+    results.append(CheckResult(
+        category=CATEGORY,
+        check_name="Defender Signature Age",
+        status=Status.PASS if sig_ok else Status.WARN,
+        severity=Severity.HIGH,
+        description=(
+            f"Checks whether Defender virus definitions are less than "
+            f"{_SIGNATURE_WARN_DAYS} days old."
+        ),
+        details=f"Antivirus signature age: {sig_age} day(s).",
+        remediation=(
+            "" if sig_ok else
+            "Update Defender signatures immediately: Update-MpSignature. "
+            "Or: Windows Security → Virus & threat protection → Check for updates"
+        ),
+    ))
+
+    # Tamper protection
+    results.append(CheckResult(
+        category=CATEGORY,
+        check_name="Defender Tamper Protection",
+        status=Status.PASS if tamper else Status.WARN,
+        severity=Severity.MEDIUM,
+        description=(
+            "Checks whether Tamper Protection is enabled to prevent "
+            "unauthorised changes to Defender settings."
+        ),
+        details=f"TamperProtectionEnabled: {tamper}",
+        remediation=(
+            "" if tamper else
+            "Enable Tamper Protection: "
+            "Windows Security → Virus & threat protection → "
+            "Manage settings → Tamper Protection: On"
+        ),
+    ))
+
+    return results
+
+
+def _check_security_center() -> list[CheckResult]:
+    """List antivirus products registered with Windows Security Center."""
+    try:
+        data = run_powershell_json(_PS_SECURITY_CENTER)
+    except WinPostureError as exc:
+        return [_error("Registered AV Products", str(exc))]
+
+    products = data if isinstance(data, list) else ([data] if data else [])
+
+    if not products:
+        return [CheckResult(
             category=CATEGORY,
-            check_name="Windows Defender Status",
-            status=Status.INFO,
+            check_name="Registered AV Products",
+            status=Status.FAIL,
             severity=Severity.CRITICAL,
-            description="Checks whether Windows Defender is enabled and definitions are current.",
-            details="Not yet implemented.",
-            remediation="",
-        )
-    ]
+            description="Lists antivirus products registered with Windows Security Center.",
+            details=(
+                "No antivirus product is registered with Windows Security Center "
+                "(root\\SecurityCenter2)."
+            ),
+            remediation=(
+                "Install and enable a supported antivirus product, "
+                "or ensure Windows Defender is enabled and not suppressed by policy."
+            ),
+        )]
+
+    names = [str(p.get("displayName", "Unknown")) for p in products]
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="Registered AV Products",
+        status=Status.INFO,
+        severity=Severity.INFO,
+        description="Lists antivirus products registered with Windows Security Center.",
+        details=f"Registered AV product(s): {', '.join(names)}",
+        remediation="",
+    )]
+
+
+def _error(check_name: str, details: str) -> CheckResult:
+    """Return a synthetic ERROR result for a failed sub-check."""
+    return CheckResult(
+        category=CATEGORY,
+        check_name=check_name,
+        status=Status.ERROR,
+        severity=Severity.INFO,
+        description="An error occurred while running this check.",
+        details=details,
+        remediation="Run with --log-level DEBUG for more detail.",
+    )

--- a/src/winposture/checks/encryption.py
+++ b/src/winposture/checks/encryption.py
@@ -1,31 +1,125 @@
-"""Check: BitLocker drive encryption status."""
+"""Check: BitLocker disk encryption status per fixed drive."""
 
 from __future__ import annotations
 
 import logging
 
+from winposture.exceptions import WinPostureError
 from winposture.models import CheckResult, Severity, Status
+from winposture.utils import run_powershell_json
 
 log = logging.getLogger(__name__)
 
 CATEGORY = "Encryption"
 
+# Get-BitLockerVolume requires admin; the outer try/catch returns an empty JSON
+# array so run() can produce a graceful WARN instead of crashing.
+_PS_BITLOCKER = (
+    "try { "
+    "Get-BitLockerVolume "
+    "| Select-Object MountPoint, VolumeType, VolumeStatus, "
+    "ProtectionStatus, EncryptionMethod, EncryptionPercentage "
+    "| ConvertTo-Json -Compress "
+    "} catch { '[]' }"
+)
+
+# ProtectionStatus values from Get-BitLockerVolume
+_PROTECTION_ON = 1
+
 
 def run() -> list[CheckResult]:
-    """Return BitLocker encryption status for all drives.
+    """Return BitLocker encryption status checks.
 
     Returns:
-        list[CheckResult]: One result per detected drive volume.
+        list[CheckResult]: One result per detected volume, or a single WARN/ERROR
+        result when BitLocker data is unavailable.
     """
-    # TODO: implement via Get-BitLockerVolume PowerShell cmdlet
-    return [
-        CheckResult(
+    try:
+        data = run_powershell_json(_PS_BITLOCKER)
+    except WinPostureError as exc:
+        return [CheckResult(
             category=CATEGORY,
-            check_name="BitLocker — System Drive",
-            status=Status.INFO,
+            check_name="BitLocker Status",
+            status=Status.ERROR,
             severity=Severity.HIGH,
-            description="Checks whether BitLocker encryption is enabled on each drive.",
-            details="Not yet implemented.",
+            description="Checks BitLocker drive encryption status.",
+            details=str(exc),
+            remediation=(
+                "Run WinPosture as Administrator for full BitLocker status. "
+                "Run with --log-level DEBUG for more detail."
+            ),
+        )]
+
+    volumes = data if isinstance(data, list) else ([data] if data else [])
+
+    if not volumes:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="BitLocker Status",
+            status=Status.WARN,
+            severity=Severity.HIGH,
+            description="Checks BitLocker drive encryption status.",
+            details=(
+                "No BitLocker volumes returned. "
+                "BitLocker may be unavailable, or elevated privileges are required."
+            ),
+            remediation=(
+                "Run WinPosture as Administrator to retrieve BitLocker status. "
+                "To enable BitLocker on the OS drive: "
+                "Enable-BitLocker -MountPoint 'C:' "
+                "-EncryptionMethod XtsAes256 -RecoveryPasswordProtector"
+            ),
+        )]
+
+    results: list[CheckResult] = []
+    for vol in volumes:
+        results.extend(_check_volume(vol))
+    return results
+
+
+def _check_volume(vol: dict) -> list[CheckResult]:
+    """Evaluate a single BitLocker volume dict and return a CheckResult."""
+    mount = str(vol.get("MountPoint", "?:"))
+    vol_type = str(vol.get("VolumeType") or "Unknown")
+    vol_status = str(vol.get("VolumeStatus") or "Unknown")
+    protection = int(vol.get("ProtectionStatus") or 0)
+    method = str(vol.get("EncryptionMethod") or "None")
+    pct = int(vol.get("EncryptionPercentage") or 0)
+
+    # Identify OS drive by VolumeType; fall back to drive letter heuristic
+    is_os = "OperatingSystem" in vol_type or mount.upper().startswith("C:")
+    is_protected = protection == _PROTECTION_ON
+    severity = Severity.HIGH if is_os else Severity.MEDIUM
+
+    if is_protected:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name=f"BitLocker — {mount}",
+            status=Status.PASS,
+            severity=severity,
+            description=f"Checks BitLocker encryption status for drive {mount}.",
+            details=(
+                f"Drive: {mount} | Type: {vol_type} | "
+                f"Status: {vol_status} | Method: {method} | "
+                f"Encrypted: {pct}% | Protection: On"
+            ),
             remediation="",
-        )
-    ]
+        )]
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name=f"BitLocker — {mount}",
+        status=Status.FAIL,
+        severity=severity,
+        description=f"Checks BitLocker encryption status for drive {mount}.",
+        details=(
+            f"Drive: {mount} | Type: {vol_type} | "
+            f"Status: {vol_status} | "
+            f"Encrypted: {pct}% | Protection: Off"
+        ),
+        remediation=(
+            f"Enable BitLocker on drive {mount}: "
+            f"Enable-BitLocker -MountPoint '{mount}' "
+            f"-EncryptionMethod XtsAes256 -RecoveryPasswordProtector"
+        ),
+    )]

--- a/src/winposture/checks/firewall.py
+++ b/src/winposture/checks/firewall.py
@@ -1,36 +1,118 @@
-"""Check: Windows Firewall status across all profiles."""
+"""Check: Windows Firewall — per-profile enabled status and default inbound action."""
 
 from __future__ import annotations
 
 import logging
 
+from winposture.exceptions import WinPostureError
 from winposture.models import CheckResult, Severity, Status
+from winposture.utils import run_powershell_json
 
 log = logging.getLogger(__name__)
 
 CATEGORY = "Firewall"
 
-_PROFILES = ["Domain", "Private", "Public"]
+_PS_PROFILES = (
+    "Get-NetFirewallProfile "
+    "| Select-Object Name, Enabled, DefaultInboundAction, DefaultOutboundAction "
+    "| ConvertTo-Json -Compress"
+)
+
+# PS 5.1 serialises the Action enum as integers; PS 7+ as strings.
+# NetSecurity.Action: NotConfigured=0, Allow=2, Block=4
+_ACTION_INT_MAP: dict[int, str] = {0: "NotConfigured", 2: "Allow", 4: "Block"}
+
+
+def _parse_action(val: object) -> str:
+    """Normalise a PS firewall action value to a plain string.
+
+    Args:
+        val: Integer (PS 5.1) or string (PS 7+) representation of the action.
+
+    Returns:
+        One of ``"Block"``, ``"Allow"``, ``"NotConfigured"``, or ``"Unknown(<val>)"``.
+    """
+    if val is None:
+        return "NotConfigured"
+    if isinstance(val, str):
+        return val
+    try:
+        return _ACTION_INT_MAP.get(int(val), f"Unknown({val})")
+    except (TypeError, ValueError):
+        return f"Unknown({val})"
 
 
 def run() -> list[CheckResult]:
-    """Return firewall status for all three Windows Firewall profiles.
+    """Return Windows Firewall profile checks.
+
+    Produces two results per profile: one for the enabled/disabled state and
+    one for the default inbound action.
 
     Returns:
-        list[CheckResult]: One result per firewall profile.
+        list[CheckResult]: Six results for a standard three-profile system.
     """
-    # TODO: implement via Get-NetFirewallProfile PowerShell cmdlet
-    results = []
-    for profile in _PROFILES:
-        results.append(
-            CheckResult(
-                category=CATEGORY,
-                check_name=f"Windows Firewall — {profile} Profile",
-                status=Status.INFO,
-                severity=Severity.HIGH,
-                description=f"Checks whether the Windows Firewall {profile} profile is enabled.",
-                details="Not yet implemented.",
-                remediation="",
-            )
-        )
+    try:
+        data = run_powershell_json(_PS_PROFILES)
+    except WinPostureError as exc:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="Windows Firewall",
+            status=Status.ERROR,
+            severity=Severity.HIGH,
+            description="Checks Windows Firewall profile status.",
+            details=str(exc),
+            remediation="Ensure Get-NetFirewallProfile is available. Run with --log-level DEBUG.",
+        )]
+
+    profiles = data if isinstance(data, list) else [data]
+    results: list[CheckResult] = []
+
+    for profile in profiles:
+        name = str(profile.get("Name", "Unknown"))
+        enabled = bool(profile.get("Enabled", False))
+        inbound = _parse_action(profile.get("DefaultInboundAction"))
+        outbound = _parse_action(profile.get("DefaultOutboundAction"))
+
+        # --- Check 1: profile enabled ---
+        results.append(CheckResult(
+            category=CATEGORY,
+            check_name=f"Firewall — {name} Profile Enabled",
+            status=Status.PASS if enabled else Status.FAIL,
+            severity=Severity.HIGH,
+            description=f"Checks whether the Windows Firewall {name} profile is enabled.",
+            details=f"Profile: {name} | Enabled: {enabled}",
+            remediation=(
+                "" if enabled else
+                f"Enable the {name} firewall profile: "
+                f"Set-NetFirewallProfile -Profile {name} -Enabled True"
+            ),
+        ))
+
+        # --- Check 2: default inbound action ---
+        # "NotConfigured" inherits from Group Policy; the Windows built-in default
+        # is Block, so it is NOT treated as a finding.  Only explicit "Allow" warns.
+        inbound_lower = inbound.lower()
+        inbound_explicit_allow = inbound_lower == "allow"
+        inbound_status = Status.WARN if inbound_explicit_allow else Status.PASS
+        results.append(CheckResult(
+            category=CATEGORY,
+            check_name=f"Firewall — {name} Default Inbound Action",
+            status=inbound_status,
+            severity=Severity.MEDIUM,
+            description=(
+                f"Checks that the {name} profile does not explicitly allow all "
+                "unsolicited inbound connections by default."
+            ),
+            details=(
+                f"Profile: {name} | "
+                f"DefaultInboundAction: {inbound} | "
+                f"DefaultOutboundAction: {outbound}"
+            ),
+            remediation=(
+                "" if not inbound_explicit_allow else
+                f"Set default inbound to Block for the {name} profile: "
+                f"Set-NetFirewallProfile -Profile {name} -DefaultInboundAction Block"
+            ),
+        ))
+
     return results

--- a/src/winposture/checks/os_info.py
+++ b/src/winposture/checks/os_info.py
@@ -1,31 +1,345 @@
-"""Check: OS version, build, and patch level."""
+"""Check: System information — OS version, end-of-life status, uptime, domain, Secure Boot, TPM."""
 
 from __future__ import annotations
 
+import json
 import logging
+from datetime import datetime, timezone
 
+from winposture.exceptions import WinPostureError
 from winposture.models import CheckResult, Severity, Status
+from winposture.utils import run_powershell, run_powershell_json
 
 log = logging.getLogger(__name__)
 
-CATEGORY = "OS"
+CATEGORY = "System"
+
+# Build number → (friendly name, end-of-support date)
+# Uses Home/Pro dates (most restrictive). Server editions noted where the build overlaps.
+# Source: https://learn.microsoft.com/en-us/windows/release-health/
+_EOL_TABLE: dict[int, tuple[str, datetime]] = {
+    10240: ("Windows 10 1507",               datetime(2017,  5,  9, tzinfo=timezone.utc)),
+    10586: ("Windows 10 1511",               datetime(2017, 10, 10, tzinfo=timezone.utc)),
+    14393: ("Windows 10 1607 / Server 2016", datetime(2027,  1, 12, tzinfo=timezone.utc)),
+    15063: ("Windows 10 1703",               datetime(2018, 10,  9, tzinfo=timezone.utc)),
+    16299: ("Windows 10 1709",               datetime(2019,  4,  9, tzinfo=timezone.utc)),
+    17134: ("Windows 10 1803",               datetime(2019, 11, 12, tzinfo=timezone.utc)),
+    17763: ("Windows 10 1809 / Server 2019", datetime(2029,  1,  9, tzinfo=timezone.utc)),
+    18362: ("Windows 10 1903",               datetime(2020, 12,  8, tzinfo=timezone.utc)),
+    18363: ("Windows 10 1909",               datetime(2021,  5, 11, tzinfo=timezone.utc)),
+    19041: ("Windows 10 2004",               datetime(2021, 12, 14, tzinfo=timezone.utc)),
+    19042: ("Windows 10 20H2",               datetime(2022,  5, 10, tzinfo=timezone.utc)),
+    19043: ("Windows 10 21H1",               datetime(2022, 12, 13, tzinfo=timezone.utc)),
+    19044: ("Windows 10 21H2",               datetime(2023,  6, 13, tzinfo=timezone.utc)),
+    19045: ("Windows 10 22H2",               datetime(2025, 10, 14, tzinfo=timezone.utc)),
+    20348: ("Windows Server 2022",           datetime(2031, 10, 14, tzinfo=timezone.utc)),
+    22000: ("Windows 11 21H2",               datetime(2024, 10,  8, tzinfo=timezone.utc)),
+    22621: ("Windows 11 22H2",               datetime(2025, 10, 14, tzinfo=timezone.utc)),
+    22631: ("Windows 11 23H2",               datetime(2026, 11, 10, tzinfo=timezone.utc)),
+    26100: ("Windows 11 24H2",               datetime(2027, 10, 12, tzinfo=timezone.utc)),
+}
+
+# Cumulative updates can push build numbers past the base release build.
+# These ranges catch e.g. 26200 (post-24H2 CU) mapping to "Windows 11 24H2".
+# Sorted descending so the first match wins.
+_EOL_RANGES: list[tuple[int, tuple[str, datetime]]] = [
+    (26100, ("Windows 11 24H2",               datetime(2027, 10, 12, tzinfo=timezone.utc))),
+    (22631, ("Windows 11 23H2",               datetime(2026, 11, 10, tzinfo=timezone.utc))),
+    (22621, ("Windows 11 22H2",               datetime(2025, 10, 14, tzinfo=timezone.utc))),
+    (22000, ("Windows 11 21H2",               datetime(2024, 10,  8, tzinfo=timezone.utc))),
+    (20348, ("Windows Server 2022",           datetime(2031, 10, 14, tzinfo=timezone.utc))),
+    (19041, ("Windows 10 20xx",               datetime(2025, 10, 14, tzinfo=timezone.utc))),
+]
+
+
+def _lookup_eol(build: int) -> tuple[str, datetime] | None:
+    """Return (friendly_name, eol_date) for a build number, using range fallback.
+
+    Tries exact match first, then falls back to the largest known base build
+    that is <= the given build (handles post-GA cumulative update builds).
+    """
+    if build in _EOL_TABLE:
+        return _EOL_TABLE[build]
+    for min_build, entry in _EOL_RANGES:
+        if build >= min_build:
+            return entry
+    return None
+
+_UPTIME_WARN_DAYS = 30
+
+_PS_OS = (
+    "Get-CimInstance Win32_OperatingSystem "
+    "| Select-Object Caption, BuildNumber, Version "
+    "| ConvertTo-Json -Compress"
+)
+_PS_UPTIME = (
+    "[int](New-TimeSpan "
+    "-Start (Get-CimInstance Win32_OperatingSystem).LastBootUpTime).TotalDays"
+)
+_PS_DOMAIN = (
+    "Get-CimInstance Win32_ComputerSystem "
+    "| Select-Object PartOfDomain, Domain, Workgroup "
+    "| ConvertTo-Json -Compress"
+)
+_PS_SECUREBOOT = "try { Confirm-SecureBootUEFI } catch { 'UNSUPPORTED' }"
+_PS_TPM = (
+    "try { Get-Tpm | Select-Object TpmPresent, TpmReady, ManufacturerVersion "
+    "| ConvertTo-Json -Compress } "
+    "catch { '{\"TpmPresent\":false,\"TpmReady\":false,\"ManufacturerVersion\":null}' }"
+)
+
+
+def _now() -> datetime:
+    """Return current UTC time. Exists as a separate function to allow mocking in tests."""
+    return datetime.now(tz=timezone.utc)
 
 
 def run() -> list[CheckResult]:
-    """Return OS version and build information checks.
+    """Return system information checks.
 
     Returns:
-        list[CheckResult]: One or more results about OS currency.
+        list[CheckResult]: Results for OS build, uptime, domain, Secure Boot, and TPM.
     """
-    # TODO: implement using platform / WMI / PowerShell
-    return [
-        CheckResult(
+    results: list[CheckResult] = []
+    results.extend(_check_os_build())
+    results.extend(_check_uptime())
+    results.extend(_check_domain())
+    results.extend(_check_secure_boot())
+    results.extend(_check_tpm())
+    return results
+
+
+def _check_os_build() -> list[CheckResult]:
+    """Check OS version and end-of-support status."""
+    try:
+        data = run_powershell_json(_PS_OS)
+    except WinPostureError as exc:
+        return [_error("OS Version", str(exc)), _error("OS End-of-Support Status", str(exc))]
+
+    if isinstance(data, list):
+        data = data[0] if data else {}
+
+    caption = str(data.get("Caption", "Unknown"))
+    build_str = str(data.get("BuildNumber", "0"))
+    version = str(data.get("Version", ""))
+
+    try:
+        build = int(build_str)
+    except ValueError:
+        build = 0
+
+    version_result = CheckResult(
+        category=CATEGORY,
+        check_name="OS Version",
+        status=Status.INFO,
+        severity=Severity.INFO,
+        description="Reports the installed Windows version and build number.",
+        details=f"{caption}  (Build {build_str}, Version {version})",
+        remediation="",
+    )
+
+    now = _now()
+    eol_entry = _lookup_eol(build)
+    if eol_entry is not None:
+        friendly_name, eol_date = eol_entry
+        if now > eol_date:
+            eol_result = CheckResult(
+                category=CATEGORY,
+                check_name="OS End-of-Support Status",
+                status=Status.FAIL,
+                severity=Severity.HIGH,
+                description="Checks whether the installed Windows build is still supported by Microsoft.",
+                details=(
+                    f"{friendly_name} reached end of support on "
+                    f"{eol_date.strftime('%Y-%m-%d')}. "
+                    f"This build no longer receives security updates."
+                ),
+                remediation=(
+                    "Upgrade to a supported Windows release. "
+                    "See: https://learn.microsoft.com/en-us/windows/release-health/"
+                ),
+            )
+        else:
+            days_remaining = (eol_date - now).days
+            eol_result = CheckResult(
+                category=CATEGORY,
+                check_name="OS End-of-Support Status",
+                status=Status.PASS,
+                severity=Severity.HIGH,
+                description="Checks whether the installed Windows build is still supported by Microsoft.",
+                details=(
+                    f"{friendly_name} is supported until "
+                    f"{eol_date.strftime('%Y-%m-%d')} "
+                    f"({days_remaining} days remaining)."
+                ),
+                remediation="",
+            )
+    else:
+        eol_result = CheckResult(
             category=CATEGORY,
-            check_name="OS Info",
-            status=Status.INFO,
-            severity=Severity.INFO,
-            description="Collects OS version, build number, and patch level.",
-            details="Not yet implemented.",
-            remediation="",
+            check_name="OS End-of-Support Status",
+            status=Status.WARN,
+            severity=Severity.HIGH,
+            description="Checks whether the installed Windows build is still supported by Microsoft.",
+            details=(
+                f"Build {build_str} is not in the known support table. "
+                "Verify this is a current supported release."
+            ),
+            remediation=(
+                "Check the Microsoft support lifecycle page: "
+                "https://learn.microsoft.com/en-us/windows/release-health/"
+            ),
         )
-    ]
+
+    return [version_result, eol_result]
+
+
+def _check_uptime() -> list[CheckResult]:
+    """Check system uptime — long uptime suggests reboots are being skipped after patches."""
+    try:
+        output = run_powershell(_PS_UPTIME)
+        days = int(output.strip())
+    except (WinPostureError, ValueError) as exc:
+        return [_error("System Uptime", str(exc))]
+
+    if days > _UPTIME_WARN_DAYS:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="System Uptime",
+            status=Status.WARN,
+            severity=Severity.MEDIUM,
+            description=f"Warns when uptime exceeds {_UPTIME_WARN_DAYS} days (suggests pending patch reboots).",
+            details=f"System has been running for {days} days without a reboot.",
+            remediation=(
+                "Reboot the system to apply pending patches. "
+                "Review Windows Update history for updates that require a restart."
+            ),
+        )]
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="System Uptime",
+        status=Status.PASS,
+        severity=Severity.MEDIUM,
+        description=f"Warns when uptime exceeds {_UPTIME_WARN_DAYS} days (suggests pending patch reboots).",
+        details=f"System uptime is {days} day(s).",
+        remediation="",
+    )]
+
+
+def _check_domain() -> list[CheckResult]:
+    """Report domain vs workgroup membership (informational)."""
+    try:
+        data = run_powershell_json(_PS_DOMAIN)
+    except WinPostureError as exc:
+        return [_error("Domain Membership", str(exc))]
+
+    if isinstance(data, list):
+        data = data[0] if data else {}
+
+    part_of_domain = bool(data.get("PartOfDomain", False))
+    domain_name = str(data.get("Domain") or data.get("Workgroup") or "UNKNOWN")
+    label = "Domain" if part_of_domain else "Workgroup"
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="Domain Membership",
+        status=Status.INFO,
+        severity=Severity.INFO,
+        description="Reports whether this machine is joined to an Active Directory domain.",
+        details=f"{'Domain-joined' if part_of_domain else 'Workgroup member'}. {label}: {domain_name}",
+        remediation="",
+    )]
+
+
+def _check_secure_boot() -> list[CheckResult]:
+    """Check UEFI Secure Boot status."""
+    try:
+        output = run_powershell(_PS_SECUREBOOT).strip()
+    except WinPostureError as exc:
+        return [_error("Secure Boot", str(exc))]
+
+    if output.upper() == "UNSUPPORTED":
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="Secure Boot",
+            status=Status.WARN,
+            severity=Severity.MEDIUM,
+            description="Checks whether UEFI Secure Boot is enabled.",
+            details="Secure Boot is not supported or the system is running in legacy BIOS mode.",
+            remediation=(
+                "Enable UEFI mode in firmware settings if the hardware supports it. "
+                "Secure Boot requires UEFI firmware."
+            ),
+        )]
+
+    enabled = output.lower() == "true"
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="Secure Boot",
+        status=Status.PASS if enabled else Status.FAIL,
+        severity=Severity.MEDIUM,
+        description="Checks whether UEFI Secure Boot is enabled.",
+        details=f"Secure Boot is {'enabled' if enabled else 'disabled'}.",
+        remediation=(
+            "" if enabled else
+            "Enable Secure Boot in UEFI/BIOS firmware settings. "
+            "Note: may require reinstalling Windows in UEFI mode if currently using legacy BIOS."
+        ),
+    )]
+
+
+def _check_tpm() -> list[CheckResult]:
+    """Check TPM chip presence, readiness, and version."""
+    try:
+        data = run_powershell_json(_PS_TPM)
+    except WinPostureError as exc:
+        return [_error("TPM Status", str(exc))]
+
+    if isinstance(data, list):
+        data = data[0] if data else {}
+
+    present = bool(data.get("TpmPresent", False))
+    ready = bool(data.get("TpmReady", False))
+    version = str(data.get("ManufacturerVersion") or "Unknown")
+
+    if not present:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="TPM Status",
+            status=Status.WARN,
+            severity=Severity.MEDIUM,
+            description="Checks whether a TPM chip is present and functional.",
+            details="No TPM chip detected.",
+            remediation=(
+                "A TPM 2.0 chip is required for BitLocker and is mandatory for Windows 11. "
+                "Enable TPM in UEFI/BIOS settings if available."
+            ),
+        )]
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="TPM Status",
+        status=Status.PASS if ready else Status.WARN,
+        severity=Severity.MEDIUM,
+        description="Checks whether a TPM chip is present and functional.",
+        details=f"TPM present. Ready: {ready}. Firmware version: {version}.",
+        remediation=(
+            "" if ready else
+            "Check TPM status in tpm.msc or Device Manager. "
+            "Clear and re-initialize the TPM if it reports errors."
+        ),
+    )]
+
+
+def _error(check_name: str, details: str) -> CheckResult:
+    """Return a synthetic ERROR result for a failed sub-check."""
+    return CheckResult(
+        category=CATEGORY,
+        check_name=check_name,
+        status=Status.ERROR,
+        severity=Severity.INFO,
+        description="An error occurred while running this check.",
+        details=details,
+        remediation="Run with --log-level DEBUG for more detail.",
+    )

--- a/src/winposture/checks/updates.py
+++ b/src/winposture/checks/updates.py
@@ -1,31 +1,244 @@
-"""Check: Windows Update status."""
+"""Check: Windows Update status — last install date, pending updates, service state."""
 
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 
+from winposture.exceptions import WinPostureError
 from winposture.models import CheckResult, Severity, Status
+from winposture.utils import run_powershell
 
 log = logging.getLogger(__name__)
 
-CATEGORY = "Updates"
+CATEGORY = "Patching"
+
+_FAIL_DAYS = 60   # CRITICAL: no updates installed in this many days
+_WARN_DAYS = 30   # HIGH: no updates installed in this many days
+
+# Get the most recently installed hotfix with a valid date.
+# Some hotfixes have a null InstalledOn; filter those out.
+_PS_LAST_HOTFIX = (
+    "$hf = Get-HotFix "
+    "| Where-Object { $_.InstalledOn -ne $null } "
+    "| Sort-Object InstalledOn -Descending "
+    "| Select-Object -First 1; "
+    "if ($hf) { $hf.InstalledOn.ToString('yyyy-MM-dd') } else { 'NONE' }"
+)
+
+_PS_WU_SERVICE = (
+    "(Get-Service -Name wuauserv -ErrorAction SilentlyContinue).Status"
+)
+
+# Query pending updates via COM. Returns count or 'UNAVAILABLE' on failure.
+_PS_PENDING = (
+    "try { "
+    "$s = New-Object -ComObject Microsoft.Update.Session; "
+    "$r = $s.CreateUpdateSearcher().Search(\"IsInstalled=0 and Type='Software'\"); "
+    "$r.Updates.Count "
+    "} catch { 'UNAVAILABLE' }"
+)
+
+
+def _now() -> datetime:
+    """Return current UTC time. Exists as a separate function to allow mocking in tests."""
+    return datetime.now(tz=timezone.utc)
 
 
 def run() -> list[CheckResult]:
     """Return Windows Update status checks.
 
     Returns:
-        list[CheckResult]: Results about pending/missing updates.
+        list[CheckResult]: Results for last update age, WU service, and pending count.
     """
-    # TODO: implement via COM (wuapi) or PSWindowsUpdate
-    return [
-        CheckResult(
+    results: list[CheckResult] = []
+    results.extend(_check_last_update())
+    results.extend(_check_wu_service())
+    results.extend(_check_pending_updates())
+    return results
+
+
+def _check_last_update() -> list[CheckResult]:
+    """Check when the last Windows Update was installed."""
+    try:
+        output = run_powershell(_PS_LAST_HOTFIX).strip()
+    except WinPostureError as exc:
+        return [_error("Last Windows Update", str(exc))]
+
+    if not output or output == "NONE":
+        return [CheckResult(
             category=CATEGORY,
-            check_name="Windows Update Status",
+            check_name="Last Windows Update",
+            status=Status.WARN,
+            severity=Severity.HIGH,
+            description="Checks when the most recent Windows Update was installed.",
+            details="No hotfixes with a valid install date were found in the hotfix log.",
+            remediation=(
+                "Run Windows Update manually: "
+                "Settings → Windows Update → Check for updates."
+            ),
+        )]
+
+    try:
+        last_update = datetime.strptime(output, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    except ValueError as exc:
+        return [_error("Last Windows Update", f"Could not parse date {output!r}: {exc}")]
+
+    now = _now()
+    age_days = (now - last_update).days
+
+    if age_days >= _FAIL_DAYS:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="Last Windows Update",
+            status=Status.FAIL,
+            severity=Severity.CRITICAL,
+            description="Checks when the most recent Windows Update was installed.",
+            details=(
+                f"Last update installed {age_days} days ago "
+                f"({last_update.strftime('%Y-%m-%d')}). "
+                f"System is {age_days - _FAIL_DAYS} days past the {_FAIL_DAYS}-day threshold."
+            ),
+            remediation=(
+                "Install all pending Windows Updates immediately. "
+                "Open: Start-Process ms-settings:windowsupdate"
+            ),
+        )]
+
+    if age_days >= _WARN_DAYS:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="Last Windows Update",
+            status=Status.WARN,
+            severity=Severity.HIGH,
+            description="Checks when the most recent Windows Update was installed.",
+            details=(
+                f"Last update installed {age_days} days ago "
+                f"({last_update.strftime('%Y-%m-%d')})."
+            ),
+            remediation=(
+                "Check for and install pending Windows Updates: "
+                "Start-Process ms-settings:windowsupdate"
+            ),
+        )]
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="Last Windows Update",
+        status=Status.PASS,
+        severity=Severity.CRITICAL,
+        description="Checks when the most recent Windows Update was installed.",
+        details=(
+            f"Last update installed {age_days} day(s) ago "
+            f"({last_update.strftime('%Y-%m-%d')})."
+        ),
+        remediation="",
+    )]
+
+
+def _check_wu_service() -> list[CheckResult]:
+    """Check whether the Windows Update service is running."""
+    try:
+        output = run_powershell(_PS_WU_SERVICE).strip()
+    except WinPostureError as exc:
+        return [_error("Windows Update Service", str(exc))]
+
+    if not output:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="Windows Update Service",
+            status=Status.ERROR,
+            severity=Severity.HIGH,
+            description="Checks whether the Windows Update (wuauserv) service is running.",
+            details="Could not determine Windows Update service status (service may not exist).",
+            remediation="Verify the service exists: Get-Service -Name wuauserv",
+        )]
+
+    running = output.lower() == "running"
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="Windows Update Service",
+        status=Status.PASS if running else Status.WARN,
+        severity=Severity.HIGH,
+        description="Checks whether the Windows Update (wuauserv) service is running.",
+        details=f"Windows Update service status: {output}.",
+        remediation=(
+            "" if running else
+            "Start the Windows Update service: Start-Service -Name wuauserv. "
+            "If disabled, change startup type: "
+            "Set-Service -Name wuauserv -StartupType Automatic"
+        ),
+    )]
+
+
+def _check_pending_updates() -> list[CheckResult]:
+    """Count Windows Updates that are available but not yet installed."""
+    try:
+        output = run_powershell(_PS_PENDING).strip()
+    except WinPostureError as exc:
+        return [_error("Pending Windows Updates", str(exc))]
+
+    if output == "UNAVAILABLE":
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="Pending Windows Updates",
             status=Status.INFO,
             severity=Severity.HIGH,
-            description="Checks whether Windows Update is enabled and up to date.",
-            details="Not yet implemented.",
+            description="Counts Windows Updates that are available but not yet installed.",
+            details=(
+                "Could not query pending updates "
+                "(Windows Update COM object unavailable or access denied)."
+            ),
             remediation="",
-        )
-    ]
+        )]
+
+    try:
+        count = int(output)
+    except ValueError:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="Pending Windows Updates",
+            status=Status.INFO,
+            severity=Severity.HIGH,
+            description="Counts Windows Updates that are available but not yet installed.",
+            details=f"Unexpected output from pending update check: {output!r}",
+            remediation="",
+        )]
+
+    if count == 0:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="Pending Windows Updates",
+            status=Status.PASS,
+            severity=Severity.HIGH,
+            description="Counts Windows Updates that are available but not yet installed.",
+            details="No pending Windows Updates found.",
+            remediation="",
+        )]
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="Pending Windows Updates",
+        status=Status.FAIL,
+        severity=Severity.HIGH,
+        description="Counts Windows Updates that are available but not yet installed.",
+        details=f"{count} pending Windows Update(s) are available but not installed.",
+        remediation=(
+            f"Install {count} pending update(s): "
+            "Settings → Windows Update → Install now, or: "
+            "Install-WindowsUpdate -AcceptAll (requires PSWindowsUpdate module)"
+        ),
+    )]
+
+
+def _error(check_name: str, details: str) -> CheckResult:
+    """Return a synthetic ERROR result for a failed sub-check."""
+    return CheckResult(
+        category=CATEGORY,
+        check_name=check_name,
+        status=Status.ERROR,
+        severity=Severity.INFO,
+        description="An error occurred while running this check.",
+        details=details,
+        remediation="Run with --log-level DEBUG for more detail.",
+    )

--- a/tests/test_checks/test_antivirus.py
+++ b/tests/test_checks/test_antivirus.py
@@ -1,0 +1,189 @@
+"""Tests for winposture.checks.antivirus."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from winposture.checks import antivirus
+from winposture.exceptions import WinPostureError
+from winposture.models import Status, Severity
+
+
+# ---------------------------------------------------------------------------
+# Shared mock data
+# ---------------------------------------------------------------------------
+
+def _defender(am=True, rtp=True, av=True, tamper=True, sig_age=1) -> dict:
+    return {
+        "AMServiceEnabled": am,
+        "RealTimeProtectionEnabled": rtp,
+        "AntivirusEnabled": av,
+        "TamperProtectionEnabled": tamper,
+        "AntivirusSignatureAge": sig_age,
+    }
+
+
+_SC2_DEFENDER = [{"displayName": "Windows Defender", "productState": 397568}]
+_SC2_THIRD_PARTY = [{"displayName": "CrowdStrike Falcon", "productState": 266240}]
+_SC2_MULTI = [
+    {"displayName": "Windows Defender", "productState": 397568},
+    {"displayName": "Malwarebytes",     "productState": 266240},
+]
+
+
+# ---------------------------------------------------------------------------
+# _check_defender
+# ---------------------------------------------------------------------------
+
+class TestCheckDefender:
+    def test_all_good_returns_three_pass(self):
+        with patch("winposture.checks.antivirus.run_powershell_json",
+                   return_value=_defender()):
+            results = antivirus._check_defender()
+        assert len(results) == 3
+        assert all(r.status == Status.PASS for r in results)
+
+    def test_rtp_disabled_returns_critical_fail(self):
+        with patch("winposture.checks.antivirus.run_powershell_json",
+                   return_value=_defender(rtp=False)):
+            results = antivirus._check_defender()
+        rtp = next(r for r in results if "Real-Time" in r.check_name)
+        assert rtp.status == Status.FAIL
+        assert rtp.severity == Severity.CRITICAL
+        assert rtp.remediation != ""
+
+    def test_old_signatures_returns_warn(self):
+        with patch("winposture.checks.antivirus.run_powershell_json",
+                   return_value=_defender(sig_age=10)):
+            results = antivirus._check_defender()
+        sig = next(r for r in results if "Signature" in r.check_name)
+        assert sig.status == Status.WARN
+        assert sig.severity == Severity.HIGH
+        assert "Update-MpSignature" in sig.remediation
+
+    def test_signatures_at_threshold_returns_warn(self):
+        with patch("winposture.checks.antivirus.run_powershell_json",
+                   return_value=_defender(sig_age=8)):
+            results = antivirus._check_defender()
+        sig = next(r for r in results if "Signature" in r.check_name)
+        assert sig.status == Status.WARN
+
+    def test_signatures_within_threshold_returns_pass(self):
+        with patch("winposture.checks.antivirus.run_powershell_json",
+                   return_value=_defender(sig_age=7)):
+            results = antivirus._check_defender()
+        sig = next(r for r in results if "Signature" in r.check_name)
+        assert sig.status == Status.PASS
+
+    def test_tamper_protection_off_returns_warn(self):
+        with patch("winposture.checks.antivirus.run_powershell_json",
+                   return_value=_defender(tamper=False)):
+            results = antivirus._check_defender()
+        tp = next(r for r in results if "Tamper" in r.check_name)
+        assert tp.status == Status.WARN
+        assert tp.severity == Severity.MEDIUM
+        assert tp.remediation != ""
+
+    def test_ps_error_returns_error_result(self):
+        with patch("winposture.checks.antivirus.run_powershell_json",
+                   side_effect=WinPostureError("cmdlet not found")):
+            results = antivirus._check_defender()
+        assert len(results) == 1
+        assert results[0].status == Status.ERROR
+
+    def test_list_response_unwrapped(self):
+        """ConvertTo-Json may emit a list for single objects on some PS versions."""
+        with patch("winposture.checks.antivirus.run_powershell_json",
+                   return_value=[_defender()]):
+            results = antivirus._check_defender()
+        assert all(r.status == Status.PASS for r in results)
+
+    def test_sig_age_none_treated_as_zero(self):
+        data = _defender()
+        data["AntivirusSignatureAge"] = None
+        with patch("winposture.checks.antivirus.run_powershell_json", return_value=data):
+            results = antivirus._check_defender()
+        sig = next(r for r in results if "Signature" in r.check_name)
+        assert sig.status == Status.PASS
+
+    def test_all_fields_false_rtp_is_still_critical_fail(self):
+        with patch("winposture.checks.antivirus.run_powershell_json",
+                   return_value=_defender(am=False, rtp=False, av=False, tamper=False, sig_age=999)):
+            results = antivirus._check_defender()
+        rtp = next(r for r in results if "Real-Time" in r.check_name)
+        assert rtp.status == Status.FAIL
+        assert rtp.severity == Severity.CRITICAL
+
+
+# ---------------------------------------------------------------------------
+# _check_security_center
+# ---------------------------------------------------------------------------
+
+class TestCheckSecurityCenter:
+    def test_defender_registered_returns_info(self):
+        with patch("winposture.checks.antivirus.run_powershell_json",
+                   return_value=_SC2_DEFENDER):
+            results = antivirus._check_security_center()
+        assert results[0].status == Status.INFO
+        assert "Windows Defender" in results[0].details
+
+    def test_third_party_av_returns_info(self):
+        with patch("winposture.checks.antivirus.run_powershell_json",
+                   return_value=_SC2_THIRD_PARTY):
+            results = antivirus._check_security_center()
+        assert results[0].status == Status.INFO
+        assert "CrowdStrike" in results[0].details
+
+    def test_multiple_av_products_listed(self):
+        with patch("winposture.checks.antivirus.run_powershell_json",
+                   return_value=_SC2_MULTI):
+            results = antivirus._check_security_center()
+        assert "Windows Defender" in results[0].details
+        assert "Malwarebytes" in results[0].details
+
+    def test_no_av_registered_returns_critical_fail(self):
+        with patch("winposture.checks.antivirus.run_powershell_json", return_value=[]):
+            results = antivirus._check_security_center()
+        assert results[0].status == Status.FAIL
+        assert results[0].severity == Severity.CRITICAL
+        assert results[0].remediation != ""
+
+    def test_ps_error_returns_error(self):
+        with patch("winposture.checks.antivirus.run_powershell_json",
+                   side_effect=WinPostureError("namespace not found")):
+            results = antivirus._check_security_center()
+        assert results[0].status == Status.ERROR
+
+    def test_single_dict_response_handled(self):
+        single = {"displayName": "Windows Defender", "productState": 397568}
+        with patch("winposture.checks.antivirus.run_powershell_json", return_value=single):
+            results = antivirus._check_security_center()
+        assert results[0].status == Status.INFO
+
+
+# ---------------------------------------------------------------------------
+# run() — integration
+# ---------------------------------------------------------------------------
+
+class TestAntivirusRun:
+    def test_returns_four_results_when_all_good(self):
+        with patch("winposture.checks.antivirus.run_powershell_json",
+                   side_effect=[_defender(), _SC2_DEFENDER]):
+            results = antivirus.run()
+        assert len(results) == 4   # 3 defender + 1 security center
+
+    def test_all_have_antivirus_category(self):
+        with patch("winposture.checks.antivirus.run_powershell_json",
+                   side_effect=[_defender(), _SC2_DEFENDER]):
+            results = antivirus.run()
+        assert all(r.category == "Antivirus" for r in results)
+
+    def test_error_in_defender_does_not_crash_sc2_check(self):
+        with patch("winposture.checks.antivirus.run_powershell_json",
+                   side_effect=[WinPostureError("no Defender"), _SC2_DEFENDER]):
+            results = antivirus.run()
+        assert len(results) == 2   # 1 error + 1 security center
+        assert results[0].status == Status.ERROR
+        assert results[1].status == Status.INFO

--- a/tests/test_checks/test_encryption.py
+++ b/tests/test_checks/test_encryption.py
@@ -1,0 +1,179 @@
+"""Tests for winposture.checks.encryption."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from winposture.checks import encryption
+from winposture.exceptions import WinPostureError
+from winposture.models import Status, Severity
+
+
+# ---------------------------------------------------------------------------
+# Shared mock data
+# ---------------------------------------------------------------------------
+
+def _vol(mount="C:", vol_type="OperatingSystem", status="FullyEncrypted",
+         protection=1, method="XtsAes256", pct=100) -> dict:
+    return {
+        "MountPoint": mount,
+        "VolumeType": vol_type,
+        "VolumeStatus": status,
+        "ProtectionStatus": protection,
+        "EncryptionMethod": method,
+        "EncryptionPercentage": pct,
+    }
+
+
+_OS_ENCRYPTED   = _vol("C:", "OperatingSystem", "FullyEncrypted",   protection=1, pct=100)
+_OS_UNENCRYPTED = _vol("C:", "OperatingSystem", "FullyDecrypted",   protection=0, pct=0)
+_DATA_ENCRYPTED = _vol("D:", "FixedDisk",        "FullyEncrypted",   protection=1, pct=100)
+_DATA_PLAIN     = _vol("D:", "FixedDisk",        "FullyDecrypted",   protection=0, pct=0)
+_OS_IN_PROGRESS = _vol("C:", "OperatingSystem", "EncryptionInProgress", protection=0, pct=45)
+
+
+# ---------------------------------------------------------------------------
+# run() — empty / unavailable
+# ---------------------------------------------------------------------------
+
+class TestEncryptionRunEmpty:
+    def test_empty_list_returns_warn(self):
+        with patch("winposture.checks.encryption.run_powershell_json", return_value=[]):
+            results = encryption.run()
+        assert len(results) == 1
+        assert results[0].status == Status.WARN
+        assert results[0].severity == Severity.HIGH
+        assert results[0].remediation != ""
+
+    def test_ps_error_returns_error_result(self):
+        with patch("winposture.checks.encryption.run_powershell_json",
+                   side_effect=WinPostureError("access denied")):
+            results = encryption.run()
+        assert len(results) == 1
+        assert results[0].status == Status.ERROR
+
+    def test_error_result_has_admin_remediation(self):
+        with patch("winposture.checks.encryption.run_powershell_json",
+                   side_effect=WinPostureError("access denied")):
+            results = encryption.run()
+        assert "Administrator" in results[0].remediation
+
+
+# ---------------------------------------------------------------------------
+# run() — single OS drive
+# ---------------------------------------------------------------------------
+
+class TestEncryptionRunOsDrive:
+    def test_encrypted_os_drive_returns_pass(self):
+        with patch("winposture.checks.encryption.run_powershell_json",
+                   return_value=[_OS_ENCRYPTED]):
+            results = encryption.run()
+        assert len(results) == 1
+        assert results[0].status == Status.PASS
+        assert results[0].severity == Severity.HIGH
+
+    def test_unencrypted_os_drive_returns_high_fail(self):
+        with patch("winposture.checks.encryption.run_powershell_json",
+                   return_value=[_OS_UNENCRYPTED]):
+            results = encryption.run()
+        assert results[0].status == Status.FAIL
+        assert results[0].severity == Severity.HIGH
+        assert results[0].remediation != ""
+        assert "Enable-BitLocker" in results[0].remediation
+
+    def test_unencrypted_os_drive_remediation_includes_mount_point(self):
+        with patch("winposture.checks.encryption.run_powershell_json",
+                   return_value=[_OS_UNENCRYPTED]):
+            results = encryption.run()
+        assert "C:" in results[0].remediation
+
+    def test_encryption_in_progress_treated_as_unprotected(self):
+        """ProtectionStatus=0 while encrypting → still FAIL until protection is On."""
+        with patch("winposture.checks.encryption.run_powershell_json",
+                   return_value=[_OS_IN_PROGRESS]):
+            results = encryption.run()
+        assert results[0].status == Status.FAIL
+        assert "45%" in results[0].details
+
+    def test_pass_details_include_encryption_method(self):
+        with patch("winposture.checks.encryption.run_powershell_json",
+                   return_value=[_OS_ENCRYPTED]):
+            results = encryption.run()
+        assert "XtsAes256" in results[0].details
+
+
+# ---------------------------------------------------------------------------
+# run() — data drives
+# ---------------------------------------------------------------------------
+
+class TestEncryptionRunDataDrives:
+    def test_encrypted_data_drive_returns_pass_medium(self):
+        with patch("winposture.checks.encryption.run_powershell_json",
+                   return_value=[_DATA_ENCRYPTED]):
+            results = encryption.run()
+        assert results[0].status == Status.PASS
+        assert results[0].severity == Severity.MEDIUM
+
+    def test_unencrypted_data_drive_returns_medium_fail(self):
+        with patch("winposture.checks.encryption.run_powershell_json",
+                   return_value=[_DATA_PLAIN]):
+            results = encryption.run()
+        assert results[0].status == Status.FAIL
+        assert results[0].severity == Severity.MEDIUM
+
+    def test_check_name_includes_drive_letter(self):
+        with patch("winposture.checks.encryption.run_powershell_json",
+                   return_value=[_DATA_PLAIN]):
+            results = encryption.run()
+        assert "D:" in results[0].check_name
+
+
+# ---------------------------------------------------------------------------
+# run() — multiple drives
+# ---------------------------------------------------------------------------
+
+class TestEncryptionRunMultipleDrives:
+    def test_mixed_drives_returns_one_result_per_drive(self):
+        with patch("winposture.checks.encryption.run_powershell_json",
+                   return_value=[_OS_ENCRYPTED, _DATA_PLAIN]):
+            results = encryption.run()
+        assert len(results) == 2
+
+    def test_os_pass_and_data_fail(self):
+        with patch("winposture.checks.encryption.run_powershell_json",
+                   return_value=[_OS_ENCRYPTED, _DATA_PLAIN]):
+            results = encryption.run()
+        c_result = next(r for r in results if "C:" in r.check_name)
+        d_result = next(r for r in results if "D:" in r.check_name)
+        assert c_result.status == Status.PASS
+        assert d_result.status == Status.FAIL
+
+    def test_all_encrypted_all_pass(self):
+        with patch("winposture.checks.encryption.run_powershell_json",
+                   return_value=[_OS_ENCRYPTED, _DATA_ENCRYPTED]):
+            results = encryption.run()
+        assert all(r.status == Status.PASS for r in results)
+
+    def test_all_unencrypted_all_fail(self):
+        with patch("winposture.checks.encryption.run_powershell_json",
+                   return_value=[_OS_UNENCRYPTED, _DATA_PLAIN]):
+            results = encryption.run()
+        assert all(r.status == Status.FAIL for r in results)
+
+    def test_single_dict_response_treated_as_one_volume(self):
+        """PS returns bare dict when only one volume exists."""
+        with patch("winposture.checks.encryption.run_powershell_json",
+                   return_value=_OS_ENCRYPTED):
+            results = encryption.run()
+        assert len(results) == 1
+
+    def test_null_fields_do_not_crash(self):
+        vol = {"MountPoint": "E:", "VolumeType": None, "VolumeStatus": None,
+               "ProtectionStatus": None, "EncryptionMethod": None,
+               "EncryptionPercentage": None}
+        with patch("winposture.checks.encryption.run_powershell_json", return_value=[vol]):
+            results = encryption.run()
+        assert len(results) == 1
+        assert results[0].status == Status.FAIL  # ProtectionStatus None → 0 → Off

--- a/tests/test_checks/test_firewall.py
+++ b/tests/test_checks/test_firewall.py
@@ -1,35 +1,170 @@
-"""Tests for winposture.checks.firewall.
-
-All subprocess/WMI calls will be mocked once the module is implemented.
-For now these tests verify the stub contract.
-"""
+"""Tests for winposture.checks.firewall."""
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
+import pytest
+
 from winposture.checks import firewall
-from winposture.models import CheckResult, Status
+from winposture.exceptions import WinPostureError
+from winposture.models import CheckResult, Status, Severity
 
 
-class TestFirewallRun:
-    def test_returns_list(self):
-        results = firewall.run()
-        assert isinstance(results, list)
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
 
-    def test_returns_check_results(self):
-        results = firewall.run()
-        assert all(isinstance(r, CheckResult) for r in results)
+_PROFILE_GOOD = {"Name": "Domain", "Enabled": True,
+                 "DefaultInboundAction": 4, "DefaultOutboundAction": 2}
+_PROFILE_DISABLED = {"Name": "Public", "Enabled": False,
+                     "DefaultInboundAction": 4, "DefaultOutboundAction": 2}
+_PROFILE_ALLOW_INBOUND = {"Name": "Private", "Enabled": True,
+                          "DefaultInboundAction": 2, "DefaultOutboundAction": 2}
+_PROFILE_NOT_CONFIGURED = {"Name": "Domain", "Enabled": True,
+                           "DefaultInboundAction": 0, "DefaultOutboundAction": 2}
 
-    def test_returns_three_profiles(self):
-        """Expects one result per Windows Firewall profile (Domain, Private, Public)."""
-        results = firewall.run()
-        assert len(results) == 3
+_ALL_GOOD = [
+    {"Name": "Domain",  "Enabled": True, "DefaultInboundAction": 4, "DefaultOutboundAction": 2},
+    {"Name": "Private", "Enabled": True, "DefaultInboundAction": 4, "DefaultOutboundAction": 2},
+    {"Name": "Public",  "Enabled": True, "DefaultInboundAction": 4, "DefaultOutboundAction": 2},
+]
 
-    def test_category_is_firewall(self):
-        results = firewall.run()
-        assert all(r.category == "Firewall" for r in results)
+_STRING_ACTIONS = [
+    {"Name": "Domain",  "Enabled": True, "DefaultInboundAction": "Block", "DefaultOutboundAction": "Allow"},
+    {"Name": "Private", "Enabled": True, "DefaultInboundAction": "Block", "DefaultOutboundAction": "Allow"},
+    {"Name": "Public",  "Enabled": True, "DefaultInboundAction": "Block", "DefaultOutboundAction": "Allow"},
+]
 
-    def test_profile_names_in_check_names(self):
-        results = firewall.run()
+
+# ---------------------------------------------------------------------------
+# _parse_action helper
+# ---------------------------------------------------------------------------
+
+class TestParseAction:
+    def test_integer_4_is_block(self):
+        assert firewall._parse_action(4) == "Block"
+
+    def test_integer_2_is_allow(self):
+        assert firewall._parse_action(2) == "Allow"
+
+    def test_integer_0_is_not_configured(self):
+        assert firewall._parse_action(0) == "NotConfigured"
+
+    def test_string_passthrough(self):
+        assert firewall._parse_action("Block") == "Block"
+        assert firewall._parse_action("Allow") == "Allow"
+
+    def test_unknown_integer_returns_unknown_string(self):
+        result = firewall._parse_action(99)
+        assert "Unknown" in result
+
+    def test_none_returns_not_configured(self):
+        assert firewall._parse_action(None) == "NotConfigured"
+
+
+# ---------------------------------------------------------------------------
+# run() — happy path
+# ---------------------------------------------------------------------------
+
+class TestFirewallRunHappyPath:
+    def test_all_profiles_good_returns_six_pass(self):
+        with patch("winposture.checks.firewall.run_powershell_json", return_value=_ALL_GOOD):
+            results = firewall.run()
+        assert len(results) == 6
+        assert all(r.status == Status.PASS for r in results)
+
+    def test_returns_two_results_per_profile(self):
+        with patch("winposture.checks.firewall.run_powershell_json", return_value=_ALL_GOOD):
+            results = firewall.run()
         names = [r.check_name for r in results]
         for profile in ("Domain", "Private", "Public"):
-            assert any(profile in name for name in names)
+            assert any(f"{profile} Profile Enabled" in n for n in names)
+            assert any(f"{profile} Default Inbound" in n for n in names)
+
+    def test_all_results_have_firewall_category(self):
+        with patch("winposture.checks.firewall.run_powershell_json", return_value=_ALL_GOOD):
+            results = firewall.run()
+        assert all(r.category == "Firewall" for r in results)
+
+    def test_string_enum_values_ps7_format(self):
+        """PS 7+ serialises Action enum as strings; all should still PASS."""
+        with patch("winposture.checks.firewall.run_powershell_json",
+                   return_value=_STRING_ACTIONS):
+            results = firewall.run()
+        assert all(r.status == Status.PASS for r in results)
+
+    def test_single_profile_dict_wrapped_in_list(self):
+        """PS may return a bare dict for a single profile."""
+        with patch("winposture.checks.firewall.run_powershell_json",
+                   return_value=_PROFILE_GOOD):
+            results = firewall.run()
+        assert len(results) == 2
+
+
+# ---------------------------------------------------------------------------
+# run() — failure scenarios
+# ---------------------------------------------------------------------------
+
+class TestFirewallRunFailures:
+    def test_disabled_profile_returns_fail(self):
+        profiles = [_PROFILE_DISABLED]
+        with patch("winposture.checks.firewall.run_powershell_json", return_value=profiles):
+            results = firewall.run()
+        enabled_check = next(r for r in results if "Enabled" in r.check_name)
+        assert enabled_check.status == Status.FAIL
+        assert enabled_check.severity == Severity.HIGH
+        assert "Set-NetFirewallProfile" in enabled_check.remediation
+
+    def test_explicit_allow_inbound_returns_warn(self):
+        profiles = [_PROFILE_ALLOW_INBOUND]
+        with patch("winposture.checks.firewall.run_powershell_json", return_value=profiles):
+            results = firewall.run()
+        inbound_check = next(r for r in results if "Inbound" in r.check_name)
+        assert inbound_check.status == Status.WARN
+        assert inbound_check.severity == Severity.MEDIUM
+        assert "Set-NetFirewallProfile" in inbound_check.remediation
+
+    def test_not_configured_inbound_is_not_a_warn(self):
+        """NotConfigured inherits Block from system policy — not a finding."""
+        profiles = [_PROFILE_NOT_CONFIGURED]
+        with patch("winposture.checks.firewall.run_powershell_json", return_value=profiles):
+            results = firewall.run()
+        inbound_check = next(r for r in results if "Inbound" in r.check_name)
+        assert inbound_check.status == Status.PASS
+
+    def test_public_profile_disabled_has_remediation(self):
+        profiles = [{"Name": "Public", "Enabled": False,
+                     "DefaultInboundAction": 4, "DefaultOutboundAction": 2}]
+        with patch("winposture.checks.firewall.run_powershell_json", return_value=profiles):
+            results = firewall.run()
+        enabled_check = next(r for r in results if "Enabled" in r.check_name)
+        assert "Public" in enabled_check.remediation
+
+    def test_all_profiles_disabled_returns_three_fails(self):
+        profiles = [{"Name": n, "Enabled": False,
+                     "DefaultInboundAction": 4, "DefaultOutboundAction": 2}
+                    for n in ("Domain", "Private", "Public")]
+        with patch("winposture.checks.firewall.run_powershell_json", return_value=profiles):
+            results = firewall.run()
+        enabled_checks = [r for r in results if "Enabled" in r.check_name]
+        assert all(r.status == Status.FAIL for r in enabled_checks)
+
+
+# ---------------------------------------------------------------------------
+# run() — error handling
+# ---------------------------------------------------------------------------
+
+class TestFirewallRunErrors:
+    def test_ps_error_returns_single_error_result(self):
+        with patch("winposture.checks.firewall.run_powershell_json",
+                   side_effect=WinPostureError("Get-NetFirewallProfile not found")):
+            results = firewall.run()
+        assert len(results) == 1
+        assert results[0].status == Status.ERROR
+
+    def test_error_result_has_details(self):
+        with patch("winposture.checks.firewall.run_powershell_json",
+                   side_effect=WinPostureError("access denied")):
+            results = firewall.run()
+        assert "access denied" in results[0].details

--- a/tests/test_checks/test_os_info.py
+++ b/tests/test_checks/test_os_info.py
@@ -171,11 +171,11 @@ class TestCheckDomain:
 
     def test_domain_joined_returns_info(self):
         with patch("winposture.checks.os_info.run_powershell_json",
-                   return_value=_domain_json(part_of_domain=True, domain="corp.example.com")):
+                   return_value=_domain_json(part_of_domain=True, domain="CORP")):
             results = os_info._check_domain()
         assert results[0].status == Status.INFO
         assert "Domain-joined" in results[0].details
-        assert "corp.example.com" in results[0].details
+        assert "CORP" in results[0].details
 
     def test_ps_error_returns_error_result(self):
         with patch("winposture.checks.os_info.run_powershell_json",

--- a/tests/test_checks/test_os_info.py
+++ b/tests/test_checks/test_os_info.py
@@ -1,0 +1,291 @@
+"""Tests for winposture.checks.os_info."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from winposture.checks import os_info
+from winposture.exceptions import WinPostureError
+from winposture.models import Status
+
+
+# ---------------------------------------------------------------------------
+# Shared mock data helpers
+# ---------------------------------------------------------------------------
+
+def _os_json(caption: str = "Microsoft Windows 11 Pro",
+             build: str = "22631",
+             version: str = "10.0.22631") -> dict:
+    return {"Caption": caption, "BuildNumber": build, "Version": version}
+
+
+def _domain_json(part_of_domain: bool = False,
+                 domain: str = "WORKGROUP") -> dict:
+    return {"PartOfDomain": part_of_domain, "Domain": domain, "Workgroup": "WORKGROUP"}
+
+
+def _tpm_json(present: bool = True, ready: bool = True,
+              version: str = "2.0") -> dict:
+    return {"TpmPresent": present, "TpmReady": ready, "ManufacturerVersion": version}
+
+
+# Fixed reference date used in all EOL tests
+_REF_DATE = datetime(2026, 3, 17, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# _check_os_build
+# ---------------------------------------------------------------------------
+
+class TestCheckOsBuild:
+    def test_supported_build_returns_pass(self):
+        """Build 22631 (Win11 23H2, EOL Nov 2026) should PASS on ref date."""
+        with patch("winposture.checks.os_info.run_powershell_json", return_value=_os_json(build="22631")), \
+             patch("winposture.checks.os_info._now", return_value=_REF_DATE):
+            results = os_info._check_os_build()
+        eol = next(r for r in results if r.check_name == "OS End-of-Support Status")
+        assert eol.status == Status.PASS
+
+    def test_eol_build_returns_fail(self):
+        """Build 19045 (Win10 22H2, EOL Oct 2025) should FAIL on ref date Mar 2026."""
+        with patch("winposture.checks.os_info.run_powershell_json", return_value=_os_json(build="19045")), \
+             patch("winposture.checks.os_info._now", return_value=_REF_DATE):
+            results = os_info._check_os_build()
+        eol = next(r for r in results if r.check_name == "OS End-of-Support Status")
+        assert eol.status == Status.FAIL
+        assert "end of support" in eol.details.lower()
+        assert eol.remediation != ""
+
+    def test_very_old_build_returns_fail(self):
+        """Build 10240 (Win10 1507, EOL 2017) should always FAIL."""
+        with patch("winposture.checks.os_info.run_powershell_json", return_value=_os_json(build="10240")), \
+             patch("winposture.checks.os_info._now", return_value=_REF_DATE):
+            results = os_info._check_os_build()
+        eol = next(r for r in results if r.check_name == "OS End-of-Support Status")
+        assert eol.status == Status.FAIL
+
+    def test_unknown_build_returns_warn(self):
+        """A build below all known ranges (pre-Win10) should WARN, not crash."""
+        with patch("winposture.checks.os_info.run_powershell_json", return_value=_os_json(build="5000")), \
+             patch("winposture.checks.os_info._now", return_value=_REF_DATE):
+            results = os_info._check_os_build()
+        eol = next(r for r in results if r.check_name == "OS End-of-Support Status")
+        assert eol.status == Status.WARN
+
+    def test_post_ga_cu_build_resolves_via_range(self):
+        """Build 26200 (post-24H2 CU) should resolve to Windows 11 24H2 and PASS."""
+        with patch("winposture.checks.os_info.run_powershell_json", return_value=_os_json(build="26200")), \
+             patch("winposture.checks.os_info._now", return_value=_REF_DATE):
+            results = os_info._check_os_build()
+        eol = next(r for r in results if r.check_name == "OS End-of-Support Status")
+        assert eol.status == Status.PASS
+        assert "24H2" in eol.details
+
+    def test_os_version_result_is_info(self):
+        with patch("winposture.checks.os_info.run_powershell_json", return_value=_os_json()), \
+             patch("winposture.checks.os_info._now", return_value=_REF_DATE):
+            results = os_info._check_os_build()
+        ver = next(r for r in results if r.check_name == "OS Version")
+        assert ver.status == Status.INFO
+        assert "22631" in ver.details
+
+    def test_ps_error_returns_two_error_results(self):
+        with patch("winposture.checks.os_info.run_powershell_json",
+                   side_effect=WinPostureError("Access denied")):
+            results = os_info._check_os_build()
+        assert len(results) == 2
+        assert all(r.status == Status.ERROR for r in results)
+
+    def test_single_dict_response_handled(self):
+        """PS may return a dict instead of a list; should not crash."""
+        data = _os_json(build="22631")  # already a dict
+        with patch("winposture.checks.os_info.run_powershell_json", return_value=data), \
+             patch("winposture.checks.os_info._now", return_value=_REF_DATE):
+            results = os_info._check_os_build()
+        assert len(results) == 2
+
+    def test_list_response_handled(self):
+        """PS may wrap in a list; should unwrap and use first element."""
+        data = [_os_json(build="22631")]
+        with patch("winposture.checks.os_info.run_powershell_json", return_value=data), \
+             patch("winposture.checks.os_info._now", return_value=_REF_DATE):
+            results = os_info._check_os_build()
+        assert len(results) == 2
+
+
+# ---------------------------------------------------------------------------
+# _check_uptime
+# ---------------------------------------------------------------------------
+
+class TestCheckUptime:
+    def test_low_uptime_returns_pass(self):
+        with patch("winposture.checks.os_info.run_powershell", return_value="5"):
+            results = os_info._check_uptime()
+        assert results[0].status == Status.PASS
+        assert "5 day" in results[0].details
+
+    def test_uptime_at_threshold_returns_pass(self):
+        with patch("winposture.checks.os_info.run_powershell", return_value="30"):
+            results = os_info._check_uptime()
+        assert results[0].status == Status.PASS
+
+    def test_uptime_over_threshold_returns_warn(self):
+        with patch("winposture.checks.os_info.run_powershell", return_value="45"):
+            results = os_info._check_uptime()
+        assert results[0].status == Status.WARN
+        assert "45 days" in results[0].details
+        assert results[0].remediation != ""
+
+    def test_ps_error_returns_error_result(self):
+        with patch("winposture.checks.os_info.run_powershell",
+                   side_effect=WinPostureError("timeout")):
+            results = os_info._check_uptime()
+        assert results[0].status == Status.ERROR
+
+    def test_non_integer_output_returns_error(self):
+        with patch("winposture.checks.os_info.run_powershell", return_value="not-a-number"):
+            results = os_info._check_uptime()
+        assert results[0].status == Status.ERROR
+
+    def test_zero_uptime_returns_pass(self):
+        with patch("winposture.checks.os_info.run_powershell", return_value="0"):
+            results = os_info._check_uptime()
+        assert results[0].status == Status.PASS
+
+
+# ---------------------------------------------------------------------------
+# _check_domain
+# ---------------------------------------------------------------------------
+
+class TestCheckDomain:
+    def test_workgroup_returns_info(self):
+        with patch("winposture.checks.os_info.run_powershell_json",
+                   return_value=_domain_json(part_of_domain=False, domain="WORKGROUP")):
+            results = os_info._check_domain()
+        assert results[0].status == Status.INFO
+        assert "Workgroup" in results[0].details
+
+    def test_domain_joined_returns_info(self):
+        with patch("winposture.checks.os_info.run_powershell_json",
+                   return_value=_domain_json(part_of_domain=True, domain="corp.example.com")):
+            results = os_info._check_domain()
+        assert results[0].status == Status.INFO
+        assert "Domain-joined" in results[0].details
+        assert "corp.example.com" in results[0].details
+
+    def test_ps_error_returns_error_result(self):
+        with patch("winposture.checks.os_info.run_powershell_json",
+                   side_effect=WinPostureError("access denied")):
+            results = os_info._check_domain()
+        assert results[0].status == Status.ERROR
+
+
+# ---------------------------------------------------------------------------
+# _check_secure_boot
+# ---------------------------------------------------------------------------
+
+class TestCheckSecureBoot:
+    def test_enabled_returns_pass(self):
+        with patch("winposture.checks.os_info.run_powershell", return_value="True"):
+            results = os_info._check_secure_boot()
+        assert results[0].status == Status.PASS
+
+    def test_disabled_returns_fail(self):
+        with patch("winposture.checks.os_info.run_powershell", return_value="False"):
+            results = os_info._check_secure_boot()
+        assert results[0].status == Status.FAIL
+        assert results[0].remediation != ""
+
+    def test_unsupported_returns_warn(self):
+        with patch("winposture.checks.os_info.run_powershell", return_value="UNSUPPORTED"):
+            results = os_info._check_secure_boot()
+        assert results[0].status == Status.WARN
+
+    def test_case_insensitive_unsupported(self):
+        with patch("winposture.checks.os_info.run_powershell", return_value="unsupported"):
+            results = os_info._check_secure_boot()
+        assert results[0].status == Status.WARN
+
+    def test_ps_error_returns_error_result(self):
+        with patch("winposture.checks.os_info.run_powershell",
+                   side_effect=WinPostureError("not supported")):
+            results = os_info._check_secure_boot()
+        assert results[0].status == Status.ERROR
+
+
+# ---------------------------------------------------------------------------
+# _check_tpm
+# ---------------------------------------------------------------------------
+
+class TestCheckTpm:
+    def test_tpm_present_and_ready_returns_pass(self):
+        with patch("winposture.checks.os_info.run_powershell_json",
+                   return_value=_tpm_json(present=True, ready=True, version="2.0")):
+            results = os_info._check_tpm()
+        assert results[0].status == Status.PASS
+        assert "2.0" in results[0].details
+
+    def test_tpm_present_not_ready_returns_warn(self):
+        with patch("winposture.checks.os_info.run_powershell_json",
+                   return_value=_tpm_json(present=True, ready=False)):
+            results = os_info._check_tpm()
+        assert results[0].status == Status.WARN
+
+    def test_no_tpm_returns_warn(self):
+        with patch("winposture.checks.os_info.run_powershell_json",
+                   return_value=_tpm_json(present=False, ready=False)):
+            results = os_info._check_tpm()
+        assert results[0].status == Status.WARN
+        assert "No TPM" in results[0].details
+
+    def test_ps_error_returns_error_result(self):
+        with patch("winposture.checks.os_info.run_powershell_json",
+                   side_effect=WinPostureError("WMI error")):
+            results = os_info._check_tpm()
+        assert results[0].status == Status.ERROR
+
+    def test_null_version_handled(self):
+        with patch("winposture.checks.os_info.run_powershell_json",
+                   return_value={"TpmPresent": True, "TpmReady": True, "ManufacturerVersion": None}):
+            results = os_info._check_tpm()
+        assert results[0].status == Status.PASS
+        assert "Unknown" in results[0].details
+
+
+# ---------------------------------------------------------------------------
+# run() — integration
+# ---------------------------------------------------------------------------
+
+class TestOsInfoRun:
+    def test_run_returns_list_of_check_results(self):
+        from winposture.models import CheckResult
+        with patch("winposture.checks.os_info.run_powershell_json",
+                   side_effect=[_os_json(), _domain_json(), _tpm_json()]), \
+             patch("winposture.checks.os_info.run_powershell", return_value="5"), \
+             patch("winposture.checks.os_info._now", return_value=_REF_DATE):
+            results = os_info.run()
+        assert all(isinstance(r, CheckResult) for r in results)
+        assert len(results) >= 5  # version, eol, uptime, domain, secure boot, tpm
+
+    def test_all_results_have_category_system(self):
+        with patch("winposture.checks.os_info.run_powershell_json",
+                   side_effect=[_os_json(), _domain_json(), _tpm_json()]), \
+             patch("winposture.checks.os_info.run_powershell", return_value="5"), \
+             patch("winposture.checks.os_info._now", return_value=_REF_DATE):
+            results = os_info.run()
+        assert all(r.category == "System" for r in results)
+
+    def test_one_module_error_does_not_crash_run(self):
+        """Even if one sub-check raises, run() should complete and return ERROR results."""
+        with patch("winposture.checks.os_info.run_powershell_json",
+                   side_effect=WinPostureError("access denied")), \
+             patch("winposture.checks.os_info.run_powershell",
+                   side_effect=WinPostureError("timeout")), \
+             patch("winposture.checks.os_info._now", return_value=_REF_DATE):
+            results = os_info.run()
+        assert len(results) > 0
+        assert all(r.status == Status.ERROR for r in results)

--- a/tests/test_checks/test_updates.py
+++ b/tests/test_checks/test_updates.py
@@ -1,0 +1,196 @@
+"""Tests for winposture.checks.updates."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from winposture.checks import updates
+from winposture.exceptions import WinPostureError
+from winposture.models import Status, Severity
+
+# Fixed reference date
+_REF = datetime(2026, 3, 17, tzinfo=timezone.utc)
+
+
+def _date_str(days_ago: int) -> str:
+    return (_REF - timedelta(days=days_ago)).strftime("%Y-%m-%d")
+
+
+# ---------------------------------------------------------------------------
+# _check_last_update
+# ---------------------------------------------------------------------------
+
+class TestCheckLastUpdate:
+    def test_recent_update_returns_pass(self):
+        with patch("winposture.checks.updates.run_powershell", return_value=_date_str(5)), \
+             patch("winposture.checks.updates._now", return_value=_REF):
+            results = updates._check_last_update()
+        assert results[0].status == Status.PASS
+        assert results[0].severity == Severity.CRITICAL
+
+    def test_update_just_at_warn_threshold_returns_warn(self):
+        with patch("winposture.checks.updates.run_powershell", return_value=_date_str(30)), \
+             patch("winposture.checks.updates._now", return_value=_REF):
+            results = updates._check_last_update()
+        assert results[0].status == Status.WARN
+        assert results[0].severity == Severity.HIGH
+
+    def test_update_over_warn_threshold_returns_warn(self):
+        with patch("winposture.checks.updates.run_powershell", return_value=_date_str(45)), \
+             patch("winposture.checks.updates._now", return_value=_REF):
+            results = updates._check_last_update()
+        assert results[0].status == Status.WARN
+
+    def test_update_at_fail_threshold_returns_fail(self):
+        with patch("winposture.checks.updates.run_powershell", return_value=_date_str(60)), \
+             patch("winposture.checks.updates._now", return_value=_REF):
+            results = updates._check_last_update()
+        assert results[0].status == Status.FAIL
+        assert results[0].severity == Severity.CRITICAL
+
+    def test_very_old_update_returns_critical_fail(self):
+        with patch("winposture.checks.updates.run_powershell", return_value=_date_str(180)), \
+             patch("winposture.checks.updates._now", return_value=_REF):
+            results = updates._check_last_update()
+        assert results[0].status == Status.FAIL
+        assert results[0].severity == Severity.CRITICAL
+        assert results[0].remediation != ""
+
+    def test_no_hotfix_returns_warn(self):
+        with patch("winposture.checks.updates.run_powershell", return_value="NONE"):
+            results = updates._check_last_update()
+        assert results[0].status == Status.WARN
+
+    def test_empty_output_returns_warn(self):
+        with patch("winposture.checks.updates.run_powershell", return_value=""):
+            results = updates._check_last_update()
+        assert results[0].status == Status.WARN
+
+    def test_malformed_date_returns_error(self):
+        with patch("winposture.checks.updates.run_powershell", return_value="not-a-date"), \
+             patch("winposture.checks.updates._now", return_value=_REF):
+            results = updates._check_last_update()
+        assert results[0].status == Status.ERROR
+
+    def test_ps_error_returns_error(self):
+        with patch("winposture.checks.updates.run_powershell",
+                   side_effect=WinPostureError("access denied")):
+            results = updates._check_last_update()
+        assert results[0].status == Status.ERROR
+
+    def test_details_include_date(self):
+        date_str = _date_str(10)
+        with patch("winposture.checks.updates.run_powershell", return_value=date_str), \
+             patch("winposture.checks.updates._now", return_value=_REF):
+            results = updates._check_last_update()
+        assert date_str in results[0].details
+
+
+# ---------------------------------------------------------------------------
+# _check_wu_service
+# ---------------------------------------------------------------------------
+
+class TestCheckWuService:
+    def test_running_service_returns_pass(self):
+        with patch("winposture.checks.updates.run_powershell", return_value="Running"):
+            results = updates._check_wu_service()
+        assert results[0].status == Status.PASS
+
+    def test_stopped_service_returns_warn(self):
+        with patch("winposture.checks.updates.run_powershell", return_value="Stopped"):
+            results = updates._check_wu_service()
+        assert results[0].status == Status.WARN
+        assert results[0].remediation != ""
+
+    def test_case_insensitive_running(self):
+        with patch("winposture.checks.updates.run_powershell", return_value="running"):
+            results = updates._check_wu_service()
+        assert results[0].status == Status.PASS
+
+    def test_empty_output_returns_error(self):
+        with patch("winposture.checks.updates.run_powershell", return_value=""):
+            results = updates._check_wu_service()
+        assert results[0].status == Status.ERROR
+
+    def test_ps_error_returns_error(self):
+        with patch("winposture.checks.updates.run_powershell",
+                   side_effect=WinPostureError("service not found")):
+            results = updates._check_wu_service()
+        assert results[0].status == Status.ERROR
+
+    def test_details_include_service_status(self):
+        with patch("winposture.checks.updates.run_powershell", return_value="Stopped"):
+            results = updates._check_wu_service()
+        assert "Stopped" in results[0].details
+
+
+# ---------------------------------------------------------------------------
+# _check_pending_updates
+# ---------------------------------------------------------------------------
+
+class TestCheckPendingUpdates:
+    def test_zero_pending_returns_pass(self):
+        with patch("winposture.checks.updates.run_powershell", return_value="0"):
+            results = updates._check_pending_updates()
+        assert results[0].status == Status.PASS
+
+    def test_pending_updates_returns_fail(self):
+        with patch("winposture.checks.updates.run_powershell", return_value="5"):
+            results = updates._check_pending_updates()
+        assert results[0].status == Status.FAIL
+        assert "5" in results[0].details
+        assert results[0].remediation != ""
+
+    def test_one_pending_update_returns_fail(self):
+        with patch("winposture.checks.updates.run_powershell", return_value="1"):
+            results = updates._check_pending_updates()
+        assert results[0].status == Status.FAIL
+
+    def test_unavailable_returns_info(self):
+        with patch("winposture.checks.updates.run_powershell", return_value="UNAVAILABLE"):
+            results = updates._check_pending_updates()
+        assert results[0].status == Status.INFO
+
+    def test_unexpected_output_returns_info(self):
+        with patch("winposture.checks.updates.run_powershell", return_value="some-error-text"):
+            results = updates._check_pending_updates()
+        assert results[0].status == Status.INFO
+
+    def test_ps_error_returns_error(self):
+        with patch("winposture.checks.updates.run_powershell",
+                   side_effect=WinPostureError("COM error")):
+            results = updates._check_pending_updates()
+        assert results[0].status == Status.ERROR
+
+
+# ---------------------------------------------------------------------------
+# run() — integration
+# ---------------------------------------------------------------------------
+
+class TestUpdatesRun:
+    def test_returns_three_results(self):
+        with patch("winposture.checks.updates.run_powershell",
+                   side_effect=[_date_str(5), "Running", "0"]), \
+             patch("winposture.checks.updates._now", return_value=_REF):
+            results = updates.run()
+        assert len(results) == 3
+
+    def test_all_results_have_category_patching(self):
+        with patch("winposture.checks.updates.run_powershell",
+                   side_effect=[_date_str(5), "Running", "0"]), \
+             patch("winposture.checks.updates._now", return_value=_REF):
+            results = updates.run()
+        assert all(r.category == "Patching" for r in results)
+
+    def test_error_in_one_check_does_not_stop_others(self):
+        with patch("winposture.checks.updates.run_powershell",
+                   side_effect=[WinPostureError("fail"), "Running", "0"]), \
+             patch("winposture.checks.updates._now", return_value=_REF):
+            results = updates.run()
+        assert len(results) == 3
+        assert results[0].status == Status.ERROR
+        assert results[1].status == Status.PASS   # Running
+        assert results[2].status == Status.PASS   # 0 pending


### PR DESCRIPTION
…encryption)

Implements five check modules with real PowerShell/WMI calls and full test coverage:

os_info.py (System):
- OS version and build via Win32_OperatingSystem
- End-of-support status against a hardcoded EOL table with range-based fallback so cumulative-update builds (e.g. 26200) resolve correctly to their release
- System uptime (WARN if >30 days)
- Domain vs workgroup membership
- Secure Boot via Confirm-SecureBootUEFI (handles UNSUPPORTED gracefully)
- TPM presence and readiness via Get-Tpm

updates.py (Patching):
- Last hotfix install date; FAIL at 60 days (CRITICAL), WARN at 30 days (HIGH)
- Windows Update service (wuauserv) state
- Pending update count via Microsoft.Update.Session COM object

firewall.py (Firewall):
- Per-profile enabled status (Domain, Private, Public) — FAIL if disabled
- Default inbound action; WARN only on explicit Allow, not NotConfigured

antivirus.py (Antivirus):
- Defender RTP, signature age (<7 days), tamper protection
- Registered AV products via SecurityCenter2 — FAIL if none registered

encryption.py (Encryption):
- BitLocker ProtectionStatus per volume via Get-BitLockerVolume
- OS drive HIGH severity; data drives MEDIUM
- Graceful WARN when not running as admin

Also adds _now() hook in os_info and updates for deterministic time-based testing. 183 tests, all passing.