### PR TITLE
feat: implement remaining checks and scoring engine

### DIFF
--- a/src/winposture/checks/misc.py
+++ b/src/winposture/checks/misc.py
@@ -1,40 +1,417 @@
-"""Check: Miscellaneous settings — AutoPlay, Remote Registry."""
+"""Check: Miscellaneous hardening — AutoPlay, WinRM, Spectre mitigations, audit policy, screen lock."""
 
 from __future__ import annotations
 
 import logging
 
+from winposture.exceptions import WinPostureError
 from winposture.models import CheckResult, Severity, Status
+from winposture.utils import run_powershell, run_powershell_json
 
 log = logging.getLogger(__name__)
 
-CATEGORY = "Misc"
+CATEGORY = "Hardening"
+
+# ---------------------------------------------------------------------------
+# PowerShell snippets
+# ---------------------------------------------------------------------------
+
+_AUTOPLAY_KEY = "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer"
+_PS_AUTOPLAY = (
+    f"$v = (Get-ItemProperty -LiteralPath '{_AUTOPLAY_KEY}' "
+    "-ErrorAction SilentlyContinue).NoDriveTypeAutoRun; "
+    "if ($null -eq $v) { 'NOTSET' } else { [string]$v }"
+)
+
+_PS_WINRM = "(Get-Service -Name WinRM -ErrorAction SilentlyContinue).Status"
+
+_SPECTRE_KEY = (
+    "HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Memory Management"
+)
+_PS_SPECTRE = (
+    f"$k = Get-ItemProperty -LiteralPath '{_SPECTRE_KEY}' -ErrorAction SilentlyContinue; "
+    "@{ Override=$k.FeatureSettingsOverride; Mask=$k.FeatureSettingsOverrideMask } "
+    "| ConvertTo-Json -Compress"
+)
+
+# auditpol CSV: filter to key subcategories we care about
+_PS_AUDIT = (
+    "try { "
+    "auditpol /get /category:* /r "
+    "| ConvertFrom-Csv "
+    "| Where-Object { "
+    "    $_.'Subcategory' -in @('Logon','Account Lockout','Logoff','Credential Validation','Sensitive Privilege Use') "
+    "} "
+    "| Select-Object Subcategory,'Inclusion Setting' "
+    "| ConvertTo-Json -Compress "
+    "} catch { '[]' }"
+)
+
+_SCREEN_KEY = "HKCU:\\Control Panel\\Desktop"
+_PS_SCREEN = (
+    f"$d = Get-ItemProperty -LiteralPath '{_SCREEN_KEY}' -ErrorAction SilentlyContinue; "
+    "@{ "
+    "Active=$d.ScreenSaveActive; "
+    "Secure=$d.ScreenSaverIsSecure; "
+    "Timeout=$d.ScreenSaveTimeOut "
+    "} | ConvertTo-Json -Compress"
+)
+
+# Screen-lock threshold: warn if > 15 minutes (900 seconds)
+_LOCK_WARN_SECS = 900
 
 
 def run() -> list[CheckResult]:
-    """Return miscellaneous security configuration checks.
+    """Return miscellaneous hardening checks.
 
     Returns:
-        list[CheckResult]: Results for AutoPlay and Remote Registry.
-"""
-    # TODO: implement via registry reads and service status checks
-    return [
-        CheckResult(
+        list[CheckResult]: Results for AutoPlay, WinRM, Spectre mitigations,
+        audit policy, and screen-lock timeout.
+    """
+    results: list[CheckResult] = []
+    results.extend(_check_autoplay())
+    results.extend(_check_winrm())
+    results.extend(_check_spectre())
+    results.extend(_check_audit_policy())
+    results.extend(_check_screen_lock())
+    return results
+
+
+def _check_autoplay() -> list[CheckResult]:
+    """Check whether AutoPlay/AutoRun is disabled for all drive types."""
+    try:
+        output = run_powershell(_PS_AUTOPLAY).strip()
+    except WinPostureError as exc:
+        return [_error("AutoPlay Disabled", str(exc))]
+
+    # NoDriveTypeAutoRun = 255 (0xFF) disables AutoPlay for all drive types.
+    # Common value 91 (0x5B) disables most but not network drives.
+    if output == "NOTSET":
+        return [CheckResult(
             category=CATEGORY,
             check_name="AutoPlay Disabled",
-            status=Status.INFO,
+            status=Status.WARN,
             severity=Severity.MEDIUM,
             description="Checks whether AutoPlay is disabled for all drive types.",
-            details="Not yet implemented.",
-            remediation="",
-        ),
-        CheckResult(
+            details=(
+                "NoDriveTypeAutoRun policy is not set — AutoPlay is enabled by default. "
+                "AutoPlay can be abused to auto-execute malicious content from USB drives."
+            ),
+            remediation=(
+                "Disable AutoPlay via Group Policy: Computer Configuration → Administrative "
+                "Templates → Windows Components → AutoPlay Policies → Turn off AutoPlay → Enabled. "
+                "Or via registry: Set-ItemProperty -Path "
+                f"'{_AUTOPLAY_KEY}' -Name NoDriveTypeAutoRun -Value 255 -Type DWord -Force"
+            ),
+        )]
+
+    try:
+        val = int(output)
+    except ValueError:
+        val = -1
+
+    # 0xFF = 255 disables all drive types; any non-zero typically disables most
+    fully_disabled = val == 255
+    partially_disabled = 0 < val < 255
+
+    if fully_disabled:
+        return [CheckResult(
             category=CATEGORY,
-            check_name="Remote Registry Service Disabled",
-            status=Status.INFO,
-            severity=Severity.HIGH,
-            description="Checks whether the Remote Registry service is stopped and disabled.",
-            details="Not yet implemented.",
+            check_name="AutoPlay Disabled",
+            status=Status.PASS,
+            severity=Severity.MEDIUM,
+            description="Checks whether AutoPlay is disabled for all drive types.",
+            details=f"AutoPlay is fully disabled (NoDriveTypeAutoRun = {val}).",
             remediation="",
+        )]
+
+    if partially_disabled:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="AutoPlay Disabled",
+            status=Status.WARN,
+            severity=Severity.MEDIUM,
+            description="Checks whether AutoPlay is disabled for all drive types.",
+            details=(
+                f"AutoPlay is partially disabled (NoDriveTypeAutoRun = {val}). "
+                "Some drive types may still trigger AutoPlay."
+            ),
+            remediation=(
+                "Set NoDriveTypeAutoRun to 255 to disable AutoPlay for all drive types: "
+                f"Set-ItemProperty -Path '{_AUTOPLAY_KEY}' "
+                "-Name NoDriveTypeAutoRun -Value 255 -Type DWord -Force"
+            ),
+        )]
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="AutoPlay Disabled",
+        status=Status.WARN,
+        severity=Severity.MEDIUM,
+        description="Checks whether AutoPlay is disabled for all drive types.",
+        details=f"AutoPlay may be enabled (NoDriveTypeAutoRun = {val}).",
+        remediation=(
+            f"Set-ItemProperty -Path '{_AUTOPLAY_KEY}' "
+            "-Name NoDriveTypeAutoRun -Value 255 -Type DWord -Force"
         ),
