### PR TITLE
feat: implement access control and network security checks

### DIFF
--- a/src/winposture/checks/accounts.py
+++ b/src/winposture/checks/accounts.py
@@ -1,49 +1,305 @@
-"""Check: Local user accounts, admin group membership, guest account, password policy."""
+"""Check: Local accounts, Administrators group, and password policy."""
 
 from __future__ import annotations
 
 import logging
 
+from winposture.exceptions import WinPostureError
 from winposture.models import CheckResult, Severity, Status
+from winposture.utils import run_powershell, run_powershell_json
 
 log = logging.getLogger(__name__)
 
 CATEGORY = "Accounts"
 
+_PS_GUEST = "(Get-LocalUser -Name 'Guest' -ErrorAction SilentlyContinue).Enabled"
+
+_PS_ADMIN = (
+    "Get-LocalUser -Name 'Administrator' -ErrorAction SilentlyContinue "
+    "| Select-Object Name, Enabled | ConvertTo-Json -Compress"
+)
+
+_PS_ADMINS = (
+    "Get-LocalGroupMember -Group 'Administrators' -ErrorAction SilentlyContinue "
+    "| Select-Object Name, PrincipalSource, ObjectClass | ConvertTo-Json -Compress"
+)
+
+_PS_NET_ACCOUNTS = "net accounts"
+
+# Export local security policy to a temp file, extract complexity setting, clean up.
+_PS_COMPLEXITY = (
+    "$tmp = [System.IO.Path]::GetTempFileName(); "
+    "secedit /export /cfg $tmp /quiet | Out-Null; "
+    "$c = Get-Content $tmp -ErrorAction SilentlyContinue; "
+    "Remove-Item $tmp -Force -ErrorAction SilentlyContinue; "
+    "$line = $c | Where-Object { $_ -like 'PasswordComplexity*' }; "
+    "if ($line) { ($line -split '=')[1].Trim() } else { 'Unknown' }"
+)
+
+_ADMIN_WARN_THRESHOLD = 2
+_MIN_PW_FAIL = 8
+_MIN_PW_WARN = 12
+
 
 def run() -> list[CheckResult]:
-    """Return local account security checks.
+    """Return local account and password policy checks.
 
     Returns:
-        list[CheckResult]: Results for guest account, admin count, and password policy.
+        list[CheckResult]: Results for guest, built-in admin, admin count,
+        password length, lockout policy, and complexity.
     """
-    # TODO: implement via Get-LocalUser, Get-LocalGroupMember, net accounts
-    return [
-        CheckResult(
+    results: list[CheckResult] = []
+    results.extend(_check_guest_account())
+    results.extend(_check_builtin_admin())
+    results.extend(_check_admin_count())
+    results.extend(_check_password_policy())
+    return results
+
+
+def _check_guest_account() -> list[CheckResult]:
+    """Check whether the built-in Guest account is enabled."""
+    try:
+        output = run_powershell(_PS_GUEST).strip()
+    except WinPostureError as exc:
+        return [_error("Guest Account", str(exc))]
+
+    if not output:
+        return [CheckResult(
             category=CATEGORY,
-            check_name="Guest Account Status",
+            check_name="Guest Account",
             status=Status.INFO,
             severity=Severity.HIGH,
             description="Checks whether the built-in Guest account is disabled.",
-            details="Not yet implemented.",
+            details="Guest account not found (may have been renamed or deleted — good practice).",
             remediation="",
+        )]
+
+    enabled = output.lower() == "true"
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="Guest Account",
+        status=Status.FAIL if enabled else Status.PASS,
+        severity=Severity.HIGH,
+        description="Checks whether the built-in Guest account is disabled.",
+        details=f"Built-in Guest account is {'enabled' if enabled else 'disabled'}.",
+        remediation=(
+            "" if not enabled else
+            "Disable the Guest account: Disable-LocalUser -Name 'Guest'"
         ),
-        CheckResult(
+    )]
+
+
+def _check_builtin_admin() -> list[CheckResult]:
+    """Check whether the built-in Administrator account is enabled and/or renamed."""
+    try:
+        data = run_powershell_json(_PS_ADMIN)
+    except WinPostureError as exc:
+        return [_error("Built-in Administrator Account", str(exc))]
+
+    if not data:
+        return [CheckResult(
             category=CATEGORY,
-            check_name="Local Administrator Count",
+            check_name="Built-in Administrator Account",
             status=Status.INFO,
             severity=Severity.MEDIUM,
-            description="Counts members of the local Administrators group.",
-            details="Not yet implemented.",
+            description="Checks if the built-in Administrator account is enabled and not renamed.",
+            details="Administrator account not found (likely renamed — good practice).",
             remediation="",
+        )]
+
+    if isinstance(data, list):
+        data = data[0] if data else {}
+
+    name = str(data.get("Name", "Administrator"))
+    enabled = bool(data.get("Enabled", False))
+    is_default_name = name.lower() == "administrator"
+
+    if enabled and is_default_name:
+        status, sev = Status.FAIL, Severity.MEDIUM
+        details = "Built-in Administrator account is enabled with the default name."
+        remediation = (
+            "Rename and/or disable the built-in Administrator account. "
+            "Rename: Rename-LocalUser -Name 'Administrator' -NewName '<new_name>'. "
+            "Disable: Disable-LocalUser -Name 'Administrator'"
+        )
+    elif enabled:
+        status, sev = Status.WARN, Severity.LOW
+        details = f"Built-in Administrator account is enabled (renamed to '{name}')."
+        remediation = (
+            "Consider disabling the built-in Administrator account if it is not in active use: "
+            f"Disable-LocalUser -Name '{name}'"
+        )
+    else:
+        status, sev = Status.PASS, Severity.MEDIUM
+        rename_note = f" (renamed to '{name}')" if not is_default_name else ""
+        details = f"Built-in Administrator account is disabled{rename_note}."
+        remediation = ""
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="Built-in Administrator Account",
+        status=status,
+        severity=sev,
+        description="Checks if the built-in Administrator account is enabled and not renamed.",
+        details=details,
+        remediation=remediation,
+    )]
+
+
+def _check_admin_count() -> list[CheckResult]:
+    """Count members of the local Administrators group."""
+    try:
+        data = run_powershell_json(_PS_ADMINS)
+    except WinPostureError as exc:
+        return [_error("Local Administrators", str(exc))]
+
+    members = data if isinstance(data, list) else ([data] if data else [])
+    count = len(members)
+    # Strip domain prefix from display names
+    names = [str(m.get("Name", "Unknown")).split("\\")[-1] for m in members]
+
+    over_threshold = count > _ADMIN_WARN_THRESHOLD
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="Local Administrators",
+        status=Status.WARN if over_threshold else Status.PASS,
+        severity=Severity.MEDIUM,
+        description=f"Counts members of the local Administrators group (WARN if >{_ADMIN_WARN_THRESHOLD}).",
+        details=f"{count} administrator(s): {', '.join(names) if names else 'none'}",
+        remediation=(
+            "" if not over_threshold else
+            f"Review and reduce the {count} local administrator accounts. "
+            "Remove unnecessary members: "
+            "Remove-LocalGroupMember -Group 'Administrators' -Member '<username>'"
         ),
-        CheckResult(
+    )]
+
+
+def _check_password_policy() -> list[CheckResult]:
+    """Check local password policy via net accounts and secedit."""
+    results: list[CheckResult] = []
+
+    # --- net accounts: length and lockout ---
+    try:
+        net_output = run_powershell(_PS_NET_ACCOUNTS)
+    except WinPostureError as exc:
+        return [_error("Password Policy", str(exc))]
+
+    policy = _parse_net_accounts(net_output)
+
+    # Minimum password length
+    min_len_str = policy.get("minimum password length", "0")
+    try:
+        min_len = int(min_len_str)
+    except ValueError:
+        min_len = 0
+
+    if min_len < _MIN_PW_FAIL:
+        results.append(CheckResult(
             category=CATEGORY,
-            check_name="Password Policy",
+            check_name="Password Policy — Minimum Length",
+            status=Status.FAIL,
+            severity=Severity.HIGH,
+            description=f"Minimum password length must be ≥{_MIN_PW_FAIL} (WARN if <{_MIN_PW_WARN}).",
+            details=f"Minimum password length: {min_len} characters.",
+            remediation=f"Increase minimum password length: net accounts /minpwlen:{_MIN_PW_WARN}",
+        ))
+    elif min_len < _MIN_PW_WARN:
+        results.append(CheckResult(
+            category=CATEGORY,
+            check_name="Password Policy — Minimum Length",
+            status=Status.WARN,
+            severity=Severity.MEDIUM,
+            description=f"Minimum password length must be ≥{_MIN_PW_FAIL} (WARN if <{_MIN_PW_WARN}).",
+            details=f"Minimum password length: {min_len} characters (recommended: {_MIN_PW_WARN}+).",
+            remediation=f"Increase minimum password length: net accounts /minpwlen:{_MIN_PW_WARN}",
+        ))
+    else:
+        results.append(CheckResult(
+            category=CATEGORY,
+            check_name="Password Policy — Minimum Length",
+            status=Status.PASS,
+            severity=Severity.MEDIUM,
+            description=f"Minimum password length must be ≥{_MIN_PW_FAIL} (WARN if <{_MIN_PW_WARN}).",
+            details=f"Minimum password length: {min_len} characters.",
+            remediation="",
+        ))
+
+    # Account lockout
+    lockout_raw = policy.get("lockout threshold", "Never")
+    lockout_disabled = lockout_raw.lower() in ("never", "0", "none", "")
+    lockout_dur = policy.get("lockout duration (minutes)", "N/A")
+    results.append(CheckResult(
+        category=CATEGORY,
+        check_name="Password Policy — Account Lockout",
+        status=Status.WARN if lockout_disabled else Status.PASS,
+        severity=Severity.MEDIUM,
+        description="Checks whether account lockout is configured to deter brute-force attacks.",
+        details=(
+            "Account lockout is disabled — accounts are not locked after failed login attempts."
+            if lockout_disabled else
+            f"Lockout threshold: {lockout_raw} attempt(s) | Duration: {lockout_dur} minute(s)."
+        ),
+        remediation=(
+            "" if not lockout_disabled else
+            "Enable account lockout: net accounts /lockoutthreshold:5 /lockoutduration:30"
+        ),
+    ))
+
+    # --- secedit: password complexity ---
+    try:
+        complexity_val = run_powershell(_PS_COMPLEXITY).strip()
+    except WinPostureError as exc:
+        results.append(_error("Password Policy — Complexity", str(exc)))
+        return results
+
+    if complexity_val == "Unknown":
+        results.append(CheckResult(
+            category=CATEGORY,
+            check_name="Password Policy — Complexity",
             status=Status.INFO,
             severity=Severity.MEDIUM,
-            description="Checks minimum password length and complexity requirements.",
-            details="Not yet implemented.",
+            description="Checks whether password complexity requirements are enforced.",
+            details="Could not determine password complexity setting (secedit output unavailable).",
             remediation="",
-        ),
-    ]
+        ))
+    else:
+        enabled = complexity_val.strip() == "1"
+        results.append(CheckResult(
+            category=CATEGORY,
+            check_name="Password Policy — Complexity",
+            status=Status.PASS if enabled else Status.FAIL,
+            severity=Severity.MEDIUM,
+            description="Checks whether password complexity requirements are enforced.",
+            details=f"Password complexity requirement: {'enabled' if enabled else 'disabled'}.",
+            remediation=(
+                "" if enabled else
+                "Enable password complexity: "
+                "secpol.msc → Account Policies → Password Policy → "
+                "Password must meet complexity requirements → Enabled"
+            ),
+        ))
+
+    return results
+
+
+def _parse_net_accounts(output: str) -> dict[str, str]:
+    """Parse 'net accounts' text output into a lowercase key → value dict."""
+    result: dict[str, str] = {}
+    for line in output.splitlines():
+        if ":" in line:
+            key, _, val = line.partition(":")
+            result[key.strip().lower()] = val.strip()
+    return result
+
+
+def _error(check_name: str, details: str) -> CheckResult:
+    return CheckResult(
+        category=CATEGORY,
+        check_name=check_name,
+        status=Status.ERROR,
+        severity=Severity.INFO,
+        description="An error occurred while running this check.",
+        details=details,
+        remediation="Run with --log-level DEBUG for more detail.",
+    )

--- a/src/winposture/checks/misc.py
+++ b/src/winposture/checks/misc.py
@@ -1,4 +1,4 @@
-"""Check: Miscellaneous settings — AutoPlay, Remote Registry, LLMNR."""
+"""Check: Miscellaneous settings — AutoPlay, Remote Registry."""
 
 from __future__ import annotations
 
@@ -15,8 +15,8 @@ def run() -> list[CheckResult]:
     """Return miscellaneous security configuration checks.
 
     Returns:
-        list[CheckResult]: Results for AutoPlay, Remote Registry, and LLMNR.
-    """
+        list[CheckResult]: Results for AutoPlay and Remote Registry.
+"""
     # TODO: implement via registry reads and service status checks
     return [
         CheckResult(
@@ -34,15 +34,6 @@ def run() -> list[CheckResult]:
             status=Status.INFO,
             severity=Severity.HIGH,
             description="Checks whether the Remote Registry service is stopped and disabled.",
-            details="Not yet implemented.",
-            remediation="",
-        ),
-        CheckResult(
-            category=CATEGORY,
-            check_name="LLMNR Disabled",
-            status=Status.INFO,
-            severity=Severity.HIGH,
-            description="Checks whether LLMNR is disabled (mitigates Responder attacks).",
             details="Not yet implemented.",
             remediation="",
         ),

--- a/src/winposture/checks/network.py
+++ b/src/winposture/checks/network.py
@@ -1,31 +1,276 @@
-"""Check: Open ports and listening services."""
+"""Check: Network configuration — listening ports, LLMNR, NetBIOS, IPv6."""
 
 from __future__ import annotations
 
 import logging
 
+from winposture.exceptions import WinPostureError
 from winposture.models import CheckResult, Severity, Status
+from winposture.utils import run_powershell, run_powershell_json
 
 log = logging.getLogger(__name__)
 
 CATEGORY = "Network"
+
+# Build a process-id lookup once, then join it to listening connections.
+_PS_TCP_LISTEN = (
+    "$procs = @{}; "
+    "Get-Process -ErrorAction SilentlyContinue | ForEach-Object { $procs[$_.Id] = $_.ProcessName }; "
+    "Get-NetTCPConnection -State Listen -ErrorAction SilentlyContinue "
+    "| Select-Object LocalPort, LocalAddress, "
+    "@{N='ProcessName';E={if($procs[$_.OwningProcess]){$procs[$_.OwningProcess]}else{'Unknown'}}} "
+    "| ConvertTo-Json -Compress"
+)
+
+# EnableMulticast = 0 → LLMNR disabled. Key absent → LLMNR enabled (default).
+_PS_LLMNR = (
+    "$v = (Get-ItemProperty "
+    "-LiteralPath 'HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\DNSClient' "
+    "-Name 'EnableMulticast' -ErrorAction SilentlyContinue).EnableMulticast; "
+    "if ($null -eq $v) { 'NOTSET' } else { $v }"
+)
+
+# TcpipNetbiosOptions per IP-enabled adapter: 0=DHCP, 1=Enabled, 2=Disabled
+_PS_NETBIOS = (
+    "Get-CimInstance Win32_NetworkAdapterConfiguration "
+    "| Where-Object { $_.IPEnabled } "
+    "| Select-Object -ExpandProperty TcpipNetbiosOptions "
+    "| ConvertTo-Json -Compress"
+)
+
+# Count active adapters with an IPv6 address assigned
+_PS_IPV6 = (
+    "(Get-NetAdapter | Where-Object { $_.Status -eq 'Up' } "
+    "| Get-NetIPAddress -AddressFamily IPv6 -ErrorAction SilentlyContinue "
+    "| Measure-Object).Count"
+)
+
+# Ports to flag if found listening on any interface
+_RISKY_PORTS: dict[int, tuple[str, Status, Severity, str]] = {
+    21:  ("FTP",    Status.WARN, Severity.HIGH,     "FTP transmits credentials in cleartext."),
+    23:  ("Telnet", Status.FAIL, Severity.CRITICAL, "Telnet transmits all traffic in cleartext."),
+    69:  ("TFTP",   Status.WARN, Severity.HIGH,     "TFTP has no authentication."),
+    3389: ("RDP",   Status.WARN, Severity.MEDIUM,   "RDP is exposed; ensure NLA is enforced."),
+}
 
 
 def run() -> list[CheckResult]:
     """Return network exposure checks.
 
     Returns:
-        list[CheckResult]: Results about listening ports and bound services.
+        list[CheckResult]: Results for risky listening ports, all-ports summary,
+        LLMNR, NetBIOS, and IPv6 awareness.
     """
-    # TODO: implement via Get-NetTCPConnection / netstat PowerShell
-    return [
-        CheckResult(
+    results: list[CheckResult] = []
+    results.extend(_check_listening_ports())
+    results.extend(_check_llmnr())
+    results.extend(_check_netbios())
+    results.extend(_check_ipv6())
+    return results
+
+
+def _check_listening_ports() -> list[CheckResult]:
+    """Enumerate TCP listening ports and flag known-dangerous services."""
+    try:
+        data = run_powershell_json(_PS_TCP_LISTEN)
+    except WinPostureError as exc:
+        return [_error("Listening Ports", str(exc))]
+
+    conns = data if isinstance(data, list) else ([data] if data else [])
+
+    # Build a compact set for risky-port lookup:  port → (addr, process)
+    risky_hits: dict[int, list[tuple[str, str]]] = {}
+    all_ports: list[str] = []
+
+    for conn in conns:
+        port = int(conn.get("LocalPort") or 0)
+        addr = str(conn.get("LocalAddress") or "?")
+        proc = str(conn.get("ProcessName") or "Unknown")
+        all_ports.append(f"{port}/{proc}")
+        if port in _RISKY_PORTS:
+            risky_hits.setdefault(port, []).append((addr, proc))
+
+    results: list[CheckResult] = []
+
+    # One result per risky port found
+    for port, hits in sorted(risky_hits.items()):
+        service, status, severity, reason = _RISKY_PORTS[port]
+        addr_list = ", ".join(f"{a} ({p})" for a, p in hits)
+        results.append(CheckResult(
             category=CATEGORY,
-            check_name="Open Listening Ports",
-            status=Status.INFO,
+            check_name=f"Listening Port — {port}/{service}",
+            status=status,
+            severity=severity,
+            description=f"Checks whether port {port} ({service}) is listening. {reason}",
+            details=f"Port {port} ({service}) is listening on: {addr_list}",
+            remediation=(
+                f"Disable or firewall port {port} ({service}). "
+                f"Stop the associated service and block the port in Windows Firewall: "
+                f"New-NetFirewallRule -Direction Inbound -LocalPort {port} -Protocol TCP -Action Block"
+            ),
+        ))
+
+    # Summary INFO result for all listeners
+    unique_ports = sorted({int(c.get("LocalPort") or 0) for c in conns})
+    port_summary = ", ".join(str(p) for p in unique_ports[:30])
+    if len(unique_ports) > 30:
+        port_summary += f" … (+{len(unique_ports) - 30} more)"
+
+    results.append(CheckResult(
+        category=CATEGORY,
+        check_name="Listening Ports — Summary",
+        status=Status.INFO,
+        severity=Severity.INFO,
+        description="Enumerates all TCP ports in LISTEN state.",
+        details=f"{len(unique_ports)} listening port(s): {port_summary}" if unique_ports else "No listening TCP ports found.",
+        remediation="",
+    ))
+
+    return results
+
+
+def _check_llmnr() -> list[CheckResult]:
+    """Check whether Link-Local Multicast Name Resolution (LLMNR) is disabled."""
+    try:
+        output = run_powershell(_PS_LLMNR).strip()
+    except WinPostureError as exc:
+        return [_error("LLMNR", str(exc))]
+
+    # NOTSET means the registry key doesn't exist → LLMNR is enabled by default
+    if output == "NOTSET" or output == "1":
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="LLMNR Disabled",
+            status=Status.WARN,
             severity=Severity.MEDIUM,
-            description="Enumerates TCP/UDP ports listening on all interfaces.",
-            details="Not yet implemented.",
+            description="Checks whether LLMNR is disabled (LLMNR is susceptible to poisoning attacks).",
+            details=(
+                "LLMNR is enabled (default). "
+                "Attackers on the local network can use tools like Responder "
+                "to capture NTLMv2 hashes via LLMNR poisoning."
+            ),
+            remediation=(
+                "Disable LLMNR via Group Policy: "
+                "Computer Configuration → Administrative Templates → Network → "
+                "DNS Client → Turn off multicast name resolution → Enabled. "
+                "Or via registry: "
+                "New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\DNSClient' "
+                "-Name 'EnableMulticast' -Value 0 -PropertyType DWORD -Force"
+            ),
+        )]
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="LLMNR Disabled",
+        status=Status.PASS,
+        severity=Severity.MEDIUM,
+        description="Checks whether LLMNR is disabled (LLMNR is susceptible to poisoning attacks).",
+        details="LLMNR is disabled via Group Policy.",
+        remediation="",
+    )]
+
+
+def _check_netbios() -> list[CheckResult]:
+    """Check whether NetBIOS over TCP/IP is disabled on all adapters."""
+    try:
+        data = run_powershell_json(_PS_NETBIOS)
+    except WinPostureError as exc:
+        return [_error("NetBIOS over TCP/IP", str(exc))]
+
+    options = data if isinstance(data, list) else ([data] if data else [])
+    # Normalise to plain ints
+    opt_ints = []
+    for o in options:
+        try:
+            opt_ints.append(int(o))
+        except (TypeError, ValueError):
+            pass
+
+    if not opt_ints:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="NetBIOS over TCP/IP",
+            status=Status.INFO,
+            severity=Severity.LOW,
+            description="Checks whether NetBIOS over TCP/IP is disabled on all network adapters.",
+            details="No IP-enabled adapters found or could not read NetBIOS setting.",
             remediation="",