-    ]
+    )]
+
+
+def _check_winrm() -> list[CheckResult]:
+    """Check whether Windows Remote Management (WinRM) service is running."""
+    try:
+        output = run_powershell(_PS_WINRM).strip()
+    except WinPostureError as exc:
+        return [_error("WinRM Status", str(exc))]
+
+    if not output:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="WinRM Status",
+            status=Status.INFO,
+            severity=Severity.MEDIUM,
+            description="Checks whether the Windows Remote Management (WinRM) service is running.",
+            details="WinRM service not found.",
+            remediation="",
+        )]
+
+    running = output.lower() == "running"
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="WinRM Status",
+        status=Status.WARN if running else Status.PASS,
+        severity=Severity.MEDIUM,
+        description="Checks whether the Windows Remote Management (WinRM) service is running.",
+        details=(
+            "WinRM is running — PowerShell remoting is enabled. "
+            "Ensure access is restricted by firewall rules and requires authentication."
+            if running else
+            "WinRM service is not running."
+        ),
+        remediation=(
+            "" if not running else
+            "If remote management is not required, stop and disable WinRM: "
+            "Stop-Service WinRM; Set-Service WinRM -StartupType Disabled. "
+            "If required, restrict access: "
+            "Set-Item WSMan:\\localhost\\Service\\Auth\\Basic -Value $false"
+        ),
+    )]
+
+
+def _check_spectre() -> list[CheckResult]:
+    """Check for explicit disabling of speculative-execution mitigations."""
+    try:
+        data = run_powershell_json(_PS_SPECTRE)
+    except WinPostureError as exc:
+        return [_error("Speculative Execution Mitigations", str(exc))]
+
+    if isinstance(data, list):
+        data = data[0] if data else {}
+
+    override = data.get("Override")
+    mask = data.get("Mask")
+
+    if override is None:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="Speculative Execution Mitigations",
+            status=Status.INFO,
+            severity=Severity.MEDIUM,
+            description="Checks whether Spectre/Meltdown mitigations have been explicitly disabled.",
+            details=(
+                "No FeatureSettingsOverride registry key found — "
+                "Windows default mitigations apply (recommended)."
+            ),
+            remediation="",
+        )]
+
+    # FeatureSettingsOverride bit 0 disables Spectre V2, bit 1 disables Meltdown (KPTI).
+    # Both set (value & 3 == 3) with mask = 3 means mitigations are explicitly disabled.
+    try:
+        override_int = int(override)
+        mask_int = int(mask) if mask is not None else 0
+    except (TypeError, ValueError):
+        override_int, mask_int = -1, -1
+
+    mitigations_disabled = (override_int & 3) == 3 and mask_int == 3
+
+    if mitigations_disabled:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="Speculative Execution Mitigations",
+            status=Status.WARN,
+            severity=Severity.MEDIUM,
+            description="Checks whether Spectre/Meltdown mitigations have been explicitly disabled.",
+            details=(
+                f"Speculative execution mitigations appear disabled "
+                f"(FeatureSettingsOverride={override_int}, Mask={mask_int}). "
+                "This improves CPU performance but removes Spectre/Meltdown protections."
+            ),
+            remediation=(
+                "Re-enable mitigations by removing the override registry keys: "
+                f"Remove-ItemProperty -Path '{_SPECTRE_KEY}' "
+                "-Name FeatureSettingsOverride,FeatureSettingsOverrideMask -ErrorAction SilentlyContinue"
+            ),
+        )]
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="Speculative Execution Mitigations",
+        status=Status.INFO,
+        severity=Severity.MEDIUM,
+        description="Checks whether Spectre/Meltdown mitigations have been explicitly disabled.",
+        details=(
+            f"Speculative execution mitigation override present "
+            f"(FeatureSettingsOverride={override_int}, Mask={mask_int}). "
+            "Mitigations do not appear to be fully disabled."
+        ),
+        remediation="",
+    )]
+
+
+def _check_audit_policy() -> list[CheckResult]:
+    """Check that key audit policy subcategories are logging Success and/or Failure."""
+    try:
+        data = run_powershell_json(_PS_AUDIT)
+    except WinPostureError as exc:
+        return [_error("Audit Policy", str(exc))]
+
+    entries = data if isinstance(data, list) else ([data] if data else [])
+
+    if not entries:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="Audit Policy",
+            status=Status.WARN,
+            severity=Severity.MEDIUM,
+            description="Checks that key audit policy subcategories log Success/Failure events.",
+            details=(
+                "Could not retrieve audit policy (auditpol may require elevation). "
+                "Key events like logon failures may not be recorded."
+            ),
+            remediation="Run WinPosture as Administrator to check audit policy.",
+        )]
+
+    # Build subcategory → inclusion setting map
+    audit_map: dict[str, str] = {}
+    for entry in entries:
+        name = str(entry.get("Subcategory") or "").strip()
+        setting = str(entry.get("Inclusion Setting") or "No Auditing").strip()
+        if name:
+            audit_map[name] = setting
+
+    no_audit = [name for name, setting in audit_map.items() if setting == "No Auditing"]
+
+    if no_audit:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="Audit Policy",
+            status=Status.WARN,
+            severity=Severity.MEDIUM,
+            description="Checks that key audit policy subcategories log Success/Failure events.",
+            details=(
+                f"The following subcategories have auditing disabled: "
+                f"{', '.join(no_audit)}. "
+                "Security-relevant events may not be recorded."
+            ),
+            remediation=(
+                "Enable audit logging for key subcategories via Group Policy or auditpol: "
+                "auditpol /set /subcategory:'Logon' /success:enable /failure:enable. "
+                "Review: secpol.msc → Advanced Audit Policy Configuration."
+            ),
+        )]
+
+    checked = ", ".join(audit_map.keys()) if audit_map else "none found"
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="Audit Policy",
+        status=Status.PASS,
+        severity=Severity.MEDIUM,
+        description="Checks that key audit policy subcategories log Success/Failure events.",
+        details=f"Auditing is configured for checked subcategories: {checked}.",
+        remediation="",
+    )]
+
+
+def _check_screen_lock() -> list[CheckResult]:
+    """Check that the screen-lock / screensaver timeout is configured."""
+    try:
+        data = run_powershell_json(_PS_SCREEN)
+    except WinPostureError as exc:
+        return [_error("Screen Lock Timeout", str(exc))]
+
+    if isinstance(data, list):
+        data = data[0] if data else {}
+
+    active = str(data.get("Active") or "0").strip()
+    secure = str(data.get("Secure") or "0").strip()
+    timeout_raw = data.get("Timeout")
+
+    screensaver_active = active == "1"
+    password_on_resume = secure == "1"
+
+    if not screensaver_active:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="Screen Lock Timeout",
+            status=Status.WARN,
+            severity=Severity.MEDIUM,
+            description=f"Checks that the screen automatically locks within {_LOCK_WARN_SECS // 60} minutes.",
+            details=(
+                "Screensaver is not enabled — the screen will not lock automatically on inactivity."
+            ),
+            remediation=(
+                "Enable the screensaver with password protection via: "
+                "Settings → Personalization → Screen saver → "
+                "set a timeout and check 'On resume, display logon screen'."
+            ),
+        )]
+
+    try:
+        timeout_secs = int(timeout_raw) if timeout_raw is not None else 0
+    except (TypeError, ValueError):
+        timeout_secs = 0
+
+    if timeout_secs == 0:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="Screen Lock Timeout",
+            status=Status.WARN,
+            severity=Severity.MEDIUM,
+            description=f"Checks that the screen automatically locks within {_LOCK_WARN_SECS // 60} minutes.",
+            details="Screensaver is enabled but timeout is 0 or unset.",
+            remediation="Set a screen-lock timeout of 15 minutes or less.",
+        )]
+
+    too_long = timeout_secs > _LOCK_WARN_SECS
+    mins = timeout_secs // 60
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="Screen Lock Timeout",
+        status=Status.WARN if (too_long or not password_on_resume) else Status.PASS,
+        severity=Severity.MEDIUM,
+        description=f"Checks that the screen automatically locks within {_LOCK_WARN_SECS // 60} minutes.",
+        details=(
+            f"Screen lock timeout: {mins} minute(s)"
+            + (" (exceeds 15-minute recommended maximum)." if too_long else ".")
+            + ("" if password_on_resume else " Password on resume is NOT enabled.")
+        ),
+        remediation=(
+            "" if (not too_long and password_on_resume) else
+            "Set timeout ≤ 15 minutes and enable 'On resume, display logon screen'."
+        ),
+    )]
+
+
+def _error(check_name: str, details: str) -> CheckResult:
+    return CheckResult(
+        category=CATEGORY,
+        check_name=check_name,
+        status=Status.ERROR,
+        severity=Severity.INFO,
+        description="An error occurred while running this check.",
+        details=details,
+        remediation="Run with --log-level DEBUG for more detail.",
+    )

--- a/src/winposture/checks/powershell.py
+++ b/src/winposture/checks/powershell.py
@@ -1,49 +1,228 @@
-"""Check: PowerShell execution policy, script block logging, and constrained mode."""
+"""Check: PowerShell security — execution policy, logging, constrained mode, PSv2."""
 
 from __future__ import annotations
 
 import logging
 
+from winposture.exceptions import WinPostureError
 from winposture.models import CheckResult, Severity, Status
+from winposture.utils import run_powershell
 
 log = logging.getLogger(__name__)
 
 CATEGORY = "PowerShell"
+
+# Policies that bypass script execution restrictions entirely
+_RISKY_POLICIES = {"unrestricted", "bypass"}
+
+_PS_EXEC_POLICY = "Get-ExecutionPolicy -Scope LocalMachine"
+
+_SBL_KEY = "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\PowerShell\\ScriptBlockLogging"
+_PS_SBL = (
+    f"$v = (Get-ItemProperty -LiteralPath '{_SBL_KEY}' "
+    "-ErrorAction SilentlyContinue).EnableScriptBlockLogging; "
+    "if ($null -eq $v) { 'NOTSET' } else { [string]$v }"
+)
+
+_ML_KEY = "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\PowerShell\\ModuleLogging"
+_PS_ML = (
+    f"$v = (Get-ItemProperty -LiteralPath '{_ML_KEY}' "
+    "-ErrorAction SilentlyContinue).EnableModuleLogging; "
+    "if ($null -eq $v) { 'NOTSET' } else { [string]$v }"
+)
+
+_PS_CLM = "$ExecutionContext.SessionState.LanguageMode"
+
+_PS_V2 = (
+    "try { "
+    "(Get-WindowsOptionalFeature -Online -FeatureName MicrosoftWindowsPowerShellV2Root "
+    "-ErrorAction SilentlyContinue).State "
+    "} catch { 'UNAVAILABLE' }"
+)
 
 
 def run() -> list[CheckResult]:
     """Return PowerShell security configuration checks.
 
     Returns:
-        list[CheckResult]: Results for execution policy, logging, and constrained mode.
+        list[CheckResult]: Results for execution policy, script block logging,
+        module logging, constrained language mode, and PSv2 availability.
     """
-    # TODO: implement via Get-ExecutionPolicy and registry checks
-    return [
-        CheckResult(
+    results: list[CheckResult] = []
+    results.extend(_check_execution_policy())
+    results.extend(_check_script_block_logging())
+    results.extend(_check_module_logging())
+    results.extend(_check_constrained_language())
+    results.extend(_check_psv2())
+    return results
+
+
+def _check_execution_policy() -> list[CheckResult]:
+    """Check the LocalMachine PowerShell execution policy."""
+    try:
+        output = run_powershell(_PS_EXEC_POLICY).strip()
+    except WinPostureError as exc:
+        return [_error("PowerShell Execution Policy", str(exc))]
+
+    policy = output.lower()
+    risky = policy in _RISKY_POLICIES
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="PowerShell Execution Policy",
+        status=Status.WARN if risky else Status.INFO,
+        severity=Severity.MEDIUM,
+        description="Checks the LocalMachine PowerShell execution policy.",
+        details=(
+            f"Execution policy is '{output}' — allows any script to run without restriction."
+            if risky else
+            f"Execution policy is '{output}'."
+        ),
+        remediation=(
+            "" if not risky else
+            f"Set a more restrictive policy: Set-ExecutionPolicy RemoteSigned -Scope LocalMachine. "
+            f"Current policy '{output}' allows unsigned scripts to run freely."
+        ),
+    )]
+
+
+def _check_script_block_logging() -> list[CheckResult]:
+    """Check whether PowerShell Script Block Logging is enabled."""
+    try:
+        output = run_powershell(_PS_SBL).strip()
+    except WinPostureError as exc:
+        return [_error("PowerShell Script Block Logging", str(exc))]
+
+    enabled = output == "1"
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="PowerShell Script Block Logging",
+        status=Status.PASS if enabled else Status.WARN,
+        severity=Severity.MEDIUM,
+        description="Checks whether PowerShell Script Block Logging is enabled (critical for forensics/IR).",
+        details=(
+            "Script Block Logging is enabled — PowerShell commands are logged to the event log."
+            if enabled else
+            "Script Block Logging is disabled. Malicious PowerShell activity may go undetected."
+        ),
+        remediation=(
+            "" if enabled else
+            "Enable via Group Policy: Computer Configuration → Administrative Templates → "
+            "Windows Components → Windows PowerShell → Turn on PowerShell Script Block Logging. "
+            "Or via registry: Set-ItemProperty -Path "
+            f"'{_SBL_KEY}' -Name EnableScriptBlockLogging -Value 1 -Type DWord -Force"
+        ),
+    )]
+
+
+def _check_module_logging() -> list[CheckResult]:
+    """Check whether PowerShell Module Logging is enabled."""
+    try:
+        output = run_powershell(_PS_ML).strip()
+    except WinPostureError as exc:
+        return [_error("PowerShell Module Logging", str(exc))]
+
+    enabled = output == "1"
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="PowerShell Module Logging",
+        status=Status.PASS if enabled else Status.WARN,
+        severity=Severity.MEDIUM,
+        description="Checks whether PowerShell Module Logging is enabled.",
+        details=(
+            "Module Logging is enabled — module pipeline execution events are logged."
+            if enabled else
+            "Module Logging is disabled. Detailed module activity is not recorded."
+        ),
+        remediation=(
+            "" if enabled else
+            "Enable via Group Policy: Computer Configuration → Administrative Templates → "
+            "Windows Components → Windows PowerShell → Turn on Module Logging. "
+            "Or via registry: Set-ItemProperty -Path "
+            f"'{_ML_KEY}' -Name EnableModuleLogging -Value 1 -Type DWord -Force"
+        ),
+    )]
+
+
+def _check_constrained_language() -> list[CheckResult]:
+    """Report the current PowerShell language mode (informational)."""
+    try:
+        output = run_powershell(_PS_CLM).strip()
+    except WinPostureError as exc:
+        return [_error("PowerShell Constrained Language Mode", str(exc))]
+
+    is_constrained = output.lower() == "constrainedlanguage"
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="PowerShell Constrained Language Mode",
+        status=Status.PASS if is_constrained else Status.INFO,
+        severity=Severity.LOW,
+        description="Checks whether PowerShell Constrained Language Mode is active.",
+        details=f"PowerShell language mode: {output}.",
+        remediation="",
+    )]
+
+
+def _check_psv2() -> list[CheckResult]:
+    """Check whether PowerShell v2 is installed (downgrade attack vector)."""
+    try:
+        output = run_powershell(_PS_V2).strip()
+    except WinPostureError as exc:
+        return [_error("PowerShell v2", str(exc))]
+
+    state = output.lower()
+
+    # Enabled / EnabledWithPayloadRemoved both mean v2 engine is present
+    if state in ("enabled", "enabledwithpayloadremoved"):
+        return [CheckResult(
             category=CATEGORY,
-            check_name="PowerShell Execution Policy",
-            status=Status.INFO,
+            check_name="PowerShell v2",
+            status=Status.WARN,
             severity=Severity.MEDIUM,
-            description="Checks the effective PowerShell execution policy.",
-            details="Not yet implemented.",
-            remediation="",
-        ),
-        CheckResult(
+            description="Checks whether PowerShell v2 is installed (downgrade attack vector).",
+            details=(
+                "PowerShell v2 is installed. Attackers can invoke 'powershell -Version 2' "
+                "to bypass Script Block Logging and other v5+ security controls."
+            ),
+            remediation=(
+                "Remove PowerShell v2: "
+                "Disable-WindowsOptionalFeature -Online -FeatureName MicrosoftWindowsPowerShellV2Root"
+            ),
+        )]
+
+    if state in ("disabled", "unavailable"):
+        return [CheckResult(
             category=CATEGORY,
-            check_name="PowerShell Script Block Logging",
-            status=Status.INFO,
+            check_name="PowerShell v2",
+            status=Status.PASS,
             severity=Severity.MEDIUM,
-            description="Checks whether PowerShell script block logging is enabled.",
-            details="Not yet implemented.",
+            description="Checks whether PowerShell v2 is installed (downgrade attack vector).",
+            details="PowerShell v2 is not installed or disabled.",
             remediation="",
-        ),
-        CheckResult(
-            category=CATEGORY,
-            check_name="PowerShell Constrained Language Mode",
-            status=Status.INFO,
-            severity=Severity.LOW,
-            description="Checks whether PowerShell is running in Constrained Language Mode.",
-            details="Not yet implemented.",
-            remediation="",
-        ),
-    ]
+        )]
+
+    # State could not be determined (e.g. non-Windows or missing module)
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="PowerShell v2",
+        status=Status.INFO,
+        severity=Severity.MEDIUM,
+        description="Checks whether PowerShell v2 is installed (downgrade attack vector).",
+        details=f"Could not determine PowerShell v2 status (state: '{output}').",
+        remediation="",
+    )]
+
+
+def _error(check_name: str, details: str) -> CheckResult:
+    return CheckResult(
+        category=CATEGORY,
+        check_name=check_name,
+        status=Status.ERROR,
+        severity=Severity.INFO,
+        description="An error occurred while running this check.",
+        details=details,
+        remediation="Run with --log-level DEBUG for more detail.",
+    )

--- a/src/winposture/checks/services.py
+++ b/src/winposture/checks/services.py
@@ -1,22 +1,69 @@
-"""Check: Running services, with detection of known-risky services."""
+"""Check: Running services — risky service detection and unquoted path vulnerability."""
 
 from __future__ import annotations
 
 import logging
 
+from winposture.exceptions import WinPostureError
 from winposture.models import CheckResult, Severity, Status
+from winposture.utils import run_powershell_json
 
 log = logging.getLogger(__name__)
 
 CATEGORY = "Services"
 
-# Services that should generally be disabled on hardened systems
-RISKY_SERVICES: dict[str, tuple[Severity, str]] = {
-    "RemoteRegistry": (Severity.HIGH, "Remote Registry allows remote modification of the registry."),
-    "Telnet": (Severity.CRITICAL, "Telnet transmits credentials in plaintext."),
-    "TlntSvr": (Severity.CRITICAL, "Telnet Server — should never be running."),
-    "SNMP": (Severity.MEDIUM, "SNMP (v1/v2) uses community strings instead of strong auth."),
-    "W3SVC": (Severity.LOW, "IIS web server running — verify this is intentional."),
+# Fetch name + display name for all running services.
+_PS_RUNNING = (
+    "Get-Service -ErrorAction SilentlyContinue "
+    "| Where-Object { $_.Status -eq 'Running' } "
+    "| Select-Object Name, DisplayName, @{N='Status';E={$_.Status.ToString()}} "
+    "| ConvertTo-Json -Compress"
+)
+
+# Unquoted service paths: not quoted, not a Windows system path, contain a space
+# before the executable extension — classic privilege-escalation vector.
+_PS_UNQUOTED = (
+    "Get-CimInstance Win32_Service -ErrorAction SilentlyContinue "
+    "| Where-Object { "
+    "    $_.PathName -and "
+    "    $_.PathName.Trim() -notmatch '^\"' -and "
+    "    $_.PathName.Trim() -notmatch '^[A-Za-z]:\\\\Windows\\\\' -and "
+    "    $_.PathName.Trim() -match '^[A-Za-z]:\\\\.+ .+\\.(exe|dll)' "
+    "} "
+    "| Select-Object Name, DisplayName, PathName "
+    "| ConvertTo-Json -Compress"
+)
+
+# Known-risky service names → (status, severity, details, remediation)
+_RISKY: dict[str, tuple[Status, Severity, str, str]] = {
+    "RemoteRegistry": (
+        Status.WARN,
+        Severity.HIGH,
+        "Remote Registry service is running — allows remote modification of the registry.",
+        "Stop and disable Remote Registry: "
+        "Stop-Service RemoteRegistry; Set-Service RemoteRegistry -StartupType Disabled",
+    ),
+    "TlntSvr": (
+        Status.FAIL,
+        Severity.CRITICAL,
+        "Telnet Server is running — all traffic (including credentials) is sent in cleartext.",
+        "Disable Telnet Server immediately: "
+        "Stop-Service TlntSvr; Set-Service TlntSvr -StartupType Disabled",
+    ),
+    "Telnet": (
+        Status.FAIL,
+        Severity.CRITICAL,
+        "Telnet service is running — cleartext credential exposure.",
+        "Disable Telnet: Stop-Service Telnet; Set-Service Telnet -StartupType Disabled",
+    ),
+    "SNMP": (
+        Status.WARN,
+        Severity.MEDIUM,
+        "SNMP service is running. SNMPv1/v2 uses weak community-string authentication.",
+        "Disable SNMP if not required: "
+        "Stop-Service SNMP; Set-Service SNMP -StartupType Disabled. "
+        "If required, restrict access and use SNMPv3.",
+    ),
 }
 
 
@@ -24,17 +71,108 @@ def run() -> list[CheckResult]:
     """Return service security checks.
 
     Returns:
-        list[CheckResult]: One result per risky service detected (or a clean INFO result).
+        list[CheckResult]: Results for risky running services and unquoted service paths.
     """
-    # TODO: implement via Get-Service PowerShell cmdlet
-    return [
-        CheckResult(
+    results: list[CheckResult] = []
+    results.extend(_check_risky_services())
+    results.extend(_check_unquoted_paths())
+    return results
+
+
+def _check_risky_services() -> list[CheckResult]:
+    """Flag known-dangerous services that are currently running."""
+    try:
+        data = run_powershell_json(_PS_RUNNING)
+    except WinPostureError as exc:
+        return [_error("Risky Services", str(exc))]
+
+    services = data if isinstance(data, list) else ([data] if data else [])
+    running_names = {str(s.get("Name", "")).lower(): str(s.get("Name", "")) for s in services}
+
+    results: list[CheckResult] = []
+    for svc_name, (status, severity, details, remediation) in _RISKY.items():
+        if svc_name.lower() in running_names:
+            display = running_names[svc_name.lower()]
+            results.append(CheckResult(
+                category=CATEGORY,
+                check_name=f"Risky Service — {display}",
+                status=status,
+                severity=severity,
+                description=f"Checks whether the {display} service is running.",
+                details=details,
+                remediation=remediation,
+            ))
+
+    if not results:
+        results.append(CheckResult(
             category=CATEGORY,
             check_name="Risky Services",
-            status=Status.INFO,
+            status=Status.PASS,
             severity=Severity.MEDIUM,
-            description="Checks for known-risky services that are running or set to auto-start.",
-            details="Not yet implemented.",
+            description="Checks for known-risky services (Remote Registry, Telnet, SNMP).",
+            details="No known-risky services are running.",
             remediation="",
-        )
-    ]
+        ))
+
+    return results
+
+
+def _check_unquoted_paths() -> list[CheckResult]:
+    """Detect services with unquoted executable paths containing spaces."""
+    try:
+        data = run_powershell_json(_PS_UNQUOTED)
+    except WinPostureError as exc:
+        return [_error("Unquoted Service Paths", str(exc))]
+
+    items = data if isinstance(data, list) else ([data] if data else [])
+
+    if not items:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="Unquoted Service Paths",
+            status=Status.PASS,
+            severity=Severity.HIGH,
+            description=(
+                "Checks for services whose executable path contains spaces but is not quoted "
+                "(privilege-escalation vector)."
+            ),
+            details="No services with unquoted paths containing spaces found.",
+            remediation="",
+        )]
+
+    names = [str(i.get("Name") or "Unknown") for i in items]
+    paths = [str(i.get("PathName") or "") for i in items]
+    detail_lines = "; ".join(f"{n}: {p}" for n, p in zip(names, paths))
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="Unquoted Service Paths",
+        status=Status.FAIL,
+        severity=Severity.HIGH,
+        description=(
+            "Checks for services whose executable path contains spaces but is not quoted "
+            "(privilege-escalation vector)."
+        ),
+        details=(
+            f"{len(items)} service(s) with unquoted paths: {detail_lines}. "
+            "An attacker with write access to a parent directory could place a malicious "
+            "executable that Windows resolves before the intended binary."
+        ),
+        remediation=(
+            "Quote the PathName of each affected service in the registry: "
+            "HKLM:\\SYSTEM\\CurrentControlSet\\Services\\<ServiceName>\\ImagePath. "
+            "Wrap the executable path in double quotes, preserving any arguments."
+        ),
+    )]
+
+
+def _error(check_name: str, details: str) -> CheckResult:
+    return CheckResult(
+        category=CATEGORY,
+        check_name=check_name,
+        status=Status.ERROR,
+        severity=Severity.INFO,
+        description="An error occurred while running this check.",
+        details=details,
+        remediation="Run with --log-level DEBUG for more detail.",
+    )