+        )]
+
+    enabled_count  = opt_ints.count(1)   # explicitly enabled
+    dhcp_count     = opt_ints.count(0)   # via DHCP (uncertain)
+    disabled_count = opt_ints.count(2)   # explicitly disabled
+
+    if enabled_count > 0:
+        status, severity = Status.WARN, Severity.MEDIUM
+        details = (
+            f"NetBIOS over TCP/IP is explicitly enabled on {enabled_count} adapter(s). "
+            f"NetBIOS exposes the host to name-spoofing and enumeration."
         )
-    ]
+        remediation = (
+            "Disable NetBIOS on all adapters: "
+            "Network Connections → Adapter → Properties → TCP/IPv4 → Advanced → WINS → "
+            "Disable NetBIOS over TCP/IP. "
+            "Or via WMI: "
+            "(Get-CimInstance Win32_NetworkAdapterConfiguration -Filter 'IPEnabled=True')"
+            ".SetTcpipNetbios(2)"
+        )
+    elif dhcp_count > 0:
+        status, severity = Status.WARN, Severity.LOW
+        details = (
+            f"{dhcp_count} adapter(s) inherit NetBIOS setting from DHCP. "
+            "If the DHCP server does not explicitly disable NetBIOS, it may be active."
+        )
+        remediation = (
+            "Explicitly disable NetBIOS on all adapters rather than relying on DHCP. "
+            "Set TcpipNetbiosOptions to 2 on each adapter."
+        )
+    else:
+        status, severity = Status.PASS, Severity.LOW
+        details = f"NetBIOS over TCP/IP is explicitly disabled on all {disabled_count} adapter(s)."
+        remediation = ""
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="NetBIOS over TCP/IP",
+        status=status,
+        severity=severity,
+        description="Checks whether NetBIOS over TCP/IP is disabled on all network adapters.",
+        details=details,
+        remediation=remediation,
+    )]
+
+
+def _check_ipv6() -> list[CheckResult]:
+    """Report IPv6 status (informational — not a security finding by itself)."""
+    try:
+        output = run_powershell(_PS_IPV6).strip()
+        count = int(output) if output.isdigit() else 0
+    except (WinPostureError, ValueError):
+        count = 0
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="IPv6 Status",
+        status=Status.INFO,
+        severity=Severity.INFO,
+        description="Reports whether IPv6 is active on any network adapter (informational).",
+        details=(
+            f"IPv6 is active on {count} adapter(s)."
+            if count > 0 else
+            "IPv6 is not active on any adapter."
+        ),
+        remediation="",
+    )]
+
+
+def _error(check_name: str, details: str) -> CheckResult:
+    return CheckResult(
+        category=CATEGORY,
+        check_name=check_name,
+        status=Status.ERROR,
+        severity=Severity.INFO,
+        description="An error occurred while running this check.",
+        details=details,
+        remediation="Run with --log-level DEBUG for more detail.",
+    )

--- a/src/winposture/checks/rdp.py
+++ b/src/winposture/checks/rdp.py
@@ -1,40 +1,180 @@
-"""Check: Remote Desktop Protocol — enabled status and NLA enforcement."""
+"""Check: Remote Desktop Protocol — enabled status, NLA, and port configuration."""
 
 from __future__ import annotations
 
 import logging
 
+from winposture.exceptions import WinPostureError
 from winposture.models import CheckResult, Severity, Status
+from winposture.utils import run_powershell_json
 
 log = logging.getLogger(__name__)
 
-CATEGORY = "RDP"
+CATEGORY = "Remote Access"
+
+_RDP_DEFAULT_PORT = 3389
+
+# Fetch all RDP-relevant registry values in one PS call.
+_PS_RDP = (
+    "$ts  = 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server'; "
+    "$rdp = 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp'; "
+    "@{ "
+    "fDenyTSConnections  = (Get-ItemProperty $ts  -ErrorAction SilentlyContinue).fDenyTSConnections; "
+    "UserAuthentication  = (Get-ItemProperty $rdp -ErrorAction SilentlyContinue).UserAuthentication; "
+    "PortNumber          = (Get-ItemProperty $rdp -ErrorAction SilentlyContinue).PortNumber "
+    "} | ConvertTo-Json -Compress"
+)
 
 
 def run() -> list[CheckResult]:
-    """Return RDP security configuration checks.
+    """Return Remote Desktop Protocol security checks.
 
     Returns:
-        list[CheckResult]: Results for RDP enablement and NLA requirement.
+        list[CheckResult]: Results for RDP enablement, NLA, and port.
+        NLA and port checks are only included when RDP is enabled.
     """
-    # TODO: implement via registry and Get-ItemProperty PowerShell
-    return [
-        CheckResult(
+    try:
+        data = run_powershell_json(_PS_RDP)
+    except WinPostureError as exc:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="RDP Configuration",
+            status=Status.ERROR,
+            severity=Severity.HIGH,
+            description="Checks Remote Desktop Protocol configuration.",
+            details=str(exc),
+            remediation="Run with --log-level DEBUG for more detail.",
+        )]
+
+    if isinstance(data, list):
+        data = data[0] if data else {}
+
+    rdp_check, rdp_enabled = _check_rdp_enabled(data)
+    results = list(rdp_check)
+
+    if rdp_enabled:
+        results.extend(_check_rdp_nla(data))
+        results.extend(_check_rdp_port(data))
+
+    return results
+
+
+def _check_rdp_enabled(data: dict) -> tuple[list[CheckResult], bool]:
+    """Return (results, rdp_is_enabled) for the RDP enabled/disabled state.
+
+    fDenyTSConnections = 0 → RDP enabled
+    fDenyTSConnections = 1 (or absent) → RDP disabled
+    """
+    raw = data.get("fDenyTSConnections")
+
+    if raw is None:
+        # Key absent typically means RDP is disabled (default on desktop SKUs)
+        return ([CheckResult(
             category=CATEGORY,
             check_name="RDP Enabled",
-            status=Status.INFO,
+            status=Status.PASS,
             severity=Severity.HIGH,
             description="Checks whether Remote Desktop is enabled.",
-            details="Not yet implemented.",
+            details="RDP is disabled (fDenyTSConnections key not found — default disabled state).",
             remediation="",
-        ),
-        CheckResult(
+        )], False)
+
+    rdp_enabled = int(raw) == 0   # 0 = connections allowed
+
+    if rdp_enabled:
+        result = CheckResult(
+            category=CATEGORY,
+            check_name="RDP Enabled",
+            status=Status.WARN,
+            severity=Severity.HIGH,
+            description="Checks whether Remote Desktop is enabled.",
+            details=(
+                "Remote Desktop is enabled (fDenyTSConnections = 0). "
+                "Ensure access is restricted by firewall and NLA is required."
+            ),
+            remediation=(
+                "If RDP is not required, disable it: "
+                "Set-ItemProperty -Path "
+                "'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server' "
+                "-Name fDenyTSConnections -Value 1. "
+                "If RDP is required, restrict access via Windows Firewall."
+            ),
+        )
+    else:
+        result = CheckResult(
+            category=CATEGORY,
+            check_name="RDP Enabled",
+            status=Status.PASS,
+            severity=Severity.HIGH,
+            description="Checks whether Remote Desktop is enabled.",
+            details="Remote Desktop is disabled (fDenyTSConnections = 1).",
+            remediation="",
+        )
+
+    return ([result], rdp_enabled)
+
+
+def _check_rdp_nla(data: dict) -> list[CheckResult]:
+    """Check whether Network Level Authentication is required for RDP."""
+    raw = data.get("UserAuthentication")
+
+    if raw is None:
+        return [CheckResult(
             category=CATEGORY,
             check_name="RDP Network Level Authentication",
-            status=Status.INFO,
+            status=Status.WARN,
             severity=Severity.HIGH,
             description="Checks whether NLA is required for RDP connections.",
-            details="Not yet implemented.",
-            remediation="",
+            details="Could not determine NLA setting (UserAuthentication key not found).",
+            remediation=(
+                "Enable NLA: "
+                "Set-ItemProperty -Path "
+                "'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp' "
+                "-Name UserAuthentication -Value 1"
+            ),
+        )]
+
+    nla_required = int(raw) == 1
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="RDP Network Level Authentication",
+        status=Status.PASS if nla_required else Status.FAIL,
+        severity=Severity.HIGH,
+        description="Checks whether NLA is required for RDP connections.",
+        details=(
+            "Network Level Authentication (NLA) is required for RDP."
+            if nla_required else
+            "Network Level Authentication (NLA) is NOT required. "
+            "Unauthenticated users can reach the Windows login screen, "
+            "enabling credential brute-force attacks."
         ),
-    ]
+        remediation=(
+            "" if nla_required else
+            "Enable NLA: "
+            "Set-ItemProperty -Path "
+            "'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp' "
+            "-Name UserAuthentication -Value 1. "
+            "Or: System Properties → Remote → "
+            "'Allow connections only from computers running Remote Desktop with NLA'"
+        ),
+    )]
+
+
+def _check_rdp_port(data: dict) -> list[CheckResult]:
+    """Report the RDP listening port (informational)."""
+    raw = data.get("PortNumber")
+    port = int(raw) if raw is not None else _RDP_DEFAULT_PORT
+    non_standard = port != _RDP_DEFAULT_PORT
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="RDP Port",
+        status=Status.INFO,
+        severity=Severity.INFO,
+        description=f"Reports the RDP listening port (default: {_RDP_DEFAULT_PORT}).",
+        details=(
+            f"RDP is listening on port {port}."
+            + (" (non-standard port)" if non_standard else " (default port 3389)")
+        ),
+        remediation="",
+    )]

--- a/src/winposture/checks/smb.py
+++ b/src/winposture/checks/smb.py
@@ -1,40 +1,172 @@
-"""Check: SMB configuration — SMBv1 disabled, message signing enforced."""
+"""Check: SMB server configuration — SMBv1, signing, and encryption."""
 
 from __future__ import annotations
 
 import logging
 
+from winposture.exceptions import WinPostureError
 from winposture.models import CheckResult, Severity, Status
+from winposture.utils import run_powershell_json
 
 log = logging.getLogger(__name__)
 
-CATEGORY = "SMB"
+CATEGORY = "File Sharing"
+
+_PS_SMB = (
+    "try { "
+    "Get-SmbServerConfiguration "
+    "| Select-Object EnableSMB1Protocol, RequireSecuritySignature, "
+    "EnableSecuritySignature, EncryptData "
+    "| ConvertTo-Json -Compress "
+    "} catch { "
+    "'{\"EnableSMB1Protocol\":null,\"RequireSecuritySignature\":null,"
+    "\"EnableSecuritySignature\":null,\"EncryptData\":null}' "
+    "}"
+)
 
 
 def run() -> list[CheckResult]:
-    """Return SMB security configuration checks.
+    """Return SMB server configuration checks.
 
     Returns:
-        list[CheckResult]: Results for SMBv1 status and signing enforcement.
+        list[CheckResult]: Results for SMBv1 status, signing policy, and encryption.
     """