--- a/src/winposture/checks/startup.py
+++ b/src/winposture/checks/startup.py
@@ -1,40 +1,119 @@
-"""Check: Startup programs and scheduled tasks."""
+"""Check: Startup programs and scheduled tasks (persistence points)."""
 
 from __future__ import annotations
 
 import logging
 
+from winposture.exceptions import WinPostureError
 from winposture.models import CheckResult, Severity, Status
+from winposture.utils import run_powershell_json
 
 log = logging.getLogger(__name__)
 
-CATEGORY = "Startup"
+CATEGORY = "Persistence"
+
+# Win32_StartupCommand covers HKLM/HKCU Run/RunOnce keys and startup folders.
+_PS_STARTUP = (
+    "Get-CimInstance Win32_StartupCommand -ErrorAction SilentlyContinue "
+    "| Select-Object Name, Command, Location, User "
+    "| ConvertTo-Json -Compress"
+)
+
+# Non-Microsoft scheduled tasks that are not disabled.
+_PS_TASKS = (
+    "Get-ScheduledTask -ErrorAction SilentlyContinue "
+    "| Where-Object { "
+    "    $_.TaskPath -notlike '\\Microsoft\\*' -and "
+    "    $_.State -ne 'Disabled' "
+    "} "
+    "| Select-Object TaskName, TaskPath, "
+    "@{N='RunAs';E={$_.Principal.UserId}}, "
+    "@{N='State';E={$_.State.ToString()}} "
+    "| ConvertTo-Json -Compress"
+)
+
+_MAX_DISPLAY = 20
 
 
 def run() -> list[CheckResult]:
-    """Return startup and scheduled task checks.
+    """Return persistence / startup checks.
 
     Returns:
-        list[CheckResult]: Results about auto-start items.
+        list[CheckResult]: Results for startup programs and scheduled tasks.
     """
-    # TODO: implement via Get-CimInstance Win32_StartupCommand and Get-ScheduledTask
-    return [
-        CheckResult(
-            category=CATEGORY,
-            check_name="Startup Programs",
-            status=Status.INFO,
-            severity=Severity.LOW,
-            description="Enumerates programs configured to run at startup.",
-            details="Not yet implemented.",
-            remediation="",
+    results: list[CheckResult] = []
+    results.extend(_check_startup_programs())
+    results.extend(_check_scheduled_tasks())
+    return results
+
+
+def _check_startup_programs() -> list[CheckResult]:
+    """Enumerate startup programs via Win32_StartupCommand."""
+    try:
+        data = run_powershell_json(_PS_STARTUP)
+    except WinPostureError as exc:
+        return [_error("Startup Programs", str(exc))]
+
+    items = data if isinstance(data, list) else ([data] if data else [])
+    count = len(items)
+
+    names = [str(i.get("Name") or "Unknown") for i in items]
+    display = ", ".join(names[:_MAX_DISPLAY])
+    if count > _MAX_DISPLAY:
+        display += f" … (+{count - _MAX_DISPLAY} more)"
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="Startup Programs",
+        status=Status.INFO,
+        severity=Severity.LOW,
+        description="Enumerates programs configured to run at startup (registry Run keys + startup folders).",
+        details=(
+            f"{count} startup program(s): {display}"
+            if count else
+            "No startup programs found via Win32_StartupCommand."
         ),
-        CheckResult(
-            category=CATEGORY,
-            check_name="Scheduled Tasks",
-            status=Status.INFO,
-            severity=Severity.LOW,
-            description="Enumerates non-Microsoft scheduled tasks.",
-            details="Not yet implemented.",
-            remediation="",
+        remediation="",
+    )]
+
+
+def _check_scheduled_tasks() -> list[CheckResult]:
+    """Enumerate non-Microsoft enabled scheduled tasks."""
+    try:
+        data = run_powershell_json(_PS_TASKS)
+    except WinPostureError as exc:
+        return [_error("Scheduled Tasks", str(exc))]
+
+    items = data if isinstance(data, list) else ([data] if data else [])
+    count = len(items)
+
+    names = [str(i.get("TaskName") or "Unknown") for i in items]
+    display = ", ".join(names[:_MAX_DISPLAY])
+    if count > _MAX_DISPLAY:
+        display += f" … (+{count - _MAX_DISPLAY} more)"
+
+    return [CheckResult(
+        category=CATEGORY,
+        check_name="Scheduled Tasks",
+        status=Status.INFO,
+        severity=Severity.LOW,
+        description="Enumerates non-Microsoft scheduled tasks (potential persistence points).",
+        details=(
+            f"{count} non-Microsoft task(s): {display}"
+            if count else
+            "No non-Microsoft scheduled tasks found."
         ),
-    ]
+        remediation="",
+    )]
+
+
+def _error(check_name: str, details: str) -> CheckResult:
+    return CheckResult(
+        category=CATEGORY,
+        check_name=check_name,
+        status=Status.ERROR,
+        severity=Severity.INFO,
+        description="An error occurred while running this check.",
+        details=details,
+        remediation="Run with --log-level DEBUG for more detail.",
+    )

--- a/src/winposture/scoring.py
+++ b/src/winposture/scoring.py
@@ -3,31 +3,58 @@
 Calculates a 0–100 security score from a list of CheckResult objects.
 Scoring model:
   - Start at 100
-  - Deduct per failed/warned check, weighted by severity
+  - Deduct per FAIL/WARN check, weighted by severity
+  - WARN deducts half the corresponding FAIL amount (integer floor)
   - Clamp final score to [0, 100]
+
+Deduction table:
+  Severity   FAIL   WARN
+  CRITICAL    -15    -7
+  HIGH        -10    -5
+  MEDIUM       -5    -2
+  LOW          -2    -1
+  INFO          0     0
+
+Grade thresholds:
+  90-100 → A  Excellent
+  80-89  → B  Good
+  70-79  → C  Fair
+  60-69  → D  Poor
+   0-59  → F  Critical
 """
 
 from __future__ import annotations
 
 import logging
+from collections import defaultdict
 
 from winposture.models import CheckResult, Severity, Status
 
 log = logging.getLogger(__name__)
 
-# Deduction points per (status, severity) combination
+# Deduction points per (status, severity) combination.
+# WARN = floor(FAIL / 2) for each severity level.
 _DEDUCTIONS: dict[tuple[Status, Severity], int] = {
-    (Status.FAIL, Severity.CRITICAL): 20,
-    (Status.FAIL, Severity.HIGH): 10,
-    (Status.FAIL, Severity.MEDIUM): 5,
-    (Status.FAIL, Severity.LOW): 2,
-    (Status.FAIL, Severity.INFO): 0,
-    (Status.WARN, Severity.CRITICAL): 10,
-    (Status.WARN, Severity.HIGH): 5,
-    (Status.WARN, Severity.MEDIUM): 3,
-    (Status.WARN, Severity.LOW): 2,
-    (Status.WARN, Severity.INFO): 1,
+    (Status.FAIL, Severity.CRITICAL): 15,
+    (Status.FAIL, Severity.HIGH):     10,
+    (Status.FAIL, Severity.MEDIUM):    5,
+    (Status.FAIL, Severity.LOW):       2,
+    (Status.FAIL, Severity.INFO):      0,
+    (Status.WARN, Severity.CRITICAL):  7,   # floor(15/2)
+    (Status.WARN, Severity.HIGH):      5,   # floor(10/2)
+    (Status.WARN, Severity.MEDIUM):    2,   # floor(5/2)
+    (Status.WARN, Severity.LOW):       1,   # floor(2/2)
+    (Status.WARN, Severity.INFO):      0,
 }
+
+# Letter grades
+_GRADES: list[tuple[int, str, str]] = [
+    (90, "A", "Excellent"),
+    (80, "B", "Good"),
+    (70, "C", "Fair"),
+    (60, "D", "Poor"),
+    (0,  "F", "Critical"),
+]
 
 
 def calculate_score(results: list[CheckResult]) -> int:
@@ -57,21 +84,51 @@ def calculate_score(results: list[CheckResult]) -> int:
     return final
 
 
-def score_label(score: int) -> str:
-    """Return a human-readable grade label for a numeric score.
+def calculate_category_scores(results: list[CheckResult]) -> dict[str, int]:
+    """Calculate a security score for each category independently.
+
+    Each category starts at 100 and deductions are applied only from
+    results belonging to that category.
+
+    Args:
+        results: All CheckResult objects from the scan.
+
+    Returns:
+        A dict mapping category name → integer score in [0, 100].
+    """
+    by_category: dict[str, list[CheckResult]] = defaultdict(list)
+    for result in results:
+        by_category[result.category].append(result)
+
+    return {
+        category: calculate_score(cat_results)
+        for category, cat_results in sorted(by_category.items())
+    }
+
+
+def score_grade(score: int) -> tuple[str, str]:
+    """Return the letter grade and label for a numeric score.
 
     Args:
         score: Integer score 0–100.
 
     Returns:
-        One of: "Critical", "Poor", "Fair", "Good", "Excellent".
+        Tuple of (letter, label), e.g. ("A", "Excellent") or ("F", "Critical").
     """
-    if score >= 90:
-        return "Excellent"
-    if score >= 75:
-        return "Good"
-    if score >= 50:
-        return "Fair"
-    if score >= 25:
-        return "Poor"
-    return "Critical"
+    for threshold, letter, label in _GRADES:
+        if score >= threshold:
+            return letter, label
+    return "F", "Critical"
+
+
+def score_label(score: int) -> str:
+    """Return a human-readable label for a numeric score.
+
+    Args:
+        score: Integer score 0–100.
+
+    Returns:
+        One of: "Excellent", "Good", "Fair", "Poor", "Critical".
+    """
+    _, label = score_grade(score)
+    return label

--- a/tests/test_checks/test_misc.py
+++ b/tests/test_checks/test_misc.py
@@ -1,0 +1,243 @@
+"""Tests for winposture.checks.misc (Hardening category)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from winposture.checks import misc
+from winposture.exceptions import WinPostureError
+from winposture.models import CheckResult, Status, Severity
+
+
+# ---------------------------------------------------------------------------
+# _check_autoplay
+# ---------------------------------------------------------------------------
+
+class TestCheckAutoplay:
+    def _run(self, output: str):
+        with patch("winposture.checks.misc.run_powershell", return_value=output):
+            return misc._check_autoplay()
+
+    def test_fully_disabled_255_is_pass(self):
+        r = self._run("255")[0]
+        assert r.status == Status.PASS
+
+    def test_not_set_is_warn(self):
+        r = self._run("NOTSET")[0]
+        assert r.status == Status.WARN
+        assert r.severity == Severity.MEDIUM
+
+    def test_partial_disable_is_warn(self):
+        r = self._run("91")[0]
+        assert r.status == Status.WARN
+
+    def test_zero_is_warn(self):
+        r = self._run("0")[0]
+        assert r.status == Status.WARN
+
+    def test_warn_has_remediation(self):
+        r = self._run("NOTSET")[0]
+        assert "NoDriveTypeAutoRun" in r.remediation
+
+    def test_error_returns_error(self):
+        with patch("winposture.checks.misc.run_powershell",
+                   side_effect=WinPostureError("denied")):
+            r = misc._check_autoplay()[0]
+        assert r.status == Status.ERROR
+
+
+# ---------------------------------------------------------------------------
+# _check_winrm
+# ---------------------------------------------------------------------------
+
+class TestCheckWinrm:
+    def _run(self, output: str):
+        with patch("winposture.checks.misc.run_powershell", return_value=output):
+            return misc._check_winrm()
+
+    def test_stopped_is_pass(self):
+        r = self._run("Stopped")[0]
+        assert r.status == Status.PASS
+
+    def test_running_is_warn(self):
+        r = self._run("Running")[0]
+        assert r.status == Status.WARN
+        assert r.severity == Severity.MEDIUM
+
+    def test_not_found_is_info(self):
+        r = self._run("")[0]
+        assert r.status == Status.INFO
+
+    def test_running_has_remediation(self):
+        r = self._run("Running")[0]
+        assert "WinRM" in r.remediation
+
+    def test_error_returns_error(self):
+        with patch("winposture.checks.misc.run_powershell",
+                   side_effect=WinPostureError("boom")):
+            r = misc._check_winrm()[0]
+        assert r.status == Status.ERROR
+
+
+# ---------------------------------------------------------------------------
+# _check_spectre
+# ---------------------------------------------------------------------------
+
+class TestCheckSpectre:
+    def _run(self, data):
+        with patch("winposture.checks.misc.run_powershell_json", return_value=data):
+            return misc._check_spectre()
+
+    def test_no_override_key_is_info(self):
+        r = self._run({"Override": None, "Mask": None})[0]
+        assert r.status == Status.INFO
+        assert "default" in r.details.lower()
+
+    def test_mitigations_disabled_is_warn(self):
+        # Override & 3 == 3, Mask == 3 → disabled
+        r = self._run({"Override": 3, "Mask": 3})[0]
+        assert r.status == Status.WARN
+        assert r.severity == Severity.MEDIUM
+
+    def test_mitigations_enabled_via_override_is_info(self):
+        # Override = 0, Mask = 3 → mitigations on
+        r = self._run({"Override": 0, "Mask": 3})[0]
+        assert r.status == Status.INFO
+
+    def test_list_data_wrapped(self):
+        r = self._run([{"Override": None, "Mask": None}])[0]
+        assert r.status == Status.INFO
+
+    def test_disabled_has_remediation(self):
+        r = self._run({"Override": 3, "Mask": 3})[0]
+        assert "FeatureSettingsOverride" in r.remediation
+
+    def test_error_returns_error(self):
+        with patch("winposture.checks.misc.run_powershell_json",
+                   side_effect=WinPostureError("denied")):
+            r = misc._check_spectre()[0]
+        assert r.status == Status.ERROR
+
+
+# ---------------------------------------------------------------------------
+# _check_audit_policy
+# ---------------------------------------------------------------------------
+
+class TestCheckAuditPolicy:
+    def _entry(self, name: str, setting: str = "Success and Failure") -> dict:
+        return {"Subcategory": name, "Inclusion Setting": setting}
+
+    def _run(self, data):
+        with patch("winposture.checks.misc.run_powershell_json", return_value=data):
+            return misc._check_audit_policy()
+
+    def test_all_audited_is_pass(self):
+        entries = [
+            self._entry("Logon", "Success and Failure"),
+            self._entry("Credential Validation", "Failure"),
+        ]
+        r = self._run(entries)[0]
+        assert r.status == Status.PASS
+
+    def test_no_auditing_entry_is_warn(self):
+        entries = [
+            self._entry("Logon", "No Auditing"),
+            self._entry("Account Lockout", "Success"),
+        ]
+        r = self._run(entries)[0]
+        assert r.status == Status.WARN
+        assert "Logon" in r.details
+
+    def test_empty_list_is_warn(self):
+        r = self._run([])[0]
+        assert r.status == Status.WARN
+
+    def test_warn_has_remediation(self):
+        r = self._run([self._entry("Logon", "No Auditing")])[0]
+        assert "auditpol" in r.remediation
+
+    def test_error_returns_error(self):
+        with patch("winposture.checks.misc.run_powershell_json",
+                   side_effect=WinPostureError("boom")):
+            r = misc._check_audit_policy()[0]
+        assert r.status == Status.ERROR
+
+
+# ---------------------------------------------------------------------------
+# _check_screen_lock
+# ---------------------------------------------------------------------------
+
+class TestCheckScreenLock:
+    def _data(self, active="1", secure="1", timeout=600):
+        return {"Active": active, "Secure": secure, "Timeout": timeout}
+
+    def _run(self, data):
+        with patch("winposture.checks.misc.run_powershell_json", return_value=data):
+            return misc._check_screen_lock()
+
+    def test_good_config_is_pass(self):
+        # 10-minute timeout, password on resume
+        r = self._run(self._data(active="1", secure="1", timeout=600))[0]
+        assert r.status == Status.PASS
+
+    def test_screensaver_disabled_is_warn(self):
+        r = self._run(self._data(active="0"))[0]
+        assert r.status == Status.WARN
+
+    def test_timeout_over_15min_is_warn(self):
+        r = self._run(self._data(timeout=1200))[0]
+        assert r.status == Status.WARN
+        assert "exceeds" in r.details.lower()
+
+    def test_exactly_15_min_is_pass(self):
+        r = self._run(self._data(timeout=900))[0]
+        assert r.status == Status.PASS
+
+    def test_no_password_on_resume_is_warn(self):
+        r = self._run(self._data(secure="0", timeout=300))[0]
+        assert r.status == Status.WARN
+
+    def test_zero_timeout_is_warn(self):
+        r = self._run(self._data(timeout=0))[0]
+        assert r.status == Status.WARN
+
+    def test_error_returns_error(self):
+        with patch("winposture.checks.misc.run_powershell_json",
+                   side_effect=WinPostureError("access denied")):
+            r = misc._check_screen_lock()[0]
+        assert r.status == Status.ERROR
+
+
+# ---------------------------------------------------------------------------
+# run()
+# ---------------------------------------------------------------------------
+
+class TestRun:
+    def test_run_returns_five_results(self):
+        good_screen = {"Active": "1", "Secure": "1", "Timeout": 600}
+        good_spectre = {"Override": None, "Mask": None}
+        audit_entries = [{"Subcategory": "Logon", "Inclusion Setting": "Success and Failure"}]
+        with (
+            patch("winposture.checks.misc.run_powershell",
+                  side_effect=["255", "Stopped"]),
+            patch("winposture.checks.misc.run_powershell_json",
+                  side_effect=[good_spectre, audit_entries, good_screen]),
+        ):
+            results = misc.run()
+        assert len(results) == 5
+        assert all(isinstance(r, CheckResult) for r in results)
+
+    def test_run_category_is_hardening(self):
+        good_screen = {"Active": "1", "Secure": "1", "Timeout": 600}
+        good_spectre = {"Override": None, "Mask": None}
+        audit_entries = [{"Subcategory": "Logon", "Inclusion Setting": "Success"}]
+        with (
+            patch("winposture.checks.misc.run_powershell",
+                  side_effect=["255", "Stopped"]),
+            patch("winposture.checks.misc.run_powershell_json",
+                  side_effect=[good_spectre, audit_entries, good_screen]),
+        ):
+            results = misc.run()
+        assert all(r.category == "Hardening" for r in results)