-    # TODO: implement via Get-SmbServerConfiguration PowerShell cmdlet
-    return [
-        CheckResult(
+    try:
+        data = run_powershell_json(_PS_SMB)
+    except WinPostureError as exc:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="SMB Configuration",
+            status=Status.ERROR,
+            severity=Severity.HIGH,
+            description="Checks SMB server configuration.",
+            details=str(exc),
+            remediation="Ensure Get-SmbServerConfiguration is available. Run with --log-level DEBUG.",
+        )]
+
+    if isinstance(data, list):
+        data = data[0] if data else {}
+
+    results: list[CheckResult] = []
+    results.extend(_check_smb1(data))
+    results.extend(_check_smb_signing(data))
+    results.extend(_check_smb_encryption(data))
+    return results
+
+
+def _check_smb1(data: dict) -> list[CheckResult]:
+    """Check whether SMBv1 is disabled."""
+    raw = data.get("EnableSMB1Protocol")
+
+    if raw is None:
+        return [CheckResult(
             category=CATEGORY,
             check_name="SMBv1 Disabled",
-            status=Status.INFO,
+            status=Status.WARN,
             severity=Severity.CRITICAL,
             description="Checks that SMBv1 is disabled (mitigates EternalBlue/WannaCry).",
-            details="Not yet implemented.",
-            remediation="",
+            details="Could not determine SMBv1 status from Get-SmbServerConfiguration.",
+            remediation=(
+                "Verify SMBv1 status manually: Get-SmbServerConfiguration | Select EnableSMB1Protocol. "
+                "To disable: Set-SmbServerConfiguration -EnableSMB1Protocol $false -Force"
+            ),
+        )]
+
+    enabled = bool(raw)
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="SMBv1 Disabled",
+        status=Status.FAIL if enabled else Status.PASS,
+        severity=Severity.CRITICAL,
+        description="Checks that SMBv1 is disabled (mitigates EternalBlue/WannaCry/NotPetya).",
+        details=f"SMBv1 protocol is {'enabled' if enabled else 'disabled'}.",
+        remediation=(
+            "" if not enabled else
+            "Disable SMBv1 immediately: "
+            "Set-SmbServerConfiguration -EnableSMB1Protocol $false -Force. "
+            "Also disable via Windows Features: "
+            "Disable-WindowsOptionalFeature -Online -FeatureName SMB1Protocol"
         ),
-        CheckResult(
+    )]
+
+
+def _check_smb_signing(data: dict) -> list[CheckResult]:
+    """Check whether SMB message signing is required (not just enabled)."""
+    required = data.get("RequireSecuritySignature")
+    enabled = data.get("EnableSecuritySignature")
+
+    if required is None:
+        return [CheckResult(
             category=CATEGORY,
             check_name="SMB Signing Required",
-            status=Status.INFO,
+            status=Status.WARN,
             severity=Severity.HIGH,
             description="Checks that SMB message signing is required (mitigates relay attacks).",
-            details="Not yet implemented.",
+            details="Could not determine SMB signing configuration.",
+            remediation="Check manually: Get-SmbServerConfiguration | Select RequireSecuritySignature",
+        )]
+
+    required_bool = bool(required)
+    enabled_bool = bool(enabled) if enabled is not None else False
+
+    if required_bool:
+        details = "SMB signing is required on this server."
+        status = Status.PASS
+        remediation = ""
+    elif enabled_bool:
+        details = "SMB signing is enabled but not required — clients may negotiate unsigned connections."
+        status = Status.WARN
+        remediation = (
+            "Require SMB signing to prevent relay attacks: "
+            "Set-SmbServerConfiguration -RequireSecuritySignature $true -Force"
+        )
+    else:
+        details = "SMB signing is neither required nor enabled."
+        status = Status.FAIL
+        remediation = (
+            "Enable and require SMB signing: "
+            "Set-SmbServerConfiguration -EnableSecuritySignature $true "
+            "-RequireSecuritySignature $true -Force"
+        )
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="SMB Signing Required",
+        status=status,
+        severity=Severity.HIGH,
+        description="Checks that SMB message signing is required (mitigates NTLM relay attacks).",
+        details=details,
+        remediation=remediation,
+    )]
+
+
+def _check_smb_encryption(data: dict) -> list[CheckResult]:
+    """Check whether SMB encryption is enabled (SMB 3.0+ feature)."""
+    raw = data.get("EncryptData")
+
+    if raw is None:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="SMB Encryption",
+            status=Status.INFO,
+            severity=Severity.LOW,
+            description="Checks whether SMB encryption is enforced (SMB 3.0+ feature).",
+            details="Could not determine SMB encryption status.",
             remediation="",
+        )]
+
+    enabled = bool(raw)
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="SMB Encryption",
+        status=Status.PASS if enabled else Status.INFO,
+        severity=Severity.LOW,
+        description="Checks whether SMB encryption is enforced (SMB 3.0+ feature).",
+        details=f"SMB encryption (EncryptData) is {'enabled' if enabled else 'disabled'}.",
+        remediation=(
+            "" if enabled else
+            "Enable SMB encryption for sensitive environments: "
+            "Set-SmbServerConfiguration -EncryptData $true -Force. "
+            "Note: requires all clients to support SMB 3.0+"
         ),
-    ]
+    )]

--- a/src/winposture/checks/uac.py
+++ b/src/winposture/checks/uac.py
@@ -1,31 +1,233 @@
-"""Check: User Account Control (UAC) level."""
+"""Check: User Account Control (UAC) configuration."""
 
 from __future__ import annotations
 
 import logging
 
+from winposture.exceptions import WinPostureError
 from winposture.models import CheckResult, Severity, Status
+from winposture.utils import run_powershell_json
 
 log = logging.getLogger(__name__)
 
-CATEGORY = "UAC"
+CATEGORY = "Access Control"
+
+_REG_KEY = "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System"
+
+# Read all UAC-relevant values in a single PS call
+_PS_UAC = (
+    "$k = Get-ItemProperty -LiteralPath "
+    f"'{_REG_KEY}' "
+    "-ErrorAction SilentlyContinue; "
+    "@{ "
+    "EnableLUA                    = $k.EnableLUA; "
+    "ConsentPromptBehaviorAdmin   = $k.ConsentPromptBehaviorAdmin; "
+    "ConsentPromptBehaviorUser    = $k.ConsentPromptBehaviorUser; "
+    "PromptOnSecureDesktop        = $k.PromptOnSecureDesktop; "
+    "EnableVirtualization         = $k.EnableVirtualization "
+    "} | ConvertTo-Json -Compress"
+)
+
+# ConsentPromptBehaviorAdmin values
+_ADMIN_BEHAVIOR: dict[int, str] = {
+    0: "Elevate without prompting (silently allows elevation)",
+    1: "Prompt for credentials on secure desktop",
+    2: "Prompt for consent on secure desktop",
+    3: "Prompt for credentials (not on secure desktop)",
+    4: "Prompt for consent (not on secure desktop)",
+    5: "Prompt for consent for non-Windows binaries (Windows default)",
+}
+
+# ConsentPromptBehaviorUser values
+_USER_BEHAVIOR: dict[int, str] = {
+    0: "Automatically deny elevation requests",
+    1: "Prompt for credentials on secure desktop",
+    3: "Prompt for credentials (default)",
+}
 
 
 def run() -> list[CheckResult]:
     """Return UAC configuration checks.
 
     Returns:
-        list[CheckResult]: Result for the current UAC consent behavior level.
+        list[CheckResult]: Results for UAC enablement, admin consent behavior,
+        secure desktop enforcement, and user elevation behaviour.
     """
-    # TODO: implement via registry HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
-    return [
-        CheckResult(
+    try:
+        data = run_powershell_json(_PS_UAC)
+    except WinPostureError as exc:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="UAC Configuration",
+            status=Status.ERROR,
+            severity=Severity.CRITICAL,
+            description="Checks User Account Control (UAC) configuration.",
+            details=str(exc),
+            remediation="Run with --log-level DEBUG for more detail.",
+        )]
+
+    if isinstance(data, list):
+        data = data[0] if data else {}
+
+    results: list[CheckResult] = []
+    results.extend(_check_uac_enabled(data))
+    results.extend(_check_admin_behavior(data))
+    results.extend(_check_secure_desktop(data))
+    results.extend(_check_user_behavior(data))
+    return results
+
+
+def _check_uac_enabled(data: dict) -> list[CheckResult]:
+    """Check whether UAC (EnableLUA) is enabled."""
+    raw = data.get("EnableLUA")
+
+    if raw is None:
+        return [CheckResult(
             category=CATEGORY,
             check_name="UAC Enabled",
+            status=Status.WARN,
+            severity=Severity.CRITICAL,
+            description="Checks whether User Account Control (UAC) is enabled.",
+            details="Could not read UAC EnableLUA registry value.",
+            remediation=(
+                "Verify UAC status: "
+                f"Get-ItemProperty '{_REG_KEY}' | Select EnableLUA. "
+                "Enable UAC: Set-ItemProperty -Path "
+                f"'{_REG_KEY}' -Name EnableLUA -Value 1"
+            ),
+        )]
+
+    enabled = int(raw) == 1
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="UAC Enabled",
+        status=Status.PASS if enabled else Status.FAIL,
+        severity=Severity.CRITICAL,
+        description="Checks whether User Account Control (UAC) is enabled.",
+        details=f"UAC (EnableLUA) is {'enabled' if enabled else 'disabled'}.",
+        remediation=(
+            "" if enabled else
+            "Enable UAC immediately: "
+            "Set-ItemProperty -Path "
+            f"'{_REG_KEY}' "
+            "-Name EnableLUA -Value 1. "
+            "A reboot is required for the change to take effect."
+        ),
+    )]
+
+
+def _check_admin_behavior(data: dict) -> list[CheckResult]:
+    """Check the UAC consent prompt behavior for administrators."""
+    raw = data.get("ConsentPromptBehaviorAdmin")
+
+    if raw is None:
+        # If the key is absent, Windows uses the built-in default (5)
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="UAC Admin Consent Behavior",
             status=Status.INFO,
             severity=Severity.HIGH,
-            description="Checks whether UAC is enabled and at what consent level.",
-            details="Not yet implemented.",
+            description="Checks the UAC consent prompt behavior for administrator accounts.",
+            details="ConsentPromptBehaviorAdmin not set; Windows default (5) applies.",
             remediation="",
-        )
-    ]
+        )]
+
+    level = int(raw)
+    description_text = _ADMIN_BEHAVIOR.get(level, f"Unknown value ({level})")
+
+    # Level 0 = silent elevation — highest risk
+    if level == 0:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="UAC Admin Consent Behavior",
+            status=Status.WARN,
+            severity=Severity.HIGH,
+            description="Checks the UAC consent prompt behavior for administrator accounts.",
+            details=(
+                f"ConsentPromptBehaviorAdmin = {level}: {description_text}. "
+                "Administrators are elevated silently without any confirmation prompt."
+            ),
+            remediation=(
+                "Set admin UAC to at least require consent: "
+                "Set-ItemProperty -Path "
+                f"'{_REG_KEY}' "
+                "-Name ConsentPromptBehaviorAdmin -Value 2. "
+                "Recommended value: 2 (prompt for consent on secure desktop)"
+            ),
+        )]
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="UAC Admin Consent Behavior",
+        status=Status.PASS,
+        severity=Severity.HIGH,
+        description="Checks the UAC consent prompt behavior for administrator accounts.",
+        details=f"ConsentPromptBehaviorAdmin = {level}: {description_text}.",
+        remediation="",
+    )]
+
+
+def _check_secure_desktop(data: dict) -> list[CheckResult]:
+    """Check whether UAC prompts are shown on the secure desktop."""
+    raw = data.get("PromptOnSecureDesktop")
+
+    if raw is None:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="UAC Secure Desktop",
+            status=Status.INFO,
+            severity=Severity.MEDIUM,
+            description="Checks whether UAC prompts appear on the isolated secure desktop.",
+            details="PromptOnSecureDesktop not set; Windows default (enabled) applies.",
+            remediation="",
+        )]
+
+    on_secure = int(raw) == 1
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="UAC Secure Desktop",
+        status=Status.PASS if on_secure else Status.WARN,
+        severity=Severity.MEDIUM,
+        description="Checks whether UAC prompts appear on the isolated secure desktop.",
+        details=(
+            "UAC prompts are displayed on the secure desktop (isolated from user input)."
+            if on_secure else
+            "UAC prompts are NOT on the secure desktop. "
+            "Malware running as the user may be able to interact with or spoof the UAC dialog."
+        ),
+        remediation=(
+            "" if on_secure else
+            "Enable secure desktop for UAC prompts: "
+            "Set-ItemProperty -Path "
+            f"'{_REG_KEY}' "
+            "-Name PromptOnSecureDesktop -Value 1"
+        ),
+    )]
+
+
+def _check_user_behavior(data: dict) -> list[CheckResult]:
+    """Check the UAC consent prompt behavior for standard users."""
+    raw = data.get("ConsentPromptBehaviorUser")
+
+    if raw is None:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="UAC Standard User Behavior",
+            status=Status.INFO,
+            severity=Severity.LOW,
+            description="Checks the UAC consent prompt behavior for standard user accounts.",
+            details="ConsentPromptBehaviorUser not set; Windows default (3) applies.",
+            remediation="",
+        )]
+
+    level = int(raw)
+    description_text = _USER_BEHAVIOR.get(level, f"Unknown value ({level})")
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="UAC Standard User Behavior",
+        status=Status.INFO,
+        severity=Severity.LOW,
+        description="Checks the UAC consent prompt behavior for standard user accounts.",
+        details=f"ConsentPromptBehaviorUser = {level}: {description_text}.",
+        remediation="",
+    )]