--- a/tests/test_checks/test_powershell.py
+++ b/tests/test_checks/test_powershell.py
@@ -1,0 +1,209 @@
+"""Tests for winposture.checks.powershell."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from winposture.checks import powershell
+from winposture.exceptions import WinPostureError
+from winposture.models import CheckResult, Status, Severity
+
+
+# ---------------------------------------------------------------------------
+# _check_execution_policy
+# ---------------------------------------------------------------------------
+
+class TestCheckExecutionPolicy:
+    def _run(self, output: str):
+        with patch("winposture.checks.powershell.run_powershell", return_value=output):
+            return powershell._check_execution_policy()
+
+    def test_restricted_is_info(self):
+        r = self._run("Restricted")[0]
+        assert r.status == Status.INFO
+
+    def test_remotesigned_is_info(self):
+        r = self._run("RemoteSigned")[0]
+        assert r.status == Status.INFO
+
+    def test_allsigned_is_info(self):
+        r = self._run("AllSigned")[0]
+        assert r.status == Status.INFO
+
+    def test_unrestricted_is_warn(self):
+        r = self._run("Unrestricted")[0]
+        assert r.status == Status.WARN
+        assert r.severity == Severity.MEDIUM
+
+    def test_bypass_is_warn(self):
+        r = self._run("Bypass")[0]
+        assert r.status == Status.WARN
+
+    def test_case_insensitive_match(self):
+        r = self._run("bypass")[0]
+        assert r.status == Status.WARN
+
+    def test_warn_has_remediation(self):
+        r = self._run("Unrestricted")[0]
+        assert "RemoteSigned" in r.remediation
+
+    def test_policy_value_in_details(self):
+        r = self._run("RemoteSigned")[0]
+        assert "RemoteSigned" in r.details
+
+    def test_error_returns_error(self):
+        with patch("winposture.checks.powershell.run_powershell",
+                   side_effect=WinPostureError("denied")):
+            r = powershell._check_execution_policy()[0]
+        assert r.status == Status.ERROR
+
+
+# ---------------------------------------------------------------------------
+# _check_script_block_logging
+# ---------------------------------------------------------------------------
+
+class TestCheckScriptBlockLogging:
+    def _run(self, output: str):
+        with patch("winposture.checks.powershell.run_powershell", return_value=output):
+            return powershell._check_script_block_logging()
+
+    def test_enabled_value_1_is_pass(self):
+        r = self._run("1")[0]
+        assert r.status == Status.PASS
+
+    def test_disabled_value_0_is_warn(self):
+        r = self._run("0")[0]
+        assert r.status == Status.WARN
+        assert r.severity == Severity.MEDIUM
+
+    def test_notset_is_warn(self):
+        r = self._run("NOTSET")[0]
+        assert r.status == Status.WARN
+
+    def test_warn_has_remediation(self):
+        r = self._run("NOTSET")[0]
+        assert "EnableScriptBlockLogging" in r.remediation
+
+    def test_error_returns_error(self):
+        with patch("winposture.checks.powershell.run_powershell",
+                   side_effect=WinPostureError("boom")):
+            r = powershell._check_script_block_logging()[0]
+        assert r.status == Status.ERROR
+
+
+# ---------------------------------------------------------------------------
+# _check_module_logging
+# ---------------------------------------------------------------------------
+
+class TestCheckModuleLogging:
+    def _run(self, output: str):
+        with patch("winposture.checks.powershell.run_powershell", return_value=output):
+            return powershell._check_module_logging()
+
+    def test_enabled_is_pass(self):
+        r = self._run("1")[0]
+        assert r.status == Status.PASS
+
+    def test_notset_is_warn(self):
+        r = self._run("NOTSET")[0]
+        assert r.status == Status.WARN
+
+    def test_zero_is_warn(self):
+        r = self._run("0")[0]
+        assert r.status == Status.WARN
+
+    def test_warn_has_remediation(self):
+        r = self._run("0")[0]
+        assert "EnableModuleLogging" in r.remediation
+
+
+# ---------------------------------------------------------------------------
+# _check_constrained_language
+# ---------------------------------------------------------------------------
+
+class TestCheckConstrainedLanguage:
+    def _run(self, output: str):
+        with patch("winposture.checks.powershell.run_powershell", return_value=output):
+            return powershell._check_constrained_language()
+
+    def test_constrained_mode_is_pass(self):
+        r = self._run("ConstrainedLanguage")[0]
+        assert r.status == Status.PASS
+
+    def test_full_language_mode_is_info(self):
+        r = self._run("FullLanguage")[0]
+        assert r.status == Status.INFO
+
+    def test_mode_in_details(self):
+        r = self._run("FullLanguage")[0]
+        assert "FullLanguage" in r.details
+
+    def test_no_remediation(self):
+        r = self._run("FullLanguage")[0]
+        assert r.remediation == ""
+
+
+# ---------------------------------------------------------------------------
+# _check_psv2
+# ---------------------------------------------------------------------------
+
+class TestCheckPsv2:
+    def _run(self, output: str):
+        with patch("winposture.checks.powershell.run_powershell", return_value=output):
+            return powershell._check_psv2()
+
+    def test_enabled_is_warn(self):
+        r = self._run("Enabled")[0]
+        assert r.status == Status.WARN
+        assert r.severity == Severity.MEDIUM
+
+    def test_enabled_with_payload_removed_is_warn(self):
+        r = self._run("EnabledWithPayloadRemoved")[0]
+        assert r.status == Status.WARN
+
+    def test_disabled_is_pass(self):
+        r = self._run("Disabled")[0]
+        assert r.status == Status.PASS
+
+    def test_unavailable_is_pass(self):
+        r = self._run("UNAVAILABLE")[0]
+        assert r.status == Status.PASS
+
+    def test_unknown_state_is_info(self):
+        r = self._run("SomeOtherState")[0]
+        assert r.status == Status.INFO
+
+    def test_warn_mentions_downgrade(self):
+        r = self._run("Enabled")[0]
+        assert "v2" in r.details.lower() or "Version 2" in r.details
+
+    def test_warn_has_remediation(self):
+        r = self._run("Enabled")[0]
+        assert "Disable-WindowsOptionalFeature" in r.remediation
+
+
+# ---------------------------------------------------------------------------
+# run()
+# ---------------------------------------------------------------------------
+
+class TestRun:
+    def test_run_returns_five_results(self):
+        side_effects = [
+            "RemoteSigned",  # exec policy
+            "0",             # script block logging
+            "0",             # module logging
+            "FullLanguage",  # CLM
+            "Disabled",      # PSv2
+        ]
+        with patch("winposture.checks.powershell.run_powershell", side_effect=side_effects):
+            results = powershell.run()
+        assert len(results) == 5
+        assert all(isinstance(r, CheckResult) for r in results)
+
+    def test_run_category_is_powershell(self):
+        side_effects = ["RemoteSigned", "1", "1", "ConstrainedLanguage", "Disabled"]
+        with patch("winposture.checks.powershell.run_powershell", side_effect=side_effects):
+            results = powershell.run()
+        assert all(r.category == "PowerShell" for r in results)

--- a/tests/test_checks/test_services.py
+++ b/tests/test_checks/test_services.py
@@ -1,0 +1,144 @@
+"""Tests for winposture.checks.services."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from winposture.checks import services
+from winposture.exceptions import WinPostureError
+from winposture.models import CheckResult, Status, Severity
+
+
+def _svc(name: str, display: str = "") -> dict:
+    return {"Name": name, "DisplayName": display or name, "Status": "Running"}
+
+
+def _unquoted(name: str, path: str) -> dict:
+    return {"Name": name, "DisplayName": name, "PathName": path}
+
+
+# ---------------------------------------------------------------------------
+# _check_risky_services
+# ---------------------------------------------------------------------------
+
+class TestCheckRiskyServices:
+    def _run(self, services_data):
+        with patch("winposture.checks.services.run_powershell_json", return_value=services_data):
+            return services._check_risky_services()
+
+    def test_no_risky_services_returns_pass(self):
+        r = self._run([_svc("Spooler"), _svc("WSearch")])[0]
+        assert r.status == Status.PASS
+        assert r.severity == Severity.MEDIUM
+
+    def test_remote_registry_running_is_warn(self):
+        results = self._run([_svc("RemoteRegistry")])
+        assert any(r.status == Status.WARN and r.severity == Severity.HIGH for r in results)
+
+    def test_telnet_server_running_is_fail_critical(self):
+        results = self._run([_svc("TlntSvr")])
+        assert any(r.status == Status.FAIL and r.severity == Severity.CRITICAL for r in results)
+
+    def test_telnet_service_running_is_fail_critical(self):
+        results = self._run([_svc("Telnet")])
+        assert any(r.status == Status.FAIL and r.severity == Severity.CRITICAL for r in results)
+
+    def test_snmp_running_is_warn_medium(self):
+        results = self._run([_svc("SNMP")])
+        assert any(r.status == Status.WARN and r.severity == Severity.MEDIUM for r in results)
+
+    def test_multiple_risky_services_each_get_result(self):
+        results = self._run([_svc("RemoteRegistry"), _svc("SNMP"), _svc("Spooler")])
+        risky = [r for r in results if r.status != Status.PASS]
+        assert len(risky) == 2
+
+    def test_service_name_in_check_name(self):
+        results = self._run([_svc("RemoteRegistry")])
+        names = [r.check_name for r in results]
+        assert any("RemoteRegistry" in n for n in names)
+
+    def test_case_insensitive_match(self):
+        results = self._run([_svc("remoteregistry")])
+        assert any(r.status == Status.WARN for r in results)
+
+    def test_single_dict_wrapped(self):
+        results = self._run(_svc("Spooler"))
+        assert results[0].status == Status.PASS
+
+    def test_error_returns_error(self):
+        with patch("winposture.checks.services.run_powershell_json",
+                   side_effect=WinPostureError("access denied")):
+            r = services._check_risky_services()[0]
+        assert r.status == Status.ERROR
+
+
+# ---------------------------------------------------------------------------
+# _check_unquoted_paths
+# ---------------------------------------------------------------------------
+
+class TestCheckUnquotedPaths:
+    def _run(self, data):
+        with patch("winposture.checks.services.run_powershell_json", return_value=data):
+            return services._check_unquoted_paths()
+
+    def test_no_unquoted_paths_is_pass(self):
+        r = self._run([])[0]
+        assert r.status == Status.PASS
+        assert r.severity == Severity.HIGH
+
+    def test_unquoted_path_is_fail(self):
+        r = self._run([_unquoted("MySvc", "C:\\Program Files\\My Service\\svc.exe")])[0]
+        assert r.status == Status.FAIL
+        assert r.severity == Severity.HIGH
+
+    def test_fail_includes_service_name(self):
+        r = self._run([_unquoted("MySvc", "C:\\Program Files\\svc.exe")])[0]
+        assert "MySvc" in r.details
+
+    def test_fail_includes_path(self):
+        path = "C:\\Program Files\\My Service\\svc.exe"
+        r = self._run([_unquoted("MySvc", path)])[0]
+        assert path in r.details
+
+    def test_fail_has_remediation(self):
+        r = self._run([_unquoted("MySvc", "C:\\My Path\\svc.exe")])[0]
+        assert "ImagePath" in r.remediation
+
+    def test_multiple_unquoted_paths_counted(self):
+        items = [
+            _unquoted("Svc1", "C:\\My App\\svc1.exe"),
+            _unquoted("Svc2", "C:\\Other App\\svc2.exe"),
+        ]
+        r = self._run(items)[0]
+        assert r.status == Status.FAIL
+        assert "2" in r.details
+
+    def test_error_returns_error(self):
+        with patch("winposture.checks.services.run_powershell_json",
+                   side_effect=WinPostureError("boom")):
+            r = services._check_unquoted_paths()[0]
+        assert r.status == Status.ERROR
+
+
+# ---------------------------------------------------------------------------
+# run()
+# ---------------------------------------------------------------------------
+
+class TestRun:
+    def test_run_returns_list_of_check_results(self):
+        with patch("winposture.checks.services.run_powershell_json", return_value=[]):
+            results = services.run()
+        assert all(isinstance(r, CheckResult) for r in results)
+
+    def test_run_no_risky_no_unquoted_two_pass_results(self):
+        with patch("winposture.checks.services.run_powershell_json", return_value=[]):
+            results = services.run()
+        assert len(results) == 2
+        assert all(r.status == Status.PASS for r in results)
+
+    def test_run_category_is_services(self):
+        with patch("winposture.checks.services.run_powershell_json", return_value=[]):
+            results = services.run()
+        assert all(r.category == "Services" for r in results)