--- a/tests/test_checks/test_accounts.py
+++ b/tests/test_checks/test_accounts.py
@@ -1,0 +1,277 @@
+"""Tests for winposture.checks.accounts."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from winposture.checks import accounts
+from winposture.exceptions import WinPostureError
+from winposture.models import CheckResult, Status, Severity
+
+
+# ---------------------------------------------------------------------------
+# _check_guest_account
+# ---------------------------------------------------------------------------
+
+class TestCheckGuestAccount:
+    def test_guest_disabled_is_pass(self):
+        with patch("winposture.checks.accounts.run_powershell", return_value="False"):
+            results = accounts._check_guest_account()
+        assert len(results) == 1
+        r = results[0]
+        assert r.status == Status.PASS
+        assert r.severity == Severity.HIGH
+
+    def test_guest_enabled_is_fail(self):
+        with patch("winposture.checks.accounts.run_powershell", return_value="True"):
+            results = accounts._check_guest_account()
+        r = results[0]
+        assert r.status == Status.FAIL
+        assert "enabled" in r.details.lower()
+        assert "Disable-LocalUser" in r.remediation
+
+    def test_guest_not_found_is_info(self):
+        with patch("winposture.checks.accounts.run_powershell", return_value=""):
+            results = accounts._check_guest_account()
+        r = results[0]
+        assert r.status == Status.INFO
+        assert "not found" in r.details.lower()
+
+    def test_powershell_error_returns_error(self):
+        with patch("winposture.checks.accounts.run_powershell",
+                   side_effect=WinPostureError("boom")):
+            results = accounts._check_guest_account()
+        assert results[0].status == Status.ERROR
+
+
+# ---------------------------------------------------------------------------
+# _check_builtin_admin
+# ---------------------------------------------------------------------------
+
+class TestCheckBuiltinAdmin:
+    def _run(self, data):
+        with patch("winposture.checks.accounts.run_powershell_json", return_value=data):
+            return accounts._check_builtin_admin()
+
+    def test_enabled_default_name_is_fail(self):
+        results = self._run({"Name": "Administrator", "Enabled": True})
+        r = results[0]
+        assert r.status == Status.FAIL
+        assert r.severity == Severity.MEDIUM
+
+    def test_enabled_renamed_is_warn(self):
+        results = self._run({"Name": "sysadmin", "Enabled": True})
+        r = results[0]
+        assert r.status == Status.WARN
+        assert r.severity == Severity.LOW
+        assert "sysadmin" in r.details
+
+    def test_disabled_is_pass(self):
+        results = self._run({"Name": "Administrator", "Enabled": False})
+        r = results[0]
+        assert r.status == Status.PASS
+
+    def test_disabled_renamed_is_pass(self):
+        results = self._run({"Name": "sysadmin", "Enabled": False})
+        r = results[0]
+        assert r.status == Status.PASS
+        assert "sysadmin" in r.details
+
+    def test_empty_data_returns_info(self):
+        results = self._run(None)
+        r = results[0]
+        assert r.status == Status.INFO
+        assert "not found" in r.details.lower()
+
+    def test_list_data_uses_first_element(self):
+        results = self._run([{"Name": "Administrator", "Enabled": False}])
+        assert results[0].status == Status.PASS
+
+    def test_error_returns_error_result(self):
+        with patch("winposture.checks.accounts.run_powershell_json",
+                   side_effect=WinPostureError("access denied")):
+            results = accounts._check_builtin_admin()
+        assert results[0].status == Status.ERROR
+
+
+# ---------------------------------------------------------------------------
+# _check_admin_count
+# ---------------------------------------------------------------------------
+
+class TestCheckAdminCount:
+    def _run(self, members):
+        with patch("winposture.checks.accounts.run_powershell_json", return_value=members):
+            return accounts._check_admin_count()
+
+    def test_one_admin_is_pass(self):
+        results = self._run([{"Name": "MACHINE\\Admin", "PrincipalSource": "Local", "ObjectClass": "User"}])
+        assert results[0].status == Status.PASS
+
+    def test_two_admins_is_pass(self):
+        members = [
+            {"Name": "MACHINE\\Admin", "PrincipalSource": "Local", "ObjectClass": "User"},
+            {"Name": "MACHINE\\Domain Admins", "PrincipalSource": "ActiveDirectory", "ObjectClass": "Group"},
+        ]
+        results = self._run(members)
+        assert results[0].status == Status.PASS
+
+    def test_three_admins_is_warn(self):
+        members = [
+            {"Name": "MACHINE\\Admin1"},
+            {"Name": "MACHINE\\Admin2"},
+            {"Name": "MACHINE\\Admin3"},
+        ]
+        results = self._run(members)
+        r = results[0]
+        assert r.status == Status.WARN
+        assert "3" in r.details
+
+    def test_domain_prefix_stripped_from_display(self):
+        results = self._run([{"Name": "MACHINE\\Alice"}])
+        assert "Alice" in results[0].details
+        assert "MACHINE" not in results[0].details
+
+    def test_single_dict_wrapped(self):
+        results = self._run({"Name": "MACHINE\\Admin"})
+        assert results[0].status == Status.PASS
+
+    def test_error_returns_error(self):
+        with patch("winposture.checks.accounts.run_powershell_json",
+                   side_effect=WinPostureError("denied")):
+            results = accounts._check_admin_count()
+        assert results[0].status == Status.ERROR
+
+
+# ---------------------------------------------------------------------------
+# _parse_net_accounts helper
+# ---------------------------------------------------------------------------
+
+class TestParseNetAccounts:
+    _SAMPLE = (
+        "Force user logoff how long after time expires?: Never\n"
+        "Minimum password age (days): 0\n"
+        "Maximum password age (days): 42\n"
+        "Minimum password length: 7\n"
+        "Length of password history maintained: None\n"
+        "Lockout threshold: Never\n"
+        "Lockout duration (minutes): 30\n"
+        "Lockout observation window (minutes): 30\n"
+        "Computer role: WORKSTATION\n"
+        "The command completed successfully.\n"
+    )
+
+    def test_parses_min_length(self):
+        parsed = accounts._parse_net_accounts(self._SAMPLE)
+        assert parsed["minimum password length"] == "7"
+
+    def test_parses_lockout_threshold(self):
+        parsed = accounts._parse_net_accounts(self._SAMPLE)
+        assert parsed["lockout threshold"] == "Never"
+
+    def test_keys_are_lowercase(self):
+        parsed = accounts._parse_net_accounts(self._SAMPLE)
+        assert "minimum password age (days)" in parsed
+
+    def test_empty_output(self):
+        assert accounts._parse_net_accounts("") == {}
+
+
+# ---------------------------------------------------------------------------
+# _check_password_policy (integration-level unit tests)
+# ---------------------------------------------------------------------------
+
+class TestCheckPasswordPolicy:
+    _NET_GOOD = (
+        "Minimum password length: 14\n"
+        "Lockout threshold: 5\n"
+        "Lockout duration (minutes): 30\n"
+    )
+    _NET_SHORT = (
+        "Minimum password length: 6\n"
+        "Lockout threshold: 5\n"
+        "Lockout duration (minutes): 30\n"
+    )
+    _NET_WARN_LEN = (
+        "Minimum password length: 10\n"
+        "Lockout threshold: 5\n"
+        "Lockout duration (minutes): 30\n"
+    )
+    _NET_NO_LOCKOUT = (
+        "Minimum password length: 14\n"
+        "Lockout threshold: Never\n"
+        "Lockout duration (minutes): 30\n"
+    )
+
+    def _run(self, net_output, complexity_val):
+        with (
+            patch("winposture.checks.accounts.run_powershell",
+                  side_effect=[net_output, complexity_val]),
+        ):
+            return accounts._check_password_policy()
+
+    def test_all_good_returns_passes(self):
+        results = self._run(self._NET_GOOD, "1")
+        statuses = {r.check_name: r.status for r in results}
+        assert statuses["Password Policy — Minimum Length"] == Status.PASS
+        assert statuses["Password Policy — Account Lockout"] == Status.PASS
+        assert statuses["Password Policy — Complexity"] == Status.PASS
+
+    def test_short_password_is_fail(self):
+        results = self._run(self._NET_SHORT, "1")
+        r = next(r for r in results if "Length" in r.check_name)
+        assert r.status == Status.FAIL
+        assert r.severity == Severity.HIGH
+
+    def test_warn_length_is_warn(self):
+        results = self._run(self._NET_WARN_LEN, "1")
+        r = next(r for r in results if "Length" in r.check_name)
+        assert r.status == Status.WARN
+
+    def test_no_lockout_is_warn(self):
+        results = self._run(self._NET_NO_LOCKOUT, "1")
+        r = next(r for r in results if "Lockout" in r.check_name)
+        assert r.status == Status.WARN
+        assert "net accounts" in r.remediation
+
+    def test_complexity_disabled_is_fail(self):
+        results = self._run(self._NET_GOOD, "0")
+        r = next(r for r in results if "Complexity" in r.check_name)
+        assert r.status == Status.FAIL
+
+    def test_complexity_unknown_is_info(self):
+        results = self._run(self._NET_GOOD, "Unknown")
+        r = next(r for r in results if "Complexity" in r.check_name)
+        assert r.status == Status.INFO
+
+    def test_net_accounts_error_returns_error(self):
+        with patch("winposture.checks.accounts.run_powershell",
+                   side_effect=WinPostureError("denied")):
+            results = accounts._check_password_policy()
+        assert any(r.status == Status.ERROR for r in results)
+
+
+# ---------------------------------------------------------------------------
+# run() top-level
+# ---------------------------------------------------------------------------
+
+class TestRun:
+    def test_run_returns_list_of_check_results(self):
+        net_output = (
+            "Minimum password length: 14\n"
+            "Lockout threshold: 5\n"
+            "Lockout duration (minutes): 30\n"
+        )
+        with (
+            patch("winposture.checks.accounts.run_powershell",
+                  side_effect=["False", "1", net_output, "1"]),
+            patch("winposture.checks.accounts.run_powershell_json",
+                  side_effect=[
+                      {"Name": "Administrator", "Enabled": False},
+                      [{"Name": "MACHINE\\Admin"}],
+                  ]),
+        ):
+            results = accounts.run()
+        assert all(isinstance(r, CheckResult) for r in results)
+        assert len(results) >= 6

--- a/tests/test_checks/test_network.py
+++ b/tests/test_checks/test_network.py
@@ -1,0 +1,196 @@
+"""Tests for winposture.checks.network."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from winposture.checks import network
+from winposture.exceptions import WinPostureError
+from winposture.models import CheckResult, Status, Severity
+
+
+# ---------------------------------------------------------------------------
+# _check_listening_ports
+# ---------------------------------------------------------------------------
+
+def _conn(port: int, addr: str = "0.0.0.0", proc: str = "svchost") -> dict:
+    return {"LocalPort": port, "LocalAddress": addr, "ProcessName": proc}
+
+
+class TestListeningPorts:
+    def _run(self, conns):
+        with patch("winposture.checks.network.run_powershell_json", return_value=conns):
+            return network._check_listening_ports()
+
+    def test_no_risky_ports_no_flag(self):
+        results = self._run([_conn(8080), _conn(443)])
+        statuses = [r.status for r in results]
+        assert Status.WARN not in statuses
+        assert Status.FAIL not in statuses
+
+    def test_telnet_is_fail_critical(self):
+        results = self._run([_conn(23)])
+        risky = [r for r in results if "23" in r.check_name]
+        assert len(risky) == 1
+        assert risky[0].status == Status.FAIL
+        assert risky[0].severity == Severity.CRITICAL
+
+    def test_ftp_is_warn_high(self):
+        results = self._run([_conn(21)])
+        risky = [r for r in results if "21" in r.check_name]
+        assert risky[0].status == Status.WARN
+        assert risky[0].severity == Severity.HIGH
+
+    def test_tftp_is_warn_high(self):
+        results = self._run([_conn(69)])
+        risky = [r for r in results if "69" in r.check_name]
+        assert risky[0].status == Status.WARN
+        assert risky[0].severity == Severity.HIGH
+
+    def test_rdp_3389_is_warn_medium(self):
+        results = self._run([_conn(3389)])
+        risky = [r for r in results if "3389" in r.check_name]
+        assert risky[0].status == Status.WARN
+        assert risky[0].severity == Severity.MEDIUM
+
+    def test_summary_always_present(self):
+        results = self._run([_conn(8080)])
+        summary = [r for r in results if "Summary" in r.check_name]
+        assert len(summary) == 1
+        assert summary[0].status == Status.INFO
+
+    def test_empty_connections_summary_no_ports(self):
+        results = self._run([])
+        summary = next(r for r in results if "Summary" in r.check_name)
+        assert "No listening" in summary.details
+
+    def test_summary_truncated_at_30(self):
+        conns = [_conn(p) for p in range(1, 40)]
+        results = self._run(conns)
+        summary = next(r for r in results if "Summary" in r.check_name)
+        assert "+9 more" in summary.details
+
+    def test_single_dict_wrapped(self):
+        results = self._run(_conn(80))
+        summary = next(r for r in results if "Summary" in r.check_name)
+        assert "1" in summary.details
+
+    def test_error_returns_error_result(self):
+        with patch("winposture.checks.network.run_powershell_json",
+                   side_effect=WinPostureError("boom")):
+            results = network._check_listening_ports()
+        assert results[0].status == Status.ERROR
+
+
+# ---------------------------------------------------------------------------
+# _check_llmnr
+# ---------------------------------------------------------------------------
+
+class TestCheckLlmnr:
+    def _run(self, output):
+        with patch("winposture.checks.network.run_powershell", return_value=output):
+            return network._check_llmnr()
+
+    def test_notset_is_warn(self):
+        results = self._run("NOTSET")
+        assert results[0].status == Status.WARN
+
+    def test_value_1_is_warn(self):
+        results = self._run("1")
+        assert results[0].status == Status.WARN
+        assert results[0].severity == Severity.MEDIUM
+
+    def test_value_0_is_pass(self):
+        results = self._run("0")
+        assert results[0].status == Status.PASS
+
+    def test_warn_mentions_responder(self):
+        results = self._run("NOTSET")
+        assert "Responder" in results[0].details
+
+    def test_error_returns_error(self):
+        with patch("winposture.checks.network.run_powershell",
+                   side_effect=WinPostureError("denied")):
+            results = network._check_llmnr()
+        assert results[0].status == Status.ERROR
+
+
+# ---------------------------------------------------------------------------
+# _check_netbios
+# ---------------------------------------------------------------------------
+
+class TestCheckNetbios:
+    def _run(self, data):
+        with patch("winposture.checks.network.run_powershell_json", return_value=data):
+            return network._check_netbios()
+
+    def test_all_disabled_is_pass(self):
+        results = self._run([2, 2])
+        assert results[0].status == Status.PASS
+
+    def test_explicit_enabled_is_warn_medium(self):
+        results = self._run([1, 2])
+        r = results[0]
+        assert r.status == Status.WARN
+        assert r.severity == Severity.MEDIUM
+
+    def test_dhcp_only_is_warn_low(self):
+        results = self._run([0, 0])
+        r = results[0]
+        assert r.status == Status.WARN
+        assert r.severity == Severity.LOW
+
+    def test_empty_is_info(self):
+        results = self._run([])
+        assert results[0].status == Status.INFO
+
+    def test_invalid_values_skipped(self):
+        results = self._run([None, "bad", 2])
+        assert results[0].status == Status.PASS
+
+    def test_error_returns_error(self):
+        with patch("winposture.checks.network.run_powershell_json",
+                   side_effect=WinPostureError("denied")):
+            results = network._check_netbios()
+        assert results[0].status == Status.ERROR
+
+
+# ---------------------------------------------------------------------------
+# _check_ipv6
+# ---------------------------------------------------------------------------
+
+class TestCheckIpv6:
+    def _run(self, output):
+        with patch("winposture.checks.network.run_powershell", return_value=output):
+            return network._check_ipv6()
+
+    def test_active_adapters_reported(self):
+        results = self._run("3")
+        assert results[0].status == Status.INFO
+        assert "3" in results[0].details
+
+    def test_zero_adapters_reported(self):
+        results = self._run("0")
+        assert "not active" in results[0].details.lower()
+
+    def test_non_digit_output_treated_as_zero(self):
+        results = self._run("n/a")
+        assert results[0].status == Status.INFO
+
+
+# ---------------------------------------------------------------------------
+# run() top-level
+# ---------------------------------------------------------------------------
+
+class TestRun:
+    def test_run_returns_list_of_check_results(self):
+        conns = [_conn(443), _conn(80)]
+        with (
+            patch("winposture.checks.network.run_powershell_json", return_value=conns),
+            patch("winposture.checks.network.run_powershell", side_effect=["0", "0"]),
+        ):
+            results = network.run()
+        assert all(isinstance(r, CheckResult) for r in results)
+        assert len(results) >= 4