--- a/tests/test_checks/test_startup.py
+++ b/tests/test_checks/test_startup.py
@@ -1,0 +1,123 @@
+"""Tests for winposture.checks.startup."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from winposture.checks import startup
+from winposture.exceptions import WinPostureError
+from winposture.models import CheckResult, Status, Severity
+
+
+def _item(name: str = "MyApp", command: str = "C:\\app.exe") -> dict:
+    return {"Name": name, "Command": command, "Location": "HKLM\\Run", "User": ""}
+
+
+# ---------------------------------------------------------------------------
+# _check_startup_programs
+# ---------------------------------------------------------------------------
+
+class TestCheckStartupPrograms:
+    def _run(self, data):
+        with patch("winposture.checks.startup.run_powershell_json", return_value=data):
+            return startup._check_startup_programs()
+
+    def test_empty_data_says_no_programs(self):
+        r = self._run([])[0]
+        assert r.status == Status.INFO
+        assert "No startup" in r.details
+
+    def test_single_item_reported(self):
+        r = self._run([_item("OneDrive")])[0]
+        assert "1" in r.details
+        assert "OneDrive" in r.details
+
+    def test_multiple_items_counted(self):
+        items = [_item(f"App{i}") for i in range(5)]
+        r = self._run(items)[0]
+        assert "5" in r.details
+
+    def test_more_than_20_truncated(self):
+        items = [_item(f"App{i}") for i in range(25)]
+        r = self._run(items)[0]
+        assert "+5 more" in r.details
+
+    def test_single_dict_wrapped(self):
+        r = self._run(_item("SingularApp"))[0]
+        assert "SingularApp" in r.details
+
+    def test_status_always_info(self):
+        r = self._run([_item()])[0]
+        assert r.status == Status.INFO
+        assert r.severity == Severity.LOW
+
+    def test_error_returns_error(self):
+        with patch("winposture.checks.startup.run_powershell_json",
+                   side_effect=WinPostureError("denied")):
+            r = startup._check_startup_programs()[0]
+        assert r.status == Status.ERROR
+
+    def test_check_name(self):
+        r = self._run([])[0]
+        assert r.check_name == "Startup Programs"
+
+    def test_category_is_persistence(self):
+        r = self._run([])[0]
+        assert r.category == "Persistence"
+
+
+# ---------------------------------------------------------------------------
+# _check_scheduled_tasks
+# ---------------------------------------------------------------------------
+
+class TestCheckScheduledTasks:
+    def _task(self, name: str = "MyTask") -> dict:
+        return {"TaskName": name, "TaskPath": "\\Custom\\", "RunAs": "SYSTEM", "State": "Ready"}
+
+    def _run(self, data):
+        with patch("winposture.checks.startup.run_powershell_json", return_value=data):
+            return startup._check_scheduled_tasks()
+
+    def test_empty_data_says_no_tasks(self):
+        r = self._run([])[0]
+        assert "No non-Microsoft" in r.details
+
+    def test_tasks_reported(self):
+        r = self._run([self._task("BackupJob"), self._task("Updater")])[0]
+        assert "2" in r.details
+        assert "BackupJob" in r.details
+
+    def test_more_than_20_truncated(self):
+        tasks = [self._task(f"Task{i}") for i in range(25)]
+        r = self._run(tasks)[0]
+        assert "+5 more" in r.details
+
+    def test_status_always_info(self):
+        r = self._run([self._task()])[0]
+        assert r.status == Status.INFO
+
+    def test_error_returns_error(self):
+        with patch("winposture.checks.startup.run_powershell_json",
+                   side_effect=WinPostureError("boom")):
+            r = startup._check_scheduled_tasks()[0]
+        assert r.status == Status.ERROR
+
+
+# ---------------------------------------------------------------------------
+# run()
+# ---------------------------------------------------------------------------
+
+class TestRun:
+    def test_run_returns_two_results(self):
+        empty = []
+        with patch("winposture.checks.startup.run_powershell_json", return_value=empty):
+            results = startup.run()
+        assert len(results) == 2
+        assert all(isinstance(r, CheckResult) for r in results)
+
+    def test_run_check_names(self):
+        with patch("winposture.checks.startup.run_powershell_json", return_value=[]):
+            results = startup.run()
+        names = {r.check_name for r in results}
+        assert "Startup Programs" in names
+        assert "Scheduled Tasks" in names

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -5,12 +5,17 @@ from __future__ import annotations
 import pytest
 
 from winposture.models import CheckResult, Severity, Status
-from winposture.scoring import calculate_score, score_label
+from winposture.scoring import (
+    calculate_category_scores,
+    calculate_score,
+    score_grade,
+    score_label,
+)
 
 
-def _result(status: Status, severity: Severity) -> CheckResult:
+def _result(status: Status, severity: Severity, category: str = "Test") -> CheckResult:
     return CheckResult(
-        category="Test",
+        category=category,
         check_name="test check",
         status=status,
         severity=severity,
@@ -18,6 +23,10 @@ def _result(status: Status, severity: Severity) -> CheckResult:
         details="",
     )
 
+
+# ---------------------------------------------------------------------------
+# calculate_score
+# ---------------------------------------------------------------------------
 
 class TestCalculateScore:
     def test_empty_results_returns_100(self):
@@ -27,61 +36,190 @@ class TestCalculateScore:
         results = [_result(Status.PASS, Severity.HIGH) for _ in range(5)]
         assert calculate_score(results) == 100
 
-    def test_critical_fail_deducts_20(self):
-        results = [_result(Status.FAIL, Severity.CRITICAL)]
-        assert calculate_score(results) == 80
+    # --- FAIL deductions ---
+
+    def test_critical_fail_deducts_15(self):
+        assert calculate_score([_result(Status.FAIL, Severity.CRITICAL)]) == 85
 
     def test_high_fail_deducts_10(self):
-        results = [_result(Status.FAIL, Severity.HIGH)]
-        assert calculate_score(results) == 90
+        assert calculate_score([_result(Status.FAIL, Severity.HIGH)]) == 90
 
     def test_medium_fail_deducts_5(self):
-        results = [_result(Status.FAIL, Severity.MEDIUM)]
-        assert calculate_score(results) == 95
+        assert calculate_score([_result(Status.FAIL, Severity.MEDIUM)]) == 95
 
     def test_low_fail_deducts_2(self):
-        results = [_result(Status.FAIL, Severity.LOW)]
-        assert calculate_score(results) == 98
+        assert calculate_score([_result(Status.FAIL, Severity.LOW)]) == 98
 
-    def test_warn_high_deducts_5(self):
-        results = [_result(Status.WARN, Severity.HIGH)]
-        assert calculate_score(results) == 95
+    def test_info_fail_no_deduction(self):
+        assert calculate_score([_result(Status.FAIL, Severity.INFO)]) == 100
+
+    # --- WARN deductions (floor(FAIL/2)) ---
+
+    def test_critical_warn_deducts_7(self):
+        assert calculate_score([_result(Status.WARN, Severity.CRITICAL)]) == 93
+
+    def test_high_warn_deducts_5(self):
+        assert calculate_score([_result(Status.WARN, Severity.HIGH)]) == 95
+
+    def test_medium_warn_deducts_2(self):
+        assert calculate_score([_result(Status.WARN, Severity.MEDIUM)]) == 98
+
+    def test_low_warn_deducts_1(self):
+        assert calculate_score([_result(Status.WARN, Severity.LOW)]) == 99
+
+    def test_info_warn_no_deduction(self):
+        assert calculate_score([_result(Status.WARN, Severity.INFO)]) == 100
+
+    # --- Non-penalised statuses ---
+
+    def test_info_status_no_deduction(self):
+        assert calculate_score([_result(Status.INFO, Severity.CRITICAL)]) == 100
+
+    def test_error_status_no_deduction(self):
+        assert calculate_score([_result(Status.ERROR, Severity.HIGH)]) == 100
+
+    def test_pass_status_no_deduction(self):
+        assert calculate_score([_result(Status.PASS, Severity.CRITICAL)]) == 100
+
+    # --- Clamping ---
 
     def test_score_clamps_to_zero(self):
-        # 6 critical fails = −120, should clamp to 0
-        results = [_result(Status.FAIL, Severity.CRITICAL) for _ in range(6)]
+        # 7 × CRITICAL FAIL = −105 → clamp to 0
+        results = [_result(Status.FAIL, Severity.CRITICAL) for _ in range(7)]
         assert calculate_score(results) == 0
 
     def test_score_never_exceeds_100(self):
-        results = [_result(Status.PASS, Severity.INFO)]
-        assert calculate_score(results) <= 100
+        assert calculate_score([_result(Status.PASS, Severity.INFO)]) <= 100
 
-    def test_info_status_no_deduction(self):
-        results = [_result(Status.INFO, Severity.CRITICAL)]
-        assert calculate_score(results) == 100
+    # --- Mixed combinations ---
 
-    def test_error_status_no_deduction(self):
-        results = [_result(Status.ERROR, Severity.HIGH)]
-        assert calculate_score(results) == 100
+    def test_mixed_fail_and_warn(self):
+        # CRITICAL FAIL (−15) + HIGH WARN (−5) = −20 → 80
+        results = [
+            _result(Status.FAIL, Severity.CRITICAL),
+            _result(Status.WARN, Severity.HIGH),
+        ]
+        assert calculate_score(results) == 80
 
-    def test_mixed_results(self, fail_result, warn_result, pass_result):
-        # fail CRITICAL (−20) + warn HIGH (−5) + pass (0) = 75
-        results = [fail_result, warn_result, pass_result]
-        assert calculate_score(results) == 75
+    def test_mixed_with_pass_unchanged(self):
+        # FAIL HIGH (−10) + PASS + INFO = 90
+        results = [
+            _result(Status.FAIL, Severity.HIGH),
+            _result(Status.PASS, Severity.CRITICAL),
+            _result(Status.INFO, Severity.CRITICAL),
+        ]
+        assert calculate_score(results) == 90
 
+    def test_multiple_medium_fails(self):
+        # 4 × MEDIUM FAIL = −20 → 80
+        results = [_result(Status.FAIL, Severity.MEDIUM) for _ in range(4)]
+        assert calculate_score(results) == 80
+
+    def test_all_critical_fail(self):
+        results = [_result(Status.FAIL, Severity.CRITICAL) for _ in range(10)]
+        assert calculate_score(results) == 0
+
+    def test_accumulates_across_severities(self):
+        # CRITICAL FAIL(−15) + HIGH FAIL(−10) + MEDIUM FAIL(−5) + LOW FAIL(−2) = −32 → 68
+        results = [
+            _result(Status.FAIL, Severity.CRITICAL),
+            _result(Status.FAIL, Severity.HIGH),
+            _result(Status.FAIL, Severity.MEDIUM),
+            _result(Status.FAIL, Severity.LOW),
+        ]
+        assert calculate_score(results) == 68
+
+
+# ---------------------------------------------------------------------------
+# calculate_category_scores
+# ---------------------------------------------------------------------------
+
+class TestCalculateCategoryScores:
+    def test_empty_results_returns_empty_dict(self):
+        assert calculate_category_scores([]) == {}
+
+    def test_single_category_matches_overall(self):
+        results = [_result(Status.FAIL, Severity.HIGH, category="Firewall")]
+        scores = calculate_category_scores(results)
+        assert scores == {"Firewall": 90}
+
+    def test_categories_scored_independently(self):
+        results = [
+            _result(Status.FAIL, Severity.CRITICAL, category="Firewall"),
+            _result(Status.PASS, Severity.HIGH,     category="Accounts"),
+        ]
+        scores = calculate_category_scores(results)
+        assert scores["Firewall"] == 85   # −15
+        assert scores["Accounts"] == 100  # no deduction
+
+    def test_categories_do_not_bleed_into_each_other(self):
+        # 7 CRITICAL FAILs in Firewall should not affect Accounts
+        results = (
+            [_result(Status.FAIL, Severity.CRITICAL, category="Firewall")] * 7
+            + [_result(Status.PASS, Severity.CRITICAL, category="Accounts")]
+        )
+        scores = calculate_category_scores(results)
+        assert scores["Firewall"] == 0
+        assert scores["Accounts"] == 100
+
+    def test_multiple_checks_same_category(self):
+        results = [
+            _result(Status.FAIL, Severity.HIGH,   category="Network"),
+            _result(Status.WARN, Severity.MEDIUM, category="Network"),
+        ]
+        scores = calculate_category_scores(results)
+        # HIGH FAIL(−10) + MEDIUM WARN(−2) = −12 → 88
+        assert scores["Network"] == 88
+
+    def test_returns_sorted_category_names(self):
+        results = [
+            _result(Status.PASS, Severity.LOW, category="Zebra"),
+            _result(Status.PASS, Severity.LOW, category="Alpha"),
+        ]
+        scores = calculate_category_scores(results)
+        assert list(scores.keys()) == ["Alpha", "Zebra"]
+
+
+# ---------------------------------------------------------------------------
+# score_grade
+# ---------------------------------------------------------------------------
+
+class TestScoreGrade:
+    @pytest.mark.parametrize("score,letter,label", [
+        (100, "A", "Excellent"),
+        (90,  "A", "Excellent"),
+        (89,  "B", "Good"),
+        (80,  "B", "Good"),
+        (79,  "C", "Fair"),
+        (70,  "C", "Fair"),
+        (69,  "D", "Poor"),
+        (60,  "D", "Poor"),
+        (59,  "F", "Critical"),
+        (1,   "F", "Critical"),
+        (0,   "F", "Critical"),
+    ])
+    def test_grades(self, score: int, letter: str, label: str):
+        got_letter, got_label = score_grade(score)
+        assert got_letter == letter
+        assert got_label == label
+
+
+# ---------------------------------------------------------------------------
+# score_label
+# ---------------------------------------------------------------------------
 
 class TestScoreLabel:
     @pytest.mark.parametrize("score,expected", [
         (100, "Excellent"),
-        (90, "Excellent"),
-        (89, "Good"),
-        (75, "Good"),
-        (74, "Fair"),
-        (50, "Fair"),
-        (49, "Poor"),
-        (25, "Poor"),
-        (24, "Critical"),
-        (0, "Critical"),
+        (90,  "Excellent"),
+        (89,  "Good"),
+        (80,  "Good"),
+        (79,  "Fair"),
+        (70,  "Fair"),
+        (69,  "Poor"),
+        (60,  "Poor"),
+        (59,  "Critical"),
+        (0,   "Critical"),
     ])
     def test_labels(self, score: int, expected: str):
         assert score_label(score) == expected


### PR DESCRIPTION
## Summary

- **startup.py** (Persistence): enumerates startup programs via `Win32_StartupCommand` and non-Microsoft scheduled tasks via `Get-ScheduledTask`
- **powershell.py** (PowerShell): execution policy (WARN if Unrestricted/Bypass), Script Block Logging, Module Logging (both WARN if disabled), Constrained Language Mode, PSv2 installed check (WARN — downgrade attack vector)
- **services.py** (Services): risky service detection (RemoteRegistry WARN/HIGH, Telnet FAIL/CRITICAL, SNMP WARN/MEDIUM); unquoted service path detection FAIL/HIGH (privilege escalation)
- **misc.py** (Hardening): AutoPlay disabled, WinRM status, Spectre/Meltdown override detection, audit policy via `auditpol`, screen-lock timeout (WARN if >15 min)
- **scoring.py** overhaul: CRITICAL FAIL −15 (was −20); WARN = floor(FAIL/2); new `calculate_category_scores()` for per-category scores; new `score_grade()` returning letter grades A/B/C/D/F; updated thresholds

## Test plan
- [x] `python -m pytest tests/ -q` — 421 passed, 0 failed
- [x] `python -m winposture` smoke test — all 13 categories render correctly, scoring produces 29/100 (Critical) reflecting real machine state

🤖 Generated with [Claude Code](https://claude.com/claude-code)