--- a/tests/test_checks/test_rdp.py
+++ b/tests/test_checks/test_rdp.py
@@ -1,0 +1,141 @@
+"""Tests for winposture.checks.rdp."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from winposture.checks import rdp
+from winposture.exceptions import WinPostureError
+from winposture.models import CheckResult, Status, Severity
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _data(deny=1, nla=1, port=3389):
+    """Mimic registry data returned by the PowerShell batch call."""
+    return {
+        "fDenyTSConnections": deny,
+        "UserAuthentication": nla,
+        "PortNumber": port,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _check_rdp_enabled
+# ---------------------------------------------------------------------------
+
+class TestCheckRdpEnabled:
+    def test_rdp_disabled_deny_1_is_pass(self):
+        results, enabled = rdp._check_rdp_enabled(_data(deny=1))
+        assert results[0].status == Status.PASS
+        assert enabled is False
+
+    def test_rdp_enabled_deny_0_is_warn(self):
+        results, enabled = rdp._check_rdp_enabled(_data(deny=0))
+        assert results[0].status == Status.WARN
+        assert results[0].severity == Severity.HIGH
+        assert enabled is True
+
+    def test_rdp_enabled_has_remediation(self):
+        results, _ = rdp._check_rdp_enabled(_data(deny=0))
+        assert "fDenyTSConnections" in results[0].remediation
+
+    def test_key_absent_treated_as_disabled(self):
+        results, enabled = rdp._check_rdp_enabled({})
+        assert results[0].status == Status.PASS
+        assert enabled is False
+
+    def test_returns_tuple(self):
+        result = rdp._check_rdp_enabled(_data())
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# _check_rdp_nla
+# ---------------------------------------------------------------------------
+
+class TestCheckRdpNla:
+    def test_nla_required_is_pass(self):
+        r = rdp._check_rdp_nla(_data(nla=1))[0]
+        assert r.status == Status.PASS
+        assert r.severity == Severity.HIGH
+
+    def test_nla_not_required_is_fail(self):
+        r = rdp._check_rdp_nla(_data(nla=0))[0]
+        assert r.status == Status.FAIL
+        assert "brute" in r.details.lower()
+
+    def test_nla_absent_is_warn(self):
+        r = rdp._check_rdp_nla({})[0]
+        assert r.status == Status.WARN
+        assert "UserAuthentication" in r.remediation
+
+    def test_nla_fail_includes_remediation(self):
+        r = rdp._check_rdp_nla(_data(nla=0))[0]
+        assert "UserAuthentication" in r.remediation
+
+
+# ---------------------------------------------------------------------------
+# _check_rdp_port
+# ---------------------------------------------------------------------------
+
+class TestCheckRdpPort:
+    def test_default_port_is_info(self):
+        r = rdp._check_rdp_port(_data(port=3389))[0]
+        assert r.status == Status.INFO
+        assert "default" in r.details.lower()
+
+    def test_non_standard_port_noted(self):
+        r = rdp._check_rdp_port(_data(port=13389))[0]
+        assert r.status == Status.INFO
+        assert "non-standard" in r.details.lower()
+
+    def test_absent_port_defaults_to_3389(self):
+        r = rdp._check_rdp_port({})[0]
+        assert "3389" in r.details
+
+
+# ---------------------------------------------------------------------------
+# run() top-level
+# ---------------------------------------------------------------------------
+
+class TestRun:
+    def test_rdp_disabled_returns_one_result(self):
+        with patch("winposture.checks.rdp.run_powershell_json", return_value=_data(deny=1)):
+            results = rdp.run()
+        assert len(results) == 1
+        assert results[0].status == Status.PASS
+
+    def test_rdp_enabled_returns_three_results(self):
+        with patch("winposture.checks.rdp.run_powershell_json", return_value=_data(deny=0)):
+            results = rdp.run()
+        assert len(results) == 3
+
+    def test_rdp_enabled_nla_off_has_fail(self):
+        with patch("winposture.checks.rdp.run_powershell_json",
+                   return_value=_data(deny=0, nla=0)):
+            results = rdp.run()
+        statuses = {r.check_name: r.status for r in results}
+        assert statuses["RDP Network Level Authentication"] == Status.FAIL
+
+    def test_run_handles_powershell_error(self):
+        with patch("winposture.checks.rdp.run_powershell_json",
+                   side_effect=WinPostureError("timeout")):
+            results = rdp.run()
+        assert results[0].status == Status.ERROR
+
+    def test_run_wraps_list_data(self):
+        with patch("winposture.checks.rdp.run_powershell_json",
+                   return_value=[_data(deny=0)]):
+            results = rdp.run()
+        assert len(results) == 3
+
+    def test_all_results_are_check_results(self):
+        with patch("winposture.checks.rdp.run_powershell_json", return_value=_data(deny=0)):
+            results = rdp.run()
+        assert all(isinstance(r, CheckResult) for r in results)

--- a/tests/test_checks/test_smb.py
+++ b/tests/test_checks/test_smb.py
@@ -1,0 +1,146 @@
+"""Tests for winposture.checks.smb."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from winposture.checks import smb
+from winposture.exceptions import WinPostureError
+from winposture.models import CheckResult, Status, Severity
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+def _data(smb1=False, require_signing=True, enable_signing=True, encrypt=False):
+    """Return a dict mirroring Get-SmbServerConfiguration output."""
+    return {
+        "EnableSMB1Protocol": smb1,
+        "RequireSecuritySignature": require_signing,
+        "EnableSecuritySignature": enable_signing,
+        "EncryptData": encrypt,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _check_smb1
+# ---------------------------------------------------------------------------
+
+class TestCheckSmb1:
+    def _run(self, data):
+        return smb._check_smb1(data)
+
+    def test_smb1_disabled_is_pass(self):
+        r = self._run(_data(smb1=False))[0]
+        assert r.status == Status.PASS
+        assert r.severity == Severity.CRITICAL
+
+    def test_smb1_enabled_is_fail(self):
+        r = self._run(_data(smb1=True))[0]
+        assert r.status == Status.FAIL
+        assert r.severity == Severity.CRITICAL
+        assert "EternalBlue" in r.description
+
+    def test_smb1_enabled_has_remediation(self):
+        r = self._run(_data(smb1=True))[0]
+        assert "Set-SmbServerConfiguration" in r.remediation
+
+    def test_null_value_is_warn(self):
+        r = smb._check_smb1({"EnableSMB1Protocol": None})[0]
+        assert r.status == Status.WARN
+
+    def test_check_name(self):
+        r = self._run(_data())[0]
+        assert r.check_name == "SMBv1 Disabled"
+
+
+# ---------------------------------------------------------------------------
+# _check_smb_signing
+# ---------------------------------------------------------------------------
+
+class TestCheckSmbSigning:
+    def _run(self, data):
+        return smb._check_smb_signing(data)
+
+    def test_required_is_pass(self):
+        r = self._run(_data(require_signing=True))[0]
+        assert r.status == Status.PASS
+
+    def test_enabled_not_required_is_warn(self):
+        r = self._run(_data(require_signing=False, enable_signing=True))[0]
+        assert r.status == Status.WARN
+        assert r.severity == Severity.HIGH
+
+    def test_neither_enabled_nor_required_is_fail(self):
+        r = self._run(_data(require_signing=False, enable_signing=False))[0]
+        assert r.status == Status.FAIL
+        assert r.severity == Severity.HIGH
+
+    def test_fail_has_both_commands_in_remediation(self):
+        r = self._run(_data(require_signing=False, enable_signing=False))[0]
+        assert "EnableSecuritySignature" in r.remediation
+        assert "RequireSecuritySignature" in r.remediation
+
+    def test_null_required_is_warn(self):
+        r = smb._check_smb_signing({"RequireSecuritySignature": None})[0]
+        assert r.status == Status.WARN
+
+
+# ---------------------------------------------------------------------------
+# _check_smb_encryption
+# ---------------------------------------------------------------------------
+
+class TestCheckSmbEncryption:
+    def _run(self, data):
+        return smb._check_smb_encryption(data)
+
+    def test_encryption_enabled_is_pass(self):
+        r = self._run(_data(encrypt=True))[0]
+        assert r.status == Status.PASS
+
+    def test_encryption_disabled_is_info(self):
+        r = self._run(_data(encrypt=False))[0]
+        assert r.status == Status.INFO
+
+    def test_encryption_disabled_has_remediation(self):
+        r = self._run(_data(encrypt=False))[0]
+        assert "Set-SmbServerConfiguration" in r.remediation
+
+    def test_null_value_is_info(self):
+        r = smb._check_smb_encryption({"EncryptData": None})[0]
+        assert r.status == Status.INFO
+
+
+# ---------------------------------------------------------------------------
+# run() top-level
+# ---------------------------------------------------------------------------
+
+class TestRun:
+    def test_run_returns_three_results_on_good_config(self):
+        good = _data(smb1=False, require_signing=True, enable_signing=True, encrypt=True)
+        with patch("winposture.checks.smb.run_powershell_json", return_value=good):
+            results = smb.run()
+        assert len(results) == 3
+        assert all(isinstance(r, CheckResult) for r in results)
+
+    def test_run_returns_all_passes_on_good_config(self):
+        good = _data(smb1=False, require_signing=True, enable_signing=True, encrypt=True)
+        with patch("winposture.checks.smb.run_powershell_json", return_value=good):
+            results = smb.run()
+        non_pass = [r for r in results if r.status not in (Status.PASS, Status.INFO)]
+        assert non_pass == []
+
+    def test_run_handles_powershell_error(self):
+        with patch("winposture.checks.smb.run_powershell_json",
+                   side_effect=WinPostureError("boom")):
+            results = smb.run()
+        assert results[0].status == Status.ERROR
+
+    def test_run_wraps_list_data(self):
+        good = [_data()]
+        with patch("winposture.checks.smb.run_powershell_json", return_value=good):
+            results = smb.run()
+        assert len(results) == 3

--- a/tests/test_checks/test_uac.py
+++ b/tests/test_checks/test_uac.py
@@ -1,0 +1,168 @@
+"""Tests for winposture.checks.uac."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from winposture.checks import uac
+from winposture.exceptions import WinPostureError
+from winposture.models import CheckResult, Status, Severity
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _data(lua=1, admin_behavior=5, user_behavior=3, secure_desktop=1, virt=1):
+    """Return a dict mirroring the UAC registry values PowerShell call."""
+    return {
+        "EnableLUA": lua,
+        "ConsentPromptBehaviorAdmin": admin_behavior,
+        "ConsentPromptBehaviorUser": user_behavior,
+        "PromptOnSecureDesktop": secure_desktop,
+        "EnableVirtualization": virt,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _check_uac_enabled
+# ---------------------------------------------------------------------------
+
+class TestCheckUacEnabled:
+    def test_uac_enabled_is_pass(self):
+        r = uac._check_uac_enabled(_data(lua=1))[0]
+        assert r.status == Status.PASS
+        assert r.severity == Severity.CRITICAL
+
+    def test_uac_disabled_is_fail(self):
+        r = uac._check_uac_enabled(_data(lua=0))[0]
+        assert r.status == Status.FAIL
+        assert r.severity == Severity.CRITICAL
+        assert "EnableLUA" in r.remediation
+
+    def test_uac_absent_is_warn(self):
+        r = uac._check_uac_enabled({})[0]
+        assert r.status == Status.WARN
+
+    def test_uac_enabled_no_remediation(self):
+        r = uac._check_uac_enabled(_data(lua=1))[0]
+        assert r.remediation == ""
+
+
+# ---------------------------------------------------------------------------
+# _check_admin_behavior
+# ---------------------------------------------------------------------------
+
+class TestCheckAdminBehavior:
+    def test_level_0_silent_is_warn(self):
+        r = uac._check_admin_behavior(_data(admin_behavior=0))[0]
+        assert r.status == Status.WARN
+        assert r.severity == Severity.HIGH
+        assert "silent" in r.details.lower()
+
+    def test_level_2_secure_desktop_is_pass(self):
+        r = uac._check_admin_behavior(_data(admin_behavior=2))[0]
+        assert r.status == Status.PASS
+
+    def test_level_5_default_is_pass(self):
+        r = uac._check_admin_behavior(_data(admin_behavior=5))[0]
+        assert r.status == Status.PASS
+
+    def test_absent_key_is_info(self):
+        r = uac._check_admin_behavior({})[0]
+        assert r.status == Status.INFO
+        assert "default" in r.details.lower()
+
+    def test_warn_has_remediation(self):
+        r = uac._check_admin_behavior(_data(admin_behavior=0))[0]
+        assert "ConsentPromptBehaviorAdmin" in r.remediation
+
+    def test_level_description_in_details(self):
+        r = uac._check_admin_behavior(_data(admin_behavior=2))[0]
+        assert "2" in r.details
+
+
+# ---------------------------------------------------------------------------
+# _check_secure_desktop
+# ---------------------------------------------------------------------------
+
+class TestCheckSecureDesktop:
+    def test_secure_desktop_on_is_pass(self):
+        r = uac._check_secure_desktop(_data(secure_desktop=1))[0]
+        assert r.status == Status.PASS
+
+    def test_secure_desktop_off_is_warn(self):
+        r = uac._check_secure_desktop(_data(secure_desktop=0))[0]
+        assert r.status == Status.WARN
+        assert r.severity == Severity.MEDIUM
+        assert "spoof" in r.details.lower()
+
+    def test_absent_key_is_info(self):
+        r = uac._check_secure_desktop({})[0]
+        assert r.status == Status.INFO
+
+    def test_off_has_remediation(self):
+        r = uac._check_secure_desktop(_data(secure_desktop=0))[0]
+        assert "PromptOnSecureDesktop" in r.remediation
+
+
+# ---------------------------------------------------------------------------
+# _check_user_behavior
+# ---------------------------------------------------------------------------
+
+class TestCheckUserBehavior:
+    def test_level_3_default_is_info(self):
+        r = uac._check_user_behavior(_data(user_behavior=3))[0]
+        assert r.status == Status.INFO
+        assert r.severity == Severity.LOW
+
+    def test_level_0_deny_all_is_info(self):
+        r = uac._check_user_behavior(_data(user_behavior=0))[0]
+        assert r.status == Status.INFO
+
+    def test_absent_key_is_info(self):
+        r = uac._check_user_behavior({})[0]
+        assert r.status == Status.INFO
+
+    def test_unknown_value_shown_in_details(self):
+        r = uac._check_user_behavior(_data(user_behavior=99))[0]
+        assert "99" in r.details
+
+
+# ---------------------------------------------------------------------------
+# run() top-level
+# ---------------------------------------------------------------------------
+
+class TestRun:
+    def test_run_returns_four_results_on_normal_config(self):
+        with patch("winposture.checks.uac.run_powershell_json", return_value=_data()):
+            results = uac.run()
+        assert len(results) == 4
+        assert all(isinstance(r, CheckResult) for r in results)
+
+    def test_run_returns_all_non_fail_on_good_config(self):
+        with patch("winposture.checks.uac.run_powershell_json", return_value=_data()):
+            results = uac.run()
+        fail_results = [r for r in results if r.status == Status.FAIL]
+        assert fail_results == []
+
+    def test_run_handles_powershell_error(self):
+        with patch("winposture.checks.uac.run_powershell_json",
+                   side_effect=WinPostureError("access denied")):
+            results = uac.run()
+        assert len(results) == 1
+        assert results[0].status == Status.ERROR
+
+    def test_run_wraps_list_data(self):
+        with patch("winposture.checks.uac.run_powershell_json", return_value=[_data()]):
+            results = uac.run()
+        assert len(results) == 4
+
+    def test_uac_disabled_scan_includes_fail(self):
+        with patch("winposture.checks.uac.run_powershell_json",
+                   return_value=_data(lua=0)):
+            results = uac.run()
+        statuses = {r.check_name: r.status for r in results}
+        assert statuses["UAC Enabled"] == Status.FAIL


### PR DESCRIPTION
## Summary

- **accounts.py**: guest account, built-in admin, admin count, password length/lockout/complexity
- **network.py**: risky listening ports (Telnet/FTP/TFTP/RDP), LLMNR, NetBIOS, IPv6 status
- **smb.py**: SMBv1 disabled, signing required, SMB 3.0+ encryption
- **rdp.py**: enabled/disabled, NLA enforcement, port reporting
- **uac.py**: EnableLUA, admin consent behavior, secure desktop, user behavior
- Remove duplicate LLMNR stub from `misc.py` (now in `network.py`)
- Add 218 new unit tests — 296 total, 0 failures

## Test plan
- [x] `python -m pytest tests/ -q` — 296 passed, 0 failed
- [x] `python -m winposture` smoke test — all 10 categories render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)