### PR TITLE
feat: harden error handling, admin detection, and compatibility

### DIFF
--- a/src/winposture/checks/encryption.py
+++ b/src/winposture/checks/encryption.py
@@ -11,6 +11,7 @@ from winposture.utils import run_powershell_json
 log = logging.getLogger(__name__)
 
 CATEGORY = "Encryption"
+REQUIRES_ADMIN = True  # Get-BitLockerVolume requires administrator privileges
 
 # Get-BitLockerVolume requires admin; the outer try/catch returns an empty JSON
 # array so run() can produce a graceful WARN instead of crashing.

--- a/src/winposture/checks/smb.py
+++ b/src/winposture/checks/smb.py
@@ -11,6 +11,7 @@ from winposture.utils import run_powershell_json
 log = logging.getLogger(__name__)
 
 CATEGORY = "File Sharing"
+REQUIRES_ADMIN = True  # Get-SmbServerConfiguration requires administrator privileges
 
 _PS_SMB = (
     "try { "

--- a/src/winposture/checks/updates.py
+++ b/src/winposture/checks/updates.py
@@ -174,7 +174,9 @@ def _check_wu_service() -> list[CheckResult]:
 def _check_pending_updates() -> list[CheckResult]:
     """Count Windows Updates that are available but not yet installed."""
     try:
-        output = run_powershell(_PS_PENDING).strip()
+        # COM object query can be slow on machines with many updates pending;
+        # use a 60s timeout to avoid stalling the entire scan.
+        output = run_powershell(_PS_PENDING, timeout=60).strip()
     except WinPostureError as exc:
         return [_error("Pending Windows Updates", str(exc))]
 

--- a/src/winposture/cli.py
+++ b/src/winposture/cli.py
@@ -79,12 +79,14 @@ def main() -> None:
     # Import here so startup is fast for --version / --help
     from winposture.scanner import Scanner
     from winposture.reporter import Reporter
+    from winposture.utils import is_admin
 
     categories: list[str] | None = None
     if args.category:
         categories = [c.strip().lower() for c in args.category.split(",")]
 
-    scanner  = Scanner(categories=categories)
+    admin    = is_admin()
+    scanner  = Scanner(categories=categories, is_admin=admin)
     reporter = Reporter(verbose=args.verbose, no_color=args.no_color)
 
     # Run scan with live progress display, then save outputs, then print results

--- a/src/winposture/cli.py
+++ b/src/winposture/cli.py
@@ -91,10 +91,10 @@ def main() -> None:
     report = reporter.run_with_progress(scanner)
 
     if args.html:
-        reporter.save_html(report, args.html)
+        reporter.generate_html_report(report, args.html)
 
     if args.json:
-        reporter.save_json(report, args.json)
+        reporter.generate_json_report(report, args.json)
 
     reporter.print_terminal(report, html_path=args.html, json_path=args.json)
 

--- a/src/winposture/models.py
+++ b/src/winposture/models.py
@@ -48,6 +48,7 @@ class CheckResult:
     description: str
     details: str
     remediation: str = ""
+    check_duration: float = 0.0  # seconds the parent module took to run
 
 
 @dataclass
@@ -69,6 +70,7 @@ class AuditReport:
     scan_duration: float
     results: list[CheckResult] = field(default_factory=list)
     score: int = 0
+    is_admin: bool = False
 
     # ------------------------------------------------------------------
     # Convenience helpers
@@ -96,3 +98,8 @@ class AuditReport:
     def pass_count(self) -> int:
         """Number of PASS results."""
         return len(self.by_status(Status.PASS))
+
+    @property
+    def error_count(self) -> int:
+        """Number of ERROR results."""
+        return len(self.by_status(Status.ERROR))

--- a/src/winposture/reporter.py
+++ b/src/winposture/reporter.py
@@ -134,6 +134,7 @@ class Reporter:
                 SpinnerColumn,
                 TextColumn,
                 TimeElapsedColumn,
+                TimeRemainingColumn,
             )
         except ImportError:
             return scanner.run()
@@ -144,6 +145,8 @@ class Reporter:
 
         console.print()
         self._print_banner(console)
+        if not scanner.is_admin:
+            self._print_non_admin_warning(console)
         console.print()
 
         with Progress(
@@ -152,6 +155,7 @@ class Reporter:
             BarColumn(bar_width=28, style="dim blue", complete_style="cyan"),
             MofNCompleteColumn(),
             TimeElapsedColumn(),
+            TimeRemainingColumn(),
             console=console,
             transient=False,
         ) as progress:
@@ -404,6 +408,18 @@ class Reporter:
         from rich.console import Console
         return Console(no_color=self.no_color, highlight=False)
 
+    def _print_non_admin_warning(self, console) -> None:
+        """Print a warning panel when the scan is running without elevation."""
+        from rich.panel import Panel
+        warn = _u(console, "⚠  ", "! ")
+        console.print(Panel(
+            f"  {warn}[yellow bold]Running without administrator privileges.[/yellow bold]\n"
+            "  Some checks (BitLocker, SMB configuration) will be skipped.\n"
+            "  For a complete audit, right-click and [bold]Run as Administrator[/bold].",
+            border_style="yellow",
+            padding=(0, 1),
+        ))
+
     def _print_banner(self, console) -> None:
         """Print the WinPosture logo panel."""
         from rich.align import Align
@@ -613,6 +629,18 @@ class Reporter:
         if json_path:
             console.print(
                 f"  [dim]JSON report saved to:[/dim] [bold cyan]{json_path}[/bold cyan]"
+            )
+        error_count = report.error_count
+        if error_count:
+            console.print(
+                f"  [yellow]![/yellow]  [yellow bold]{error_count} check(s) could not "
+                f"complete.[/yellow bold]  "
+                "[dim]Run as Administrator for full results.[/dim]"
+            )
+        if not report.is_admin:
+            console.print(
+                "  [dim]Note:[/dim] Some checks were skipped — "
+                "[bold]run as Administrator[/bold] for complete results."
             )
         if not self.verbose:
             console.print(

--- a/src/winposture/reporter.py
+++ b/src/winposture/reporter.py
@@ -193,8 +193,13 @@ class Reporter:
         self._print_top_issues(console, report)
         self._print_footer(console, report, html_path, json_path)
 
-    def save_html(self, report: AuditReport, path: str) -> None:
-        """Render and save an HTML report via the Jinja2 template."""
+    def generate_html_report(self, report: AuditReport, path: str) -> None:
+        """Render and save a self-contained HTML report via the Jinja2 template.
+
+        Args:
+            report: Completed :class:`~winposture.models.AuditReport`.
+            path:   Destination file path for the HTML file.
+        """
         try:
             from jinja2 import Environment, FileSystemLoader, select_autoescape
         except ImportError:
@@ -212,18 +217,17 @@ class Reporter:
             log.error("Could not load HTML template: %s", exc)
             return
 
-        letter, label = score_grade(report.score)
-        html = template.render(
-            report=report,
-            score_label=label,
-            score_grade=letter,
-            status_colors={s.value: c for s, c in _STATUS_COLOR.items()},
-        )
+        html = template.render(**self._build_template_context(report))
         Path(path).write_text(html, encoding="utf-8")
         log.info("HTML report saved to %s", path)
 
-    def save_json(self, report: AuditReport, path: str) -> None:
-        """Serialize the AuditReport to JSON."""
+    def generate_json_report(self, report: AuditReport, path: str) -> None:
+        """Serialize the AuditReport to a JSON file.
+
+        Args:
+            report: Completed :class:`~winposture.models.AuditReport`.
+            path:   Destination file path for the JSON file.
+        """
 
         def _default(obj):
             if hasattr(obj, "isoformat"):
@@ -239,6 +243,162 @@ class Reporter:
         log.info("JSON report saved to %s", path)
 
     # ── Internal rendering helpers ────────────────────────────────────────────
+
+    def _build_template_context(self, report: AuditReport) -> dict:
+        """Build the full Jinja2 template variable dict for the HTML report."""
+        from collections import Counter, defaultdict
+
+        letter, label = score_grade(report.score)
+        cat_scores = calculate_category_scores(report.results)
+
+        _sev_ord: dict[Severity, int] = {
+            Severity.CRITICAL: 0, Severity.HIGH: 1,
+            Severity.MEDIUM: 2,   Severity.LOW: 3, Severity.INFO: 4,
+        }
+        _sta_ord: dict[Status, int] = {
+            Status.FAIL: 0, Status.WARN: 1, Status.ERROR: 2,
+            Status.PASS: 3, Status.INFO: 4,
+        }
+
+        def _sort_key(r: CheckResult) -> tuple[int, int]:
+            return (_sta_ord.get(r.status, 5), _sev_ord.get(r.severity, 5))
+
+        # Per-category data (sorted by category name, results by status/severity)
+        by_cat: dict[str, list[CheckResult]] = defaultdict(list)
+        for r in report.results:
+            by_cat[r.category].append(r)
+
+        category_data = []
+        for cat_name in sorted(by_cat):
+            cat_results = sorted(by_cat[cat_name], key=_sort_key)
+            cs = cat_scores.get(cat_name, 100)
+            cl, clbl = score_grade(cs)
+            category_data.append({
+                "name":        cat_name,
+                "score":       cs,
+                "grade":       cl,
+                "grade_label": clbl,
+                "results":     cat_results,
+                "fail_count":  sum(1 for r in cat_results if r.status == Status.FAIL),
+                "warn_count":  sum(1 for r in cat_results if r.status == Status.WARN),
+                "pass_count":  sum(1 for r in cat_results if r.status == Status.PASS),
+            })
+
+        # Top findings: CRITICAL+HIGH FAIL/WARN, up to 5
+        issues = [r for r in report.results if r.status in (Status.FAIL, Status.WARN)]
+        issues.sort(key=lambda r: (_sev_ord.get(r.severity, 5),
+                                   0 if r.status == Status.FAIL else 1))
+        top_findings = [
+            r for r in issues
+            if r.severity in (Severity.CRITICAL, Severity.HIGH)
+        ][:5]
+
+        # All FAIL+WARN for detailed findings section
+        fail_warn_results = sorted(
+            [r for r in report.results if r.status in (Status.FAIL, Status.WARN)],
+            key=_sort_key,
+        )
+
+        # INFO results for appendix
+        info_results = [r for r in report.results if r.status == Status.INFO]
+
+        ts = report.scan_timestamp
+        generated_at = (
+            ts.strftime("%Y-%m-%d %H:%M UTC") if ts.tzinfo
+            else ts.strftime("%Y-%m-%d %H:%M")
+        )
+
+        return {
+            "report":            report,
+            "version":           __version__,
+            "score_grade":       letter,
+            "score_label":       label,
+            "executive_summary": self._build_executive_summary(report),
+            "category_data":     category_data,
+            "top_findings":      top_findings,
+            "fail_warn_results": fail_warn_results,
+            "info_results":      info_results,
+            "generated_at":      generated_at,
+        }
+
+    def _build_executive_summary(self, report: AuditReport) -> str:
+        """Auto-generate a one-paragraph executive summary from report findings."""
+        from collections import Counter
+
+        letter, label = score_grade(report.score)
+        total = len(report.results)
+
+        critical_fails = sum(
+            1 for r in report.results
+            if r.status == Status.FAIL and r.severity == Severity.CRITICAL
+        )
+        high_fails = sum(
+            1 for r in report.results
+            if r.status == Status.FAIL and r.severity == Severity.HIGH
+        )
+
+        # Categories with the most issues (FAIL or WARN)
+        issue_cats = Counter(
+            r.category for r in report.results
+            if r.status in (Status.FAIL, Status.WARN)
+        )
+
+        parts: list[str] = []
+
+        # Opening — always present
+        parts.append(
+            f"The security posture of {report.hostname} has been assessed as "
+            f"{label} with an overall score of {report.score}/100 ({letter}) "
+            f"across {total} security checks."
+        )
+
+        if report.fail_count == 0 and report.warn_count == 0:
+            parts.append(
+                "All checks passed with no failures or warnings detected. "
+                "The system appears to be well-configured according to "
+                "Windows security best practices."
+            )
+            return "  ".join(parts)
+
+        # Severity callout
+        if critical_fails > 0:
+            noun = "finding" if critical_fails == 1 else "findings"
+            verb = "requires" if critical_fails == 1 else "require"
+            parts.append(
+                f"{critical_fails} critical {noun} {verb} immediate remediation."
+            )
+        elif high_fails > 0:
+            noun = "finding" if high_fails == 1 else "findings"
+            parts.append(
+                f"{high_fails} high-severity {noun} should be addressed promptly."
+            )
+
+        # Fail/warn summary
+        detail_parts: list[str] = []
+        if report.fail_count > 0:
+            n = report.fail_count
+            detail_parts.append(f"{n} check{'s' if n != 1 else ''} failed")
+        if report.warn_count > 0:
+            n = report.warn_count
+            detail_parts.append(f"{n} check{'s' if n != 1 else ''} issued warnings")
+        if detail_parts:
+            parts.append(f"Of the checks performed, {' and '.join(detail_parts)}.")
+
+        # Top affected categories
+        if issue_cats:
+            top_cats = [cat for cat, _ in issue_cats.most_common(3)]
+            if len(top_cats) == 1:
+                parts.append(f"The primary area of concern is {top_cats[0]}.")
+            else:
+                joined = ", ".join(top_cats[:-1]) + f" and {top_cats[-1]}"
+                parts.append(f"The primary areas of concern are {joined}.")
+
+        parts.append(
+            "Remediation should be prioritized by severity, "
+            "addressing critical and high severity findings first."
+        )
+
+        return "  ".join(parts)
 
     def _make_console(self):
         from rich.console import Console

--- a/src/winposture/scanner.py
+++ b/src/winposture/scanner.py
@@ -29,10 +29,18 @@ class Scanner:
         categories: If provided, only modules whose ``CATEGORY`` attribute
                     matches one of these strings (case-insensitive) are run.
                     Pass ``None`` (default) to run all modules.
+        is_admin:   Whether the current process has administrator privileges.
+                    Modules with ``REQUIRES_ADMIN = True`` are skipped when
+                    this is ``False``, producing an INFO result instead.
     """
 
-    def __init__(self, categories: list[str] | None = None) -> None:
+    def __init__(
+        self,
+        categories: list[str] | None = None,
+        is_admin: bool = False,
+    ) -> None:
         self.categories = categories
+        self.is_admin = is_admin
 
     # ------------------------------------------------------------------
     # Public API
@@ -75,6 +83,13 @@ class Scanner:
         duration = time.monotonic() - start
         score = calculate_score(results)
 
+        error_count = sum(1 for r in results if r.status == Status.ERROR)
+        if error_count:
+            log.warning(
+                "%d check(s) could not complete — rerun as Administrator for full results.",
+                error_count,
+            )
+
         report = AuditReport(
             hostname=socket.gethostname(),
             os_version=platform.version(),
@@ -82,6 +97,7 @@ class Scanner:
             scan_duration=round(duration, 2),
             results=results,
             score=score,
+            is_admin=self.is_admin,
         )
         log.info(
             "Scan complete: %d results, score=%d, duration=%.2fs",
@@ -128,26 +144,52 @@ class Scanner:
     def _run_module(self, module) -> list[CheckResult]:
         """Run a single check module and return its results.
 
-        Wraps execution in a try/except so one broken module cannot crash
-        the entire scan.
+        Handles three cases:
+        - Module requires admin but we are not elevated → returns INFO result.
+        - Module runs successfully → returns its results with timing set.
+        - Module raises an unhandled exception → returns a synthetic ERROR result.
         """
+        cat = getattr(module, "CATEGORY", module.__name__)
+
+        # Skip modules that require elevation when running without admin
+        if getattr(module, "REQUIRES_ADMIN", False) and not self.is_admin:
+            log.info(
+                "Skipping %s — requires administrator privileges", module.__name__
+            )
+            return [CheckResult(
+                category=cat,
+                check_name=f"{cat} — requires administrator",
+                status=Status.INFO,
+                severity=Severity.INFO,
+                description="This check module requires administrator privileges.",
+                details=(
+                    "Run WinPosture as Administrator to include these checks."
+                ),
+                remediation="",
+            )]
+
         log.debug("Running %s", module.__name__)
+        t_start = time.monotonic()
         try:
             results = module.run()
             if not isinstance(results, list):
-                raise TypeError(f"run() must return list[CheckResult], got {type(results)}")
-            return results
+                raise TypeError(
+                    f"run() must return list[CheckResult], got {type(results)}"
+                )
         except Exception as exc:
             log.error("Error in %s.run(): %s", module.__name__, exc, exc_info=True)
-            # Return a synthetic ERROR result so the report reflects the failure
-            return [
-                CheckResult(
-                    category=getattr(module, "CATEGORY", module.__name__),
-                    check_name=f"{module.__name__} — module error",
-                    status=Status.ERROR,
-                    severity=Severity.INFO,
-                    description="The check module raised an unhandled exception.",
-                    details=str(exc),
-                    remediation="",
-                )
-            ]
+            results = [CheckResult(
+                category=cat,
+                check_name=f"{cat} — module error",
+                status=Status.ERROR,
+                severity=Severity.INFO,
+                description="The check module raised an unhandled exception.",
+                details=str(exc),
+                remediation="Run with --log-level DEBUG for more detail.",
+            )]
+
+        duration = time.monotonic() - t_start
+        for r in results:
+            r.check_duration = duration
+        log.debug("%s finished in %.2fs", module.__name__, duration)
+        return results

--- a/templates/report.html.j2
+++ b/templates/report.html.j2
@@ -3,96 +3,583 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>WinPosture Report — {{ report.hostname }}</title>
+  <title>WinPosture Security Audit &mdash; {{ report.hostname }}</title>
   <style>
+    /* ── Reset ─────────────────────────────────────────────────── */
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    /* ── Base ──────────────────────────────────────────────────── */
     body {
-      font-family: 'Segoe UI', system-ui, sans-serif;
-      background: #0f0f0f;
-      color: #e0e0e0;
-      padding: 2rem;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                   "Helvetica Neue", Arial, sans-serif;
+      background: #f1f5f9;
+      color: #1e293b;
+      font-size: 14px;
+      line-height: 1.6;
+      -webkit-print-color-adjust: exact;
+      print-color-adjust: exact;
     }
-    h1 { color: #4fc3f7; margin-bottom: 0.25rem; }
-    .meta { color: #888; font-size: 0.9rem; margin-bottom: 2rem; }
-    .score-box {
+
+    /* ── Page wrapper ──────────────────────────────────────────── */
+    .page {
+      max-width: 1100px;
+      margin: 1.5rem auto;
+      background: #ffffff;
+      border-radius: 6px;
+      box-shadow: 0 2px 12px rgba(0,0,0,.10);
+      overflow: hidden;
+    }
+
+    /* ── Report header ─────────────────────────────────────────── */
+    .report-header {
+      background: linear-gradient(135deg, #1e3a5f 0%, #1d4ed8 100%);
+      color: #ffffff;
+      padding: 2rem 2.5rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 2rem;
+    }
+    .header-brand {
+      font-size: .8rem;
+      font-weight: 700;
+      letter-spacing: .12em;
+      text-transform: uppercase;
+      opacity: .75;
+      margin-bottom: .35rem;
+    }
+    .header-title {
+      font-size: 1.55rem;
+      font-weight: 700;
+      margin-bottom: .75rem;
+    }
+    .header-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: .5rem 1.5rem;
+      font-size: .8rem;
+      opacity: .85;
+    }
+    .header-meta span::before { margin-right: .3em; }
+
+    /* ── Score gauge (CSS conic-gradient) ──────────────────────── */
+    .gauge-wrap { text-align: center; flex-shrink: 0; }
+    .gauge {
+      width: 130px;
+      height: 130px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0 auto .4rem;
+      position: relative;
+    }
+    /* Grade colour sets --gauge-color via class */
+    .gauge-A { background: conic-gradient(#059669 {{ report.score }}%, #e2f8ef {{ report.score }}%); }
+    .gauge-B { background: conic-gradient(#16a34a {{ report.score }}%, #e2f5e6 {{ report.score }}%); }
+    .gauge-C { background: conic-gradient(#ca8a04 {{ report.score }}%, #fef9e7 {{ report.score }}%); }
+    .gauge-D { background: conic-gradient(#ea580c {{ report.score }}%, #fff4ec {{ report.score }}%); }
+    .gauge-F { background: conic-gradient(#dc2626 {{ report.score }}%, #fff0f0 {{ report.score }}%); }
+    .gauge-inner {
+      width: 100px;
+      height: 100px;
+      border-radius: 50%;
+      background: #fff;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      line-height: 1;
+    }
+    .gauge-num  { font-size: 1.8rem; font-weight: 800; color: #1e293b; }
+    .gauge-denom { font-size: .7rem; color: #64748b; }
+    .gauge-letter { font-size: 1rem; font-weight: 700; margin-top: .1rem; }
+    .gauge-A .gauge-letter { color: #059669; }
+    .gauge-B .gauge-letter { color: #16a34a; }
+    .gauge-C .gauge-letter { color: #ca8a04; }
+    .gauge-D .gauge-letter { color: #ea580c; }
+    .gauge-F .gauge-letter { color: #dc2626; }
+    .gauge-label {
+      font-size: .8rem;
+      font-weight: 600;
+      color: rgba(255,255,255,.85);
+      letter-spacing: .04em;
+    }
+
+    /* ── Stats bar ─────────────────────────────────────────────── */
+    .stats-bar {
+      display: flex;
+      border-bottom: 1px solid #e2e8f0;
+    }
+    .stat-box {
+      flex: 1;
+      padding: .9rem 1rem;
+      text-align: center;
+      border-right: 1px solid #e2e8f0;
+    }
+    .stat-box:last-child { border-right: none; }
+    .stat-num { font-size: 1.6rem; font-weight: 800; line-height: 1; }
+    .stat-lbl { font-size: .7rem; text-transform: uppercase; letter-spacing: .08em; color: #64748b; margin-top: .15rem; }
+    .stat-total .stat-num { color: #1d4ed8; }
+    .stat-pass  .stat-num { color: #059669; }
+    .stat-fail  .stat-num { color: #dc2626; }
+    .stat-warn  .stat-num { color: #d97706; }
+
+    /* ── Section ───────────────────────────────────────────────── */
+    section { padding: 1.75rem 2.5rem; border-bottom: 1px solid #e2e8f0; }
+    section:last-of-type { border-bottom: none; }
+    .section-title {
+      font-size: .7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: .1em;
+      color: #64748b;
+      margin-bottom: 1rem;
+      padding-bottom: .5rem;
+      border-bottom: 1px solid #e2e8f0;
+    }
+
+    /* ── Executive summary ─────────────────────────────────────── */
+    .exec-summary { color: #374151; max-width: 80ch; margin-bottom: 1.25rem; }
+
+    /* ── Callout ───────────────────────────────────────────────── */
+    .callout {
+      border-radius: 5px;
+      padding: 1rem 1.25rem;
+      margin-bottom: .75rem;
+    }
+    .callout-alert {
+      background: #fef2f2;
+      border: 1px solid #fca5a5;
+      border-left: 4px solid #dc2626;
+    }
+    .callout-title {
+      font-size: .8rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: .06em;
+      color: #991b1b;
+      margin-bottom: .6rem;
+    }
+    .callout ul { list-style: none; display: flex; flex-direction: column; gap: .4rem; }
+    .callout li { display: flex; align-items: flex-start; gap: .5rem; flex-wrap: wrap; font-size: .85rem; color: #374151; }
+    .callout li .rem-text { color: #6b7280; margin-left: .25rem; }
+
+    /* ── Badges ────────────────────────────────────────────────── */
+    .badge {
       display: inline-block;
-      padding: 1rem 2rem;
-      border-radius: 8px;
-      margin-bottom: 2rem;
-      font-size: 1.4rem;
-      font-weight: bold;
+      padding: .12rem .45rem;
+      border-radius: 3px;
+      font-size: .7rem;
+      font-weight: 700;
+      white-space: nowrap;
+      vertical-align: middle;
     }
-    .score-excellent { background: #1b5e20; color: #a5d6a7; }
-    .score-good      { background: #2e7d32; color: #c8e6c9; }
-    .score-fair      { background: #f57f17; color: #fff9c4; }
-    .score-poor      { background: #b71c1c; color: #ffcdd2; }
-    .score-critical  { background: #4a0000; color: #ff8a80; }
-    .summary { display: flex; gap: 1rem; margin-bottom: 2rem; }
-    .stat { padding: 0.75rem 1.5rem; border-radius: 6px; font-weight: bold; }
-    .stat-pass { background: #1b5e20; color: #a5d6a7; }
-    .stat-fail { background: #b71c1c; color: #ffcdd2; }
-    .stat-warn { background: #e65100; color: #ffe0b2; }
-    table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
-    th { background: #1e1e1e; color: #4fc3f7; text-align: left; padding: 0.6rem 0.8rem; }
-    tr:nth-child(even) { background: #1a1a1a; }
-    td { padding: 0.5rem 0.8rem; border-bottom: 1px solid #2a2a2a; vertical-align: top; }
-    .status-PASS  { color: #66bb6a; font-weight: bold; }
-    .status-FAIL  { color: #ef5350; font-weight: bold; }
-    .status-WARN  { color: #ffa726; font-weight: bold; }
-    .status-INFO  { color: #4fc3f7; }
-    .status-ERROR { color: #ce93d8; font-weight: bold; }
-    .sev-CRITICAL { color: #ef5350; font-weight: bold; }
-    .sev-HIGH     { color: #ff7043; }
-    .sev-MEDIUM   { color: #ffa726; }
-    .sev-LOW      { color: #29b6f6; }
-    .sev-INFO     { color: #78909c; }
-    footer { margin-top: 2rem; color: #555; font-size: 0.8rem; }
+    .badge-PASS  { background: #dcfce7; color: #15803d; }
+    .badge-FAIL  { background: #fee2e2; color: #b91c1c; }
+    .badge-WARN  { background: #fef3c7; color: #b45309; }
+    .badge-INFO  { background: #dbeafe; color: #1d4ed8; }
+    .badge-ERROR { background: #f3e8ff; color: #6d28d9; }
+
+    .sev {
+      display: inline-block;
+      padding: .1rem .4rem;
+      border-radius: 3px;
+      font-size: .7rem;
+      font-weight: 600;
+      white-space: nowrap;
+      vertical-align: middle;
+    }
+    .sev-CRITICAL { background: #fef2f2; color: #991b1b; border: 1px solid #fca5a5; }
+    .sev-HIGH     { background: #fff7ed; color: #9a3412; border: 1px solid #fdba74; }
+    .sev-MEDIUM   { background: #fefce8; color: #854d0e; border: 1px solid #fde047; }
+    .sev-LOW      { background: #eff6ff; color: #1e40af; border: 1px solid #93c5fd; }
+    .sev-INFO     { background: #f8fafc; color: #475569; border: 1px solid #cbd5e1; }
+
+    /* ── Category section ──────────────────────────────────────── */
+    .cat-block { margin-bottom: 1.5rem; border: 1px solid #e2e8f0; border-radius: 6px; overflow: hidden; }
+    .cat-block:last-child { margin-bottom: 0; }
+    .cat-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: .65rem 1rem;
+      background: #f8fafc;
+      border-bottom: 1px solid #e2e8f0;
+      cursor: pointer;
+      user-select: none;
+      list-style: none;
+    }
+    .cat-header::-webkit-details-marker { display: none; }
+    .cat-name { font-weight: 600; font-size: .9rem; color: #1e293b; }
+    .cat-meta { display: flex; align-items: center; gap: .75rem; font-size: .8rem; color: #64748b; }
+    .cat-score { font-weight: 700; }
+    .cat-score-A { color: #059669; }
+    .cat-score-B { color: #16a34a; }
+    .cat-score-C { color: #ca8a04; }
+    .cat-score-D { color: #ea580c; }
+    .cat-score-F { color: #dc2626; }
+    .cat-chevron { font-size: .65rem; color: #94a3b8; }
+    details.cat-block[open] .cat-chevron::after { content: "▲"; }
+    details.cat-block:not([open]) .cat-chevron::after { content: "▼"; }
+
+    /* ── Category table ────────────────────────────────────────── */
+    .cat-table { width: 100%; border-collapse: collapse; }
+    .cat-table thead th {
+      background: #f8fafc;
+      font-size: .7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: .06em;
+      color: #64748b;
+      padding: .55rem .75rem;
+      text-align: left;
+      border-bottom: 1px solid #e2e8f0;
+    }
+    .cat-table tbody td {
+      padding: .6rem .75rem;
+      border-bottom: 1px solid #f1f5f9;
+      vertical-align: top;
+      font-size: .85rem;
+    }
+    .cat-table tbody tr:last-child td { border-bottom: none; }
+    .row-FAIL { background: #fff8f8; }
+    .row-WARN { background: #fffdf0; }
+    .row-INFO { background: #f8fbff; }
+    .row-ERROR { background: #fdf8ff; }
+
+    .check-name { font-weight: 500; }
+    .check-desc { font-size: .78rem; color: #64748b; margin-top: .15rem; }
+    .details-text { font-size: .8rem; color: #374151; white-space: pre-wrap; word-break: break-word; }
+
+    details.row-detail summary {
+      list-style: none;
+      cursor: pointer;
+      font-size: .78rem;
+      color: #2563eb;
+    }
+    details.row-detail summary::-webkit-details-marker { display: none; }
+    details.row-detail[open] .rem-block { margin-top: .4rem; }
+    .rem-block {
+      font-size: .78rem;
+      color: #374151;
+      background: #f8fafc;
+      border-left: 3px solid #93c5fd;
+      padding: .4rem .6rem;
+      margin-top: .4rem;
+      border-radius: 0 3px 3px 0;
+    }
+
+    /* ── Detailed findings cards ───────────────────────────────── */
+    .finding {
+      border: 1px solid #e2e8f0;
+      border-radius: 6px;
+      margin-bottom: 1rem;
+      overflow: hidden;
+    }
+    .finding:last-child { margin-bottom: 0; }
+    .finding-FAIL { border-color: #fca5a5; }
+    .finding-WARN { border-color: #fde68a; }
+
+    .finding-header {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: .5rem;
+      padding: .7rem 1rem;
+      background: #f8fafc;
+      border-bottom: 1px solid #e2e8f0;
+    }
+    .finding-FAIL .finding-header { background: #fff5f5; border-bottom-color: #fecaca; }
+    .finding-WARN .finding-header { background: #fffbeb; border-bottom-color: #fde68a; }
+    .finding-title { font-weight: 600; font-size: .9rem; color: #1e293b; margin-left: .25rem; flex: 1; }
+    .finding-cat   { font-size: .75rem; color: #94a3b8; margin-left: auto; }
+
+    .finding-body { padding: 1rem; display: grid; grid-template-columns: 1fr 1fr; gap: .75rem 1.5rem; }
+    .finding-field dt { font-size: .7rem; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; color: #64748b; margin-bottom: .25rem; }
+    .finding-field dd { font-size: .85rem; color: #374151; white-space: pre-wrap; word-break: break-word; }
+    .finding-field.full-width { grid-column: 1 / -1; }
+
+    /* ── Appendix table ────────────────────────────────────────── */
+    .app-table { width: 100%; border-collapse: collapse; }
+    .app-table thead th {
+      background: #f8fafc;
+      font-size: .7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: .06em;
+      color: #64748b;
+      padding: .5rem .75rem;
+      text-align: left;
+      border-bottom: 2px solid #e2e8f0;
+    }
+    .app-table tbody td {
+      padding: .5rem .75rem;
+      border-bottom: 1px solid #f1f5f9;
+      vertical-align: top;
+      font-size: .82rem;
+    }
+    .app-table tbody tr:last-child td { border-bottom: none; }
+
+    /* ── Footer ────────────────────────────────────────────────── */
+    .report-footer {
+      padding: 1rem 2.5rem;
+      background: #f8fafc;
+      border-top: 1px solid #e2e8f0;
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 2rem;
+      flex-wrap: wrap;
+    }
+    .footer-brand { font-size: .78rem; color: #475569; }
+    .footer-brand strong { color: #1e293b; }
+    .footer-disclaimer {
+      font-size: .72rem;
+      color: #94a3b8;
+      max-width: 60ch;
+      font-style: italic;
+    }
+
+    /* ── Print ─────────────────────────────────────────────────── */
+    @media print {
+      @page { size: A4; margin: 15mm 12mm; }
+      body { background: white; font-size: 10pt; }
+      .page { box-shadow: none; border-radius: 0; margin: 0; max-width: 100%; }
+      .report-header { background: #1d4ed8 !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+      section { break-inside: avoid; }
+      .finding { break-inside: avoid; page-break-inside: avoid; }
+      .cat-block { break-inside: avoid; }
+      details.cat-block { display: block; }
+      details.cat-block summary { display: flex; }
+      details.row-detail { display: block; }
+      details.row-detail summary { display: none; }
+      details.row-detail .rem-block { display: block; }
+    }
+
+    @media (max-width: 700px) {
+      .report-header { flex-direction: column; }
+      .stats-bar { flex-wrap: wrap; }
+      .stat-box { min-width: 50%; }
+      .finding-body { grid-template-columns: 1fr; }
+    }
   </style>
 </head>
 <body>
-  <h1>WinPosture Security Audit</h1>
-  <p class="meta">
-    Host: <strong>{{ report.hostname }}</strong> &nbsp;|&nbsp;
-    OS: {{ report.os_version }} &nbsp;|&nbsp;
-    Scanned: {{ report.scan_timestamp.strftime('%Y-%m-%d %H:%M UTC') }} &nbsp;|&nbsp;
-    Duration: {{ "%.1f"|format(report.scan_duration) }}s
-  </p>
+<div class="page">
 
-  <div class="score-box score-{{ score_label | lower }}">
-    {{ report.score }}/100 &mdash; {{ score_label }}
+  {# ── HEADER ──────────────────────────────────────────────────── #}
+  <header class="report-header">
+    <div class="header-left">
+      <div class="header-brand">WinPosture Security Audit Report</div>
+      <div class="header-title">{{ report.hostname }}</div>
+      <div class="header-meta">
+        <span>OS: {{ report.os_version }}</span>
+        <span>Scanned: {{ generated_at }}</span>
+        <span>Duration: {{ "%.1f"|format(report.scan_duration) }}s</span>
+      </div>
+    </div>
+    <div class="gauge-wrap">
+      <div class="gauge gauge-{{ score_grade }}">
+        <div class="gauge-inner">
+          <span class="gauge-num">{{ report.score }}</span>
+          <span class="gauge-denom">/100</span>
+          <span class="gauge-letter">{{ score_grade }}</span>
+        </div>
+      </div>
+      <div class="gauge-label">{{ score_label }}</div>
+    </div>
+  </header>
+
+  {# ── STATS BAR ────────────────────────────────────────────────── #}
+  <div class="stats-bar">
+    <div class="stat-box stat-total">
+      <div class="stat-num">{{ report.results | length }}</div>
+      <div class="stat-lbl">Total Checks</div>
+    </div>
+    <div class="stat-box stat-pass">
+      <div class="stat-num">{{ report.pass_count }}</div>
+      <div class="stat-lbl">Passed</div>
+    </div>
+    <div class="stat-box stat-fail">
+      <div class="stat-num">{{ report.fail_count }}</div>
+      <div class="stat-lbl">Failed</div>
+    </div>
+    <div class="stat-box stat-warn">
+      <div class="stat-num">{{ report.warn_count }}</div>
+      <div class="stat-lbl">Warnings</div>
+    </div>
   </div>
 
-  <div class="summary">
-    <div class="stat stat-pass">PASS: {{ report.pass_count }}</div>
-    <div class="stat stat-fail">FAIL: {{ report.fail_count }}</div>
-    <div class="stat stat-warn">WARN: {{ report.warn_count }}</div>
-  </div>
+  {# ── EXECUTIVE SUMMARY ────────────────────────────────────────── #}
+  <section>
+    <h2 class="section-title">Executive Summary</h2>
+    <p class="exec-summary">{{ executive_summary }}</p>
 
-  <table>
-    <thead>
-      <tr>
-        <th>Category</th>
-        <th>Check</th>
-        <th>Status</th>
-        <th>Severity</th>
-        <th>Details</th>
-        <th>Remediation</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for result in report.results | sort(attribute='category') %}
-      <tr>
-        <td>{{ result.category }}</td>
-        <td title="{{ result.description }}">{{ result.check_name }}</td>
-        <td class="status-{{ result.status.value }}">{{ result.status.value }}</td>
-        <td class="sev-{{ result.severity.value }}">{{ result.severity.value }}</td>
-        <td>{{ result.details }}</td>
-        <td>{{ result.remediation }}</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+    {% if top_findings %}
+    <div class="callout callout-alert">
+      <div class="callout-title">Critical &amp; High Priority Findings</div>
+      <ul>
+        {% for f in top_findings %}
+        <li>
+          <span class="badge badge-{{ f.status.value }}">{{ f.status.value }}</span>
+          <span class="sev sev-{{ f.severity.value }}">{{ f.severity.value }}</span>
+          <strong>{{ f.check_name }}</strong>
+          {% if f.remediation %}
+          <span class="rem-text">&mdash; {{ f.remediation }}</span>
+          {% endif %}
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
+  </section>
 
-  <footer>Generated by WinPosture &mdash; <a href="https://github.com/yourname/winposture" style="color:#4fc3f7;">github.com/yourname/winposture</a></footer>
+  {# ── CATEGORY BREAKDOWN ───────────────────────────────────────── #}
+  <section>
+    <h2 class="section-title">Category Breakdown</h2>
+    {% for cat in category_data %}
+    <details class="cat-block" open>
+      <summary class="cat-header">
+        <span class="cat-name">{{ cat.name }}</span>
+        <span class="cat-meta">
+          {% if cat.fail_count %}<span class="badge badge-FAIL">{{ cat.fail_count }} failed</span>{% endif %}
+          {% if cat.warn_count %}<span class="badge badge-WARN">{{ cat.warn_count }} warn</span>{% endif %}
+          <span class="cat-score cat-score-{{ cat.grade }}">{{ cat.score }}/100 &nbsp;{{ cat.grade }}</span>
+          <span class="cat-chevron"></span>
+        </span>
+      </summary>
+      <table class="cat-table">
+        <thead>
+          <tr>
+            <th style="width:6%">Status</th>
+            <th style="width:8%">Severity</th>
+            <th style="width:28%">Check</th>
+            <th>Details</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for r in cat.results %}
+          <tr class="row-{{ r.status.value }}">
+            <td><span class="badge badge-{{ r.status.value }}">{{ r.status.value }}</span></td>
+            <td><span class="sev sev-{{ r.severity.value }}">{{ r.severity.value }}</span></td>
+            <td>
+              <div class="check-name">{{ r.check_name }}</div>
+              <div class="check-desc">{{ r.description }}</div>
+            </td>
+            <td>
+              <div class="details-text">{{ r.details }}</div>
+              {% if r.remediation %}
+              <details class="row-detail">
+                <summary>&#9656; Remediation</summary>
+                <div class="rem-block">{{ r.remediation }}</div>
+              </details>
+              {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </details>
+    {% endfor %}
+  </section>
+
+  {# ── DETAILED FINDINGS ────────────────────────────────────────── #}
+  {% if fail_warn_results %}
+  <section>
+    <h2 class="section-title">Detailed Findings</h2>
+    {% for r in fail_warn_results %}
+    <div class="finding finding-{{ r.status.value }}">
+      <div class="finding-header">
+        <span class="badge badge-{{ r.status.value }}">{{ r.status.value }}</span>
+        <span class="sev sev-{{ r.severity.value }}">{{ r.severity.value }}</span>
+        <span class="finding-title">{{ r.check_name }}</span>
+        <span class="finding-cat">{{ r.category }}</span>
+      </div>
+      <div class="finding-body">
+        <div class="finding-field">
+          <dt>Description</dt>
+          <dd>{{ r.description }}</dd>
+        </div>
+        <div class="finding-field">
+          <dt>Finding</dt>
+          <dd>{{ r.details }}</dd>
+        </div>
+        {% if r.remediation %}
+        <div class="finding-field full-width">
+          <dt>Remediation</dt>
+          <dd>{{ r.remediation }}</dd>
+        </div>
+        {% endif %}
+      </div>
+    </div>
+    {% endfor %}
+  </section>
+  {% endif %}
+
+  {# ── APPENDIX A — SYSTEM INVENTORY ───────────────────────────── #}
+  {% if info_results %}
+  <section>
+    <h2 class="section-title">Appendix A &mdash; System Inventory</h2>
+    <table class="app-table">
+      <thead>
+        <tr>
+          <th>Category</th>
+          <th>Item</th>
+          <th>Details</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for r in info_results | sort(attribute='category') %}
+        <tr>
+          <td>{{ r.category }}</td>
+          <td>{{ r.check_name }}</td>
+          <td style="white-space: pre-wrap; word-break: break-word;">{{ r.details }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+  {% endif %}
+
+  {# ── APPENDIX B — FULL CHECK LIST ─────────────────────────────── #}
+  <section>
+    <h2 class="section-title">Appendix B &mdash; Full Check List</h2>
+    <table class="app-table">
+      <thead>
+        <tr>
+          <th style="width:5%">Status</th>
+          <th style="width:8%">Severity</th>
+          <th style="width:16%">Category</th>
+          <th>Check Name</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for r in report.results | sort(attribute='category') %}
+        <tr>
+          <td><span class="badge badge-{{ r.status.value }}">{{ r.status.value }}</span></td>
+          <td><span class="sev sev-{{ r.severity.value }}">{{ r.severity.value }}</span></td>
+          <td>{{ r.category }}</td>
+          <td>{{ r.check_name }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+
+  {# ── FOOTER ───────────────────────────────────────────────────── #}
+  <footer class="report-footer">
+    <div class="footer-brand">
+      Generated by <strong>WinPosture v{{ version }}</strong>
+      on {{ generated_at }}
+    </div>
+    <div class="footer-disclaimer">
+      This report is for informational purposes only. It does not constitute
+      a complete security assessment. Review all findings with a qualified
+      security professional before taking remediation actions.
+    </div>
+  </footer>
+
+</div>
 </body>
 </html>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,210 @@
+"""Tests for winposture.cli — argument parsing and main() dispatch."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from winposture.cli import build_parser
+
+
+# ---------------------------------------------------------------------------
+# Argument parser
+# ---------------------------------------------------------------------------
+
+class TestBuildParser:
+    def _parse(self, *args: str):
+        return build_parser().parse_args(list(args))
+
+    def test_defaults(self):
+        ns = self._parse()
+        assert ns.html is None
+        assert ns.json is None
+        assert ns.category is None
+        assert ns.verbose is False
+        assert ns.no_color is False
+        assert ns.log_level == "WARNING"
+
+    def test_html_flag(self):
+        ns = self._parse("--html", "report.html")
+        assert ns.html == "report.html"
+
+    def test_json_flag(self):
+        ns = self._parse("--json", "out.json")
+        assert ns.json == "out.json"
+
+    def test_category_flag(self):
+        ns = self._parse("--category", "firewall,encryption")
+        assert ns.category == "firewall,encryption"
+
+    def test_verbose_flag(self):
+        ns = self._parse("--verbose")
+        assert ns.verbose is True
+
+    def test_no_color_flag(self):
+        ns = self._parse("--no-color")
+        assert ns.no_color is True
+
+    def test_log_level_debug(self):
+        ns = self._parse("--log-level", "DEBUG")
+        assert ns.log_level == "DEBUG"
+
+    def test_log_level_invalid(self):
+        with pytest.raises(SystemExit):
+            self._parse("--log-level", "VERBOSE")
+
+    def test_all_flags_together(self):
+        ns = self._parse(
+            "--html", "r.html",
+            "--json", "r.json",
+            "--category", "firewall",
+            "--verbose",
+            "--no-color",
+            "--log-level", "DEBUG",
+        )
+        assert ns.html == "r.html"
+        assert ns.json == "r.json"
+        assert ns.category == "firewall"
+        assert ns.verbose is True
+        assert ns.no_color is True
+        assert ns.log_level == "DEBUG"
+
+    def test_version_exits(self):
+        with pytest.raises(SystemExit) as exc_info:
+            self._parse("--version")
+        assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# main() dispatch
+# ---------------------------------------------------------------------------
+
+class TestMain:
+    # Scanner/Reporter/is_admin are lazy-imported inside main(), so we patch
+    # them in their source modules (not in winposture.cli).
+    _SCANNER_PATH  = "winposture.scanner.Scanner"
+    _REPORTER_PATH = "winposture.reporter.Reporter"
+    _ADMIN_PATH    = "winposture.utils.is_admin"
+
+    def _run_main(self, argv=None, is_admin=False):
+        """Run main() with mocked scanner, reporter, and is_admin."""
+        mock_report = MagicMock()
+        mock_report.fail_count = 0
+        mock_report.error_count = 0
+
+        mock_scanner_instance = MagicMock()
+        mock_scanner_instance.is_admin = is_admin
+
+        mock_reporter_instance = MagicMock()
+        mock_reporter_instance.run_with_progress.return_value = mock_report
+
+        argv = argv or []
+        with (
+            patch("sys.argv", ["winposture"] + argv),
+            patch(self._SCANNER_PATH, return_value=mock_scanner_instance) as MockScanner,
+            patch(self._REPORTER_PATH, return_value=mock_reporter_instance) as MockReporter,
+            patch(self._ADMIN_PATH, return_value=is_admin),
+        ):
+            from winposture import cli as cli_mod
+            import importlib
+            importlib.reload(cli_mod)
+            cli_mod.main()
+
+        return MockScanner, mock_reporter_instance, mock_report
+
+    def test_scanner_created_with_is_admin_false(self):
+        MockScanner, _, _ = self._run_main(is_admin=False)
+        assert MockScanner.called
+
+    def test_scanner_created_with_is_admin_true(self):
+        MockScanner, _, _ = self._run_main(is_admin=True)
+        call_kwargs = MockScanner.call_args[1]
+        assert call_kwargs.get("is_admin") is True
+
+    def test_html_report_saved_when_flag_provided(self):
+        _, mock_reporter, _ = self._run_main(["--html", "out.html"])
+        mock_reporter.generate_html_report.assert_called_once()
+
+    def test_json_report_saved_when_flag_provided(self):
+        _, mock_reporter, _ = self._run_main(["--json", "out.json"])
+        mock_reporter.generate_json_report.assert_called_once()
+
+    def test_no_html_by_default(self):
+        _, mock_reporter, _ = self._run_main()
+        mock_reporter.generate_html_report.assert_not_called()
+
+    def test_no_json_by_default(self):
+        _, mock_reporter, _ = self._run_main()
+        mock_reporter.generate_json_report.assert_not_called()
+
+    def test_print_terminal_always_called(self):
+        _, mock_reporter, _ = self._run_main()
+        mock_reporter.print_terminal.assert_called_once()
+
+    def test_exit_1_on_failures(self):
+        mock_report = MagicMock()
+        mock_report.fail_count = 3
+        mock_report.error_count = 0
+        mock_scanner = MagicMock()
+        mock_scanner.is_admin = False
+        mock_reporter = MagicMock()
+        mock_reporter.run_with_progress.return_value = mock_report
+
+        with (
+            patch("sys.argv", ["winposture"]),
+            patch(self._SCANNER_PATH, return_value=mock_scanner),
+            patch(self._REPORTER_PATH, return_value=mock_reporter),
+            patch(self._ADMIN_PATH, return_value=False),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            from winposture import cli as cli_mod
+            import importlib
+            importlib.reload(cli_mod)
+            cli_mod.main()
+
+        assert exc_info.value.code == 1
+
+    def test_exit_0_on_clean_scan(self):
+        mock_report = MagicMock()
+        mock_report.fail_count = 0
+        mock_report.error_count = 0
+        mock_scanner = MagicMock()
+        mock_scanner.is_admin = False
+        mock_reporter = MagicMock()
+        mock_reporter.run_with_progress.return_value = mock_report
+
+        with (
+            patch("sys.argv", ["winposture"]),
+            patch(self._SCANNER_PATH, return_value=mock_scanner),
+            patch(self._REPORTER_PATH, return_value=mock_reporter),
+            patch(self._ADMIN_PATH, return_value=False),
+        ):
+            from winposture import cli as cli_mod
+            import importlib
+            importlib.reload(cli_mod)
+            cli_mod.main()  # Should NOT raise SystemExit
+
+    def test_category_filter_passed_to_scanner(self):
+        MockScanner, _, _ = self._run_main(["--category", "firewall,encryption"])
+        call_kwargs = MockScanner.call_args[1]
+        assert call_kwargs.get("categories") == ["firewall", "encryption"]
+
+    def test_verbose_passed_to_reporter(self):
+        mock_report = MagicMock(fail_count=0, error_count=0)
+        mock_scanner = MagicMock(is_admin=False)
+        mock_reporter = MagicMock()
+        mock_reporter.run_with_progress.return_value = mock_report
+
+        with (
+            patch("sys.argv", ["winposture", "--verbose"]),
+            patch(self._SCANNER_PATH, return_value=mock_scanner),
+            patch(self._REPORTER_PATH, return_value=mock_reporter) as MockReporter,
+            patch(self._ADMIN_PATH, return_value=False),
+        ):
+            from winposture import cli as cli_mod
+            import importlib
+            importlib.reload(cli_mod)
+            cli_mod.main()
+
+        MockReporter.assert_called_once_with(verbose=True, no_color=False)

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -1,0 +1,261 @@
+"""Tests for winposture.reporter — HTML/JSON generation and executive summary."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from winposture.models import AuditReport, CheckResult, Severity, Status
+from winposture.reporter import Reporter
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_report(
+    score: int = 80,
+    is_admin: bool = True,
+    extra_results: list[CheckResult] | None = None,
+) -> AuditReport:
+    base = [
+        CheckResult("Firewall", "Domain Profile",  Status.PASS, Severity.HIGH,   "desc", "ok"),
+        CheckResult("Firewall", "Public Profile",  Status.FAIL, Severity.CRITICAL,"desc", "off", "Enable it"),
+        CheckResult("Services", "Risky Services",  Status.WARN, Severity.MEDIUM,  "desc", "SNMP running", "Disable SNMP"),
+        CheckResult("OS",       "OS Version",       Status.INFO, Severity.INFO,    "desc", "Win11 22621"),
+    ]
+    results = base + (extra_results or [])
+    return AuditReport(
+        hostname="TEST-PC",
+        os_version="Windows 11 Pro 10.0.22621",
+        scan_timestamp=datetime(2026, 3, 17, 12, 0, 0, tzinfo=timezone.utc),
+        scan_duration=2.5,
+        results=results,
+        score=score,
+        is_admin=is_admin,
+    )
+
+
+# ---------------------------------------------------------------------------
+# HTML report generation
+# ---------------------------------------------------------------------------
+
+class TestGenerateHtmlReport:
+    def _generate(self, report: AuditReport) -> str:
+        """Generate the HTML report and return its content."""
+        reporter = Reporter()
+        with tempfile.NamedTemporaryFile(suffix=".html", delete=False) as f:
+            path = f.name
+        try:
+            reporter.generate_html_report(report, path)
+            return Path(path).read_text(encoding="utf-8")
+        finally:
+            os.unlink(path)
+
+    def test_file_created(self):
+        reporter = Reporter()
+        report = _make_report()
+        with tempfile.NamedTemporaryFile(suffix=".html", delete=False) as f:
+            path = f.name
+        try:
+            reporter.generate_html_report(report, path)
+            assert os.path.exists(path)
+            assert os.path.getsize(path) > 5000
+        finally:
+            os.unlink(path)
+
+    def test_valid_html_structure(self):
+        html = self._generate(_make_report())
+        assert "<!DOCTYPE html>" in html
+        assert "<html" in html
+        assert "</html>" in html
+        assert "<head>" in html
+        assert "<body>" in html
+
+    def test_hostname_present(self):
+        html = self._generate(_make_report())
+        assert "TEST-PC" in html
+
+    def test_score_present(self):
+        html = self._generate(_make_report(score=80))
+        assert "80" in html
+
+    def test_grade_present(self):
+        html = self._generate(_make_report(score=80))
+        assert "Good" in html  # B = Good
+
+    def test_pass_fail_warn_counts(self):
+        html = self._generate(_make_report())
+        assert "1" in html   # 1 PASS, 1 FAIL, 1 WARN, 1 INFO
+
+    def test_category_breakdown_present(self):
+        html = self._generate(_make_report())
+        assert "Category Breakdown" in html
+        assert "Firewall" in html
+
+    def test_detailed_findings_present(self):
+        html = self._generate(_make_report())
+        assert "Detailed Findings" in html
+
+    def test_appendix_present(self):
+        html = self._generate(_make_report())
+        assert "Appendix" in html
+
+    def test_no_external_dependencies(self):
+        html = self._generate(_make_report())
+        assert "cdn." not in html
+        assert "googleapis.com" not in html
+        assert "<script src" not in html
+
+    def test_print_css_present(self):
+        html = self._generate(_make_report())
+        assert "@media print" in html
+
+    def test_version_in_footer(self):
+        html = self._generate(_make_report())
+        assert "WinPosture" in html
+
+    def test_executive_summary_present(self):
+        html = self._generate(_make_report())
+        assert "Executive Summary" in html
+        assert "TEST-PC" in html  # hostname in summary
+
+    def test_top_findings_callout_present_when_critical(self):
+        html = self._generate(_make_report())
+        assert "Critical" in html or "High Priority" in html
+
+    def test_info_appendix_present(self):
+        html = self._generate(_make_report())
+        assert "Appendix A" in html
+
+    def test_full_checklist_present(self):
+        html = self._generate(_make_report())
+        assert "Appendix B" in html
+
+
+# ---------------------------------------------------------------------------
+# JSON report generation
+# ---------------------------------------------------------------------------
+
+class TestGenerateJsonReport:
+    def _generate_json(self, report: AuditReport) -> dict:
+        reporter = Reporter()
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = f.name
+        try:
+            reporter.generate_json_report(report, path)
+            return json.loads(Path(path).read_text(encoding="utf-8"))
+        finally:
+            os.unlink(path)
+
+    def test_file_created(self):
+        reporter = Reporter()
+        report = _make_report()
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = f.name
+        try:
+            reporter.generate_json_report(report, path)
+            assert os.path.exists(path)
+        finally:
+            os.unlink(path)
+
+    def test_valid_json(self):
+        data = self._generate_json(_make_report())
+        assert isinstance(data, dict)
+
+    def test_hostname_field(self):
+        data = self._generate_json(_make_report())
+        assert data["hostname"] == "TEST-PC"
+
+    def test_score_field(self):
+        data = self._generate_json(_make_report(score=75))
+        assert data["score"] == 75
+
+    def test_results_array(self):
+        data = self._generate_json(_make_report())
+        assert "results" in data
+        assert isinstance(data["results"], list)
+        assert len(data["results"]) > 0
+
+    def test_result_fields_present(self):
+        data = self._generate_json(_make_report())
+        r = data["results"][0]
+        for field in ("category", "check_name", "status", "severity", "description", "details"):
+            assert field in r, f"Missing field: {field}"
+
+    def test_scan_timestamp_serialized(self):
+        data = self._generate_json(_make_report())
+        assert "scan_timestamp" in data
+        assert "2026" in data["scan_timestamp"]
+
+    def test_is_admin_field(self):
+        data = self._generate_json(_make_report(is_admin=True))
+        assert data["is_admin"] is True
+
+
+# ---------------------------------------------------------------------------
+# Executive summary generation
+# ---------------------------------------------------------------------------
+
+class TestBuildExecutiveSummary:
+    def _summary(self, results: list[CheckResult], score: int = 80) -> str:
+        report = AuditReport(
+            hostname="MYPC",
+            os_version="Win11",
+            scan_timestamp=datetime.now(tz=timezone.utc),
+            scan_duration=1.0,
+            results=results,
+            score=score,
+        )
+        return Reporter()._build_executive_summary(report)
+
+    def test_contains_hostname(self):
+        s = self._summary([])
+        assert "MYPC" in s
+
+    def test_contains_score(self):
+        s = self._summary([], score=85)
+        assert "85" in s
+
+    def test_clean_machine_mentions_all_passed(self):
+        results = [
+            CheckResult("Firewall", "FW", Status.PASS, Severity.HIGH, "d", "ok"),
+        ]
+        s = self._summary(results, score=100)
+        assert "pass" in s.lower() or "no failure" in s.lower()
+
+    def test_critical_failures_called_out(self):
+        results = [
+            CheckResult("Firewall", "FW", Status.FAIL, Severity.CRITICAL, "d", "off", "fix"),
+        ]
+        s = self._summary(results, score=85)
+        assert "critical" in s.lower()
+
+    def test_top_categories_mentioned(self):
+        results = [
+            CheckResult("Firewall", "FW1", Status.FAIL, Severity.HIGH, "d", "off", "fix"),
+            CheckResult("Firewall", "FW2", Status.WARN, Severity.MEDIUM, "d", "ok", "fix"),
+        ]
+        s = self._summary(results, score=75)
+        assert "Firewall" in s
+
+    def test_remediation_advice_included(self):
+        results = [
+            CheckResult("Antivirus", "AV", Status.FAIL, Severity.CRITICAL, "d", "off", "fix"),
+        ]
+        s = self._summary(results, score=60)
+        assert "remediat" in s.lower() or "priorit" in s.lower()
+
+    def test_fail_count_mentioned(self):
+        results = [
+            CheckResult("X", "C1", Status.FAIL, Severity.HIGH, "d", "d", "fix"),
+            CheckResult("X", "C2", Status.FAIL, Severity.MEDIUM, "d", "d", "fix"),
+        ]
+        s = self._summary(results, score=70)
+        assert "2" in s or "failed" in s.lower()

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,239 @@
+"""Tests for winposture.scanner — admin detection, REQUIRES_ADMIN skipping, timing."""
+
+from __future__ import annotations
+
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from winposture.models import AuditReport, CheckResult, Severity, Status
+from winposture.scanner import Scanner
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_module(
+    name: str = "test_mod",
+    category: str = "Test",
+    results: list[CheckResult] | None = None,
+    requires_admin: bool = False,
+    run_raises: Exception | None = None,
+) -> ModuleType:
+    """Return a minimal fake check module."""
+    mod = ModuleType(name)
+    mod.CATEGORY = category
+    if requires_admin:
+        mod.REQUIRES_ADMIN = True
+
+    if run_raises is not None:
+        def _run():
+            raise run_raises
+        mod.run = _run
+    else:
+        _results = results or [CheckResult(
+            category=category,
+            check_name="Dummy Check",
+            status=Status.PASS,
+            severity=Severity.LOW,
+            description="desc",
+            details="ok",
+        )]
+        mod.run = lambda: _results
+
+    return mod
+
+
+def _pass_result(category: str = "Test") -> CheckResult:
+    return CheckResult(
+        category=category, check_name="x", status=Status.PASS,
+        severity=Severity.LOW, description="d", details="ok",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Basic construction
+# ---------------------------------------------------------------------------
+
+class TestScannerInit:
+    def test_defaults(self):
+        s = Scanner()
+        assert s.categories is None
+        assert s.is_admin is False
+
+    def test_categories_stored(self):
+        s = Scanner(categories=["firewall"])
+        assert s.categories == ["firewall"]
+
+    def test_is_admin_stored(self):
+        s = Scanner(is_admin=True)
+        assert s.is_admin is True
+
+
+# ---------------------------------------------------------------------------
+# REQUIRES_ADMIN skipping
+# ---------------------------------------------------------------------------
+
+class TestRequiresAdminSkipping:
+    def test_admin_module_skipped_when_not_admin(self):
+        scanner = Scanner(is_admin=False)
+        mod = _make_module(category="Encryption", requires_admin=True)
+        results = scanner._run_module(mod)
+        assert len(results) == 1
+        assert results[0].status == Status.INFO
+        assert "administrator" in results[0].details.lower()
+
+    def test_admin_module_runs_when_admin(self):
+        scanner = Scanner(is_admin=True)
+        expected = [_pass_result("Encryption")]
+        mod = _make_module(category="Encryption", results=expected, requires_admin=True)
+        results = scanner._run_module(mod)
+        assert results == expected
+
+    def test_non_admin_module_always_runs(self):
+        scanner = Scanner(is_admin=False)
+        expected = [_pass_result()]
+        mod = _make_module(results=expected)
+        results = scanner._run_module(mod)
+        assert results == expected
+
+    def test_skipped_result_category_matches_module(self):
+        scanner = Scanner(is_admin=False)
+        mod = _make_module(category="File Sharing", requires_admin=True)
+        results = scanner._run_module(mod)
+        assert results[0].category == "File Sharing"
+
+    def test_no_requires_admin_attribute_runs(self):
+        """Module without REQUIRES_ADMIN attribute should always run."""
+        scanner = Scanner(is_admin=False)
+        mod = _make_module()
+        # Ensure the attribute is absent
+        assert not hasattr(mod, "REQUIRES_ADMIN")
+        results = scanner._run_module(mod)
+        assert results[0].status == Status.PASS
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+class TestModuleErrorHandling:
+    def test_exception_returns_error_status(self):
+        scanner = Scanner()
+        mod = _make_module(run_raises=RuntimeError("boom"))
+        results = scanner._run_module(mod)
+        assert len(results) == 1
+        assert results[0].status == Status.ERROR
+        assert "boom" in results[0].details
+
+    def test_exception_category_from_module(self):
+        scanner = Scanner()
+        mod = _make_module(category="Firewall", run_raises=ValueError("oops"))
+        results = scanner._run_module(mod)
+        assert results[0].category == "Firewall"
+
+    def test_wrong_return_type_becomes_error(self):
+        scanner = Scanner()
+        mod = ModuleType("bad_mod")
+        mod.CATEGORY = "Test"
+        mod.run = lambda: "not a list"
+        results = scanner._run_module(mod)
+        assert results[0].status == Status.ERROR
+
+
+# ---------------------------------------------------------------------------
+# Timing
+# ---------------------------------------------------------------------------
+
+class TestCheckTiming:
+    def test_check_duration_set_on_results(self):
+        scanner = Scanner()
+        mod = _make_module(results=[_pass_result(), _pass_result()])
+        results = scanner._run_module(mod)
+        assert all(r.check_duration >= 0.0 for r in results)
+
+    def test_check_duration_non_negative(self):
+        scanner = Scanner()
+        mod = _make_module()
+        results = scanner._run_module(mod)
+        assert results[0].check_duration >= 0.0
+
+    def test_skipped_module_duration_zero(self):
+        scanner = Scanner(is_admin=False)
+        mod = _make_module(requires_admin=True)
+        results = scanner._run_module(mod)
+        # Skipped modules get no timing
+        assert results[0].check_duration == 0.0
+
+
+# ---------------------------------------------------------------------------
+# report.is_admin reflects scanner.is_admin
+# ---------------------------------------------------------------------------
+
+class TestReportAdminFlag:
+    def _run_with_mocks(self, is_admin: bool) -> AuditReport:
+        scanner = Scanner(is_admin=is_admin)
+        mod = _make_module()
+        with patch.object(scanner, "_discover_modules", return_value=[mod]):
+            return scanner.run()
+
+    def test_report_is_admin_true(self):
+        report = self._run_with_mocks(is_admin=True)
+        assert report.is_admin is True
+
+    def test_report_is_admin_false(self):
+        report = self._run_with_mocks(is_admin=False)
+        assert report.is_admin is False
+
+
+# ---------------------------------------------------------------------------
+# error_count property
+# ---------------------------------------------------------------------------
+
+class TestErrorCount:
+    def test_error_count_in_report(self):
+        scanner = Scanner()
+        mod = _make_module(run_raises=RuntimeError("fail"))
+        with patch.object(scanner, "_discover_modules", return_value=[mod]):
+            report = scanner.run()
+        assert report.error_count == 1
+
+    def test_error_count_zero_when_clean(self):
+        scanner = Scanner()
+        mod = _make_module()
+        with patch.object(scanner, "_discover_modules", return_value=[mod]):
+            report = scanner.run()
+        assert report.error_count == 0
+
+
+# ---------------------------------------------------------------------------
+# on_module_start callback
+# ---------------------------------------------------------------------------
+
+class TestOnModuleStart:
+    def test_callback_called_for_each_module(self):
+        scanner = Scanner()
+        mods = [_make_module(f"mod_{i}", f"Cat{i}") for i in range(3)]
+        called = []
+
+        def _cb(m):
+            called.append(m.__name__)
+
+        with patch.object(scanner, "_discover_modules", return_value=mods):
+            scanner.run(on_module_start=_cb)
+
+        assert called == [m.__name__ for m in mods]
+
+    def test_callback_exception_does_not_abort_scan(self):
+        scanner = Scanner()
+        mod = _make_module()
+
+        def _bad_cb(m):
+            raise RuntimeError("callback exploded")
+
+        with patch.object(scanner, "_discover_modules", return_value=[mod]):
+            report = scanner.run(on_module_start=_bad_cb)
+
+        assert len(report.results) == 1

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -1,0 +1,352 @@
+"""Integration-style scenario tests — mock full scan environments and verify scores."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from winposture.models import AuditReport, CheckResult, Severity, Status
+from winposture.scoring import calculate_score, score_grade
+
+
+# ---------------------------------------------------------------------------
+# Scenario builder helpers
+# ---------------------------------------------------------------------------
+
+def _r(
+    category: str,
+    name: str,
+    status: Status,
+    severity: Severity,
+    details: str = "",
+    remediation: str = "",
+) -> CheckResult:
+    return CheckResult(
+        category=category,
+        check_name=name,
+        status=status,
+        severity=severity,
+        description=f"Check: {name}",
+        details=details or status.value,
+        remediation=remediation,
+    )
+
+
+def _report(results: list[CheckResult], is_admin: bool = True) -> AuditReport:
+    score = calculate_score(results)
+    return AuditReport(
+        hostname="SCENARIO-PC",
+        os_version="Windows 11 Pro 10.0.22621",
+        scan_timestamp=datetime.now(tz=timezone.utc),
+        scan_duration=5.0,
+        results=results,
+        score=score,
+        is_admin=is_admin,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: Clean Windows 11 Pro domain-joined machine
+# ---------------------------------------------------------------------------
+
+def _clean_win11_pro_results() -> list[CheckResult]:
+    """Simulate a well-configured Windows 11 Pro workstation."""
+    return [
+        # Firewall — all three profiles enabled
+        _r("Firewall", "Domain Profile",  Status.PASS, Severity.HIGH),
+        _r("Firewall", "Private Profile", Status.PASS, Severity.HIGH),
+        _r("Firewall", "Public Profile",  Status.PASS, Severity.HIGH),
+        # Antivirus — Defender active, definitions current
+        _r("Antivirus", "Windows Defender Status",   Status.PASS, Severity.CRITICAL),
+        _r("Antivirus", "Definition Age",             Status.PASS, Severity.HIGH),
+        _r("Antivirus", "Third-party AV",             Status.INFO, Severity.INFO),
+        # Encryption — BitLocker on OS drive
+        _r("Encryption", "BitLocker — C:", Status.PASS, Severity.HIGH),
+        # Updates — current
+        _r("Patching", "Last Windows Update",    Status.PASS, Severity.CRITICAL),
+        _r("Patching", "WU Service",              Status.PASS, Severity.MEDIUM),
+        _r("Patching", "Pending Updates",         Status.PASS, Severity.HIGH),
+        # Accounts — minimal admins, guest disabled
+        _r("Accounts", "Guest Account",           Status.PASS, Severity.HIGH),
+        _r("Accounts", "Built-in Administrator",  Status.PASS, Severity.MEDIUM),
+        _r("Accounts", "Local Administrators",    Status.PASS, Severity.MEDIUM),
+        _r("Accounts", "Password Length",         Status.PASS, Severity.MEDIUM),
+        _r("Accounts", "Account Lockout",         Status.PASS, Severity.MEDIUM),
+        _r("Accounts", "Password Complexity",     Status.PASS, Severity.MEDIUM),
+        # UAC — maximum setting
+        _r("UAC", "UAC Enabled",        Status.PASS, Severity.CRITICAL),
+        _r("UAC", "UAC Consent Level",  Status.PASS, Severity.HIGH),
+        # SMB — v1 disabled, signing required
+        _r("File Sharing", "SMBv1 Disabled",      Status.PASS, Severity.CRITICAL),
+        _r("File Sharing", "SMB Signing",          Status.PASS, Severity.HIGH),
+        _r("File Sharing", "SMB Encryption",       Status.INFO, Severity.LOW),
+        # RDP — disabled or NLA enforced
+        _r("RDP", "RDP Enabled",  Status.INFO, Severity.HIGH),
+        _r("RDP", "NLA Required", Status.PASS, Severity.HIGH),
+        # PowerShell — logging enabled
+        _r("PowerShell", "Execution Policy",    Status.PASS, Severity.HIGH),
+        _r("PowerShell", "Script Block Logging",Status.PASS, Severity.MEDIUM),
+        _r("PowerShell", "Module Logging",      Status.PASS, Severity.MEDIUM),
+        _r("PowerShell", "PSv2 Installed",      Status.PASS, Severity.MEDIUM),
+        # Network — LLMNR disabled, no risky ports
+        _r("Network", "LLMNR Disabled",  Status.PASS, Severity.MEDIUM),
+        _r("Network", "NetBIOS",         Status.PASS, Severity.MEDIUM),
+        # Services — no risky services
+        _r("Services", "Risky Services",    Status.PASS, Severity.MEDIUM),
+        _r("Services", "Unquoted Paths",    Status.PASS, Severity.HIGH),
+        # Hardening
+        _r("Hardening", "AutoPlay Disabled",  Status.PASS, Severity.MEDIUM),
+        _r("Hardening", "WinRM",              Status.PASS, Severity.MEDIUM),
+        _r("Hardening", "Audit Policy",       Status.PASS, Severity.MEDIUM),
+        _r("Hardening", "Screen Lock",        Status.PASS, Severity.MEDIUM),
+    ]
+
+
+class TestCleanWin11ProDomainMachine:
+    def test_score_is_grade_a(self):
+        results = _clean_win11_pro_results()
+        score = calculate_score(results)
+        letter, _ = score_grade(score)
+        assert letter == "A", f"Expected A grade but got {letter} (score={score})"
+
+    def test_score_at_least_90(self):
+        score = calculate_score(_clean_win11_pro_results())
+        assert score >= 90, f"Expected score >= 90, got {score}"
+
+    def test_no_failures(self):
+        report = _report(_clean_win11_pro_results())
+        assert report.fail_count == 0
+
+    def test_no_errors(self):
+        report = _report(_clean_win11_pro_results())
+        assert report.error_count == 0
+
+    def test_is_admin_flag(self):
+        report = _report(_clean_win11_pro_results(), is_admin=True)
+        assert report.is_admin is True
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2: Neglected Windows 10 Home workgroup machine
+# ---------------------------------------------------------------------------
+
+def _neglected_win10_home_results() -> list[CheckResult]:
+    """Simulate a poorly configured Windows 10 Home workstation."""
+    return [
+        # Firewall — public profile off
+        _r("Firewall", "Domain Profile",  Status.INFO, Severity.HIGH, "Not domain-joined"),
+        _r("Firewall", "Private Profile", Status.PASS, Severity.HIGH),
+        _r("Firewall", "Public Profile",  Status.FAIL, Severity.CRITICAL, "Disabled", "Enable firewall"),
+        # Antivirus — Defender disabled
+        _r("Antivirus", "Windows Defender Status",  Status.FAIL, Severity.CRITICAL, "Disabled", "Enable Defender"),
+        _r("Antivirus", "Definition Age",            Status.FAIL, Severity.HIGH, "90 days old", "Update defs"),
+        # Encryption — no BitLocker (Home edition)
+        _r("Encryption", "BitLocker — C:", Status.WARN, Severity.HIGH, "Unavailable on Home", "Upgrade to Pro"),
+        # Updates — very stale
+        _r("Patching", "Last Windows Update", Status.FAIL, Severity.CRITICAL, "120 days ago", "Run Windows Update"),
+        _r("Patching", "WU Service",          Status.WARN, Severity.MEDIUM, "Stopped", "Start service"),
+        _r("Patching", "Pending Updates",     Status.FAIL, Severity.HIGH, "15 updates", "Install updates"),
+        # Accounts — guest enabled, many admins
+        _r("Accounts", "Guest Account",          Status.FAIL, Severity.HIGH, "Enabled", "Disable guest"),
+        _r("Accounts", "Built-in Administrator", Status.FAIL, Severity.MEDIUM, "Enabled, default name", "Rename/disable"),
+        _r("Accounts", "Local Administrators",   Status.WARN, Severity.MEDIUM, "5 admins", "Reduce admins"),
+        _r("Accounts", "Password Length",        Status.FAIL, Severity.HIGH, "6 chars min", "Increase length"),
+        _r("Accounts", "Account Lockout",        Status.WARN, Severity.MEDIUM, "Disabled", "Enable lockout"),
+        _r("Accounts", "Password Complexity",    Status.FAIL, Severity.MEDIUM, "Disabled", "Enable complexity"),
+        # UAC — disabled
+        _r("UAC", "UAC Enabled",       Status.FAIL, Severity.CRITICAL, "Disabled", "Enable UAC"),
+        _r("UAC", "UAC Consent Level", Status.FAIL, Severity.HIGH, "No prompt", "Set to prompt"),
+        # SMB — v1 enabled
+        _r("File Sharing", "SMBv1 Disabled", Status.FAIL, Severity.CRITICAL, "SMBv1 enabled", "Disable SMBv1"),
+        _r("File Sharing", "SMB Signing",    Status.FAIL, Severity.HIGH, "Not required", "Enable signing"),
+        # RDP — enabled without NLA
+        _r("RDP", "RDP Enabled",  Status.WARN, Severity.HIGH, "Enabled", "Disable or restrict"),
+        _r("RDP", "NLA Required", Status.FAIL, Severity.HIGH, "NLA disabled", "Enable NLA"),
+        # PowerShell
+        _r("PowerShell", "Execution Policy", Status.WARN, Severity.HIGH, "Unrestricted", "Restrict policy"),
+        # Hardening
+        _r("Hardening", "AutoPlay Disabled", Status.WARN, Severity.MEDIUM, "Not set", "Disable AutoPlay"),
+        _r("Hardening", "Audit Policy",      Status.WARN, Severity.MEDIUM, "Not configured", "Configure"),
+    ]
+
+
+class TestNeglectedWin10HomeMachine:
+    def test_score_is_grade_f(self):
+        results = _neglected_win10_home_results()
+        score = calculate_score(results)
+        letter, _ = score_grade(score)
+        assert letter == "F", f"Expected F grade but got {letter} (score={score})"
+
+    def test_score_below_60(self):
+        score = calculate_score(_neglected_win10_home_results())
+        assert score < 60, f"Expected score < 60, got {score}"
+
+    def test_has_multiple_critical_failures(self):
+        report = _report(_neglected_win10_home_results())
+        critical_fails = sum(
+            1 for r in report.results
+            if r.status == Status.FAIL and r.severity == Severity.CRITICAL
+        )
+        assert critical_fails >= 3
+
+    def test_has_failures(self):
+        report = _report(_neglected_win10_home_results())
+        assert report.fail_count > 0
+
+    def test_score_much_lower_than_clean(self):
+        clean_score  = calculate_score(_clean_win11_pro_results())
+        bad_score    = calculate_score(_neglected_win10_home_results())
+        assert clean_score - bad_score >= 30, (
+            f"Clean ({clean_score}) vs neglected ({bad_score}) gap too small"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3: Windows Server 2022 with baseline hardening
+# ---------------------------------------------------------------------------
+
+def _server_2022_hardened_results() -> list[CheckResult]:
+    """Simulate a reasonably hardened Windows Server 2022."""
+    return [
+        # Firewall
+        _r("Firewall", "Domain Profile",  Status.PASS, Severity.HIGH),
+        _r("Firewall", "Private Profile", Status.PASS, Severity.HIGH),
+        _r("Firewall", "Public Profile",  Status.PASS, Severity.HIGH),
+        # Antivirus — Defender running
+        _r("Antivirus", "Windows Defender Status", Status.PASS, Severity.CRITICAL),
+        _r("Antivirus", "Definition Age",           Status.PASS, Severity.HIGH),
+        # Encryption — BitLocker on C:
+        _r("Encryption", "BitLocker — C:", Status.PASS, Severity.HIGH),
+        # Updates — within 30 days
+        _r("Patching", "Last Windows Update", Status.PASS, Severity.CRITICAL),
+        _r("Patching", "WU Service",          Status.PASS, Severity.MEDIUM),
+        _r("Patching", "Pending Updates",     Status.PASS, Severity.HIGH),
+        # Accounts — standard setup
+        _r("Accounts", "Guest Account",          Status.PASS, Severity.HIGH),
+        _r("Accounts", "Local Administrators",   Status.PASS, Severity.MEDIUM),
+        _r("Accounts", "Password Length",        Status.PASS, Severity.MEDIUM),
+        _r("Accounts", "Account Lockout",        Status.PASS, Severity.MEDIUM),
+        _r("Accounts", "Password Complexity",    Status.PASS, Severity.MEDIUM),
+        # UAC — enabled
+        _r("UAC", "UAC Enabled",       Status.PASS, Severity.CRITICAL),
+        _r("UAC", "UAC Consent Level", Status.PASS, Severity.HIGH),
+        # SMB — v1 disabled, signing required
+        _r("File Sharing", "SMBv1 Disabled", Status.PASS, Severity.CRITICAL),
+        _r("File Sharing", "SMB Signing",    Status.PASS, Severity.HIGH),
+        _r("File Sharing", "SMB Encryption", Status.PASS, Severity.LOW),
+        # RDP — NLA enforced
+        _r("RDP", "NLA Required", Status.PASS, Severity.HIGH),
+        # PowerShell
+        _r("PowerShell", "Execution Policy",     Status.PASS, Severity.HIGH),
+        _r("PowerShell", "Script Block Logging", Status.PASS, Severity.MEDIUM),
+        _r("PowerShell", "Module Logging",       Status.PASS, Severity.MEDIUM),
+        _r("PowerShell", "PSv2 Installed",       Status.PASS, Severity.MEDIUM),
+        # Services — one warn (Print Spooler)
+        _r("Services", "Risky Services",  Status.WARN, Severity.MEDIUM, "Spooler running", "Disable if unused"),
+        _r("Services", "Unquoted Paths",  Status.PASS, Severity.HIGH),
+        # Network
+        _r("Network", "LLMNR Disabled", Status.PASS, Severity.MEDIUM),
+        # Hardening
+        _r("Hardening", "Audit Policy",   Status.PASS, Severity.MEDIUM),
+        _r("Hardening", "Screen Lock",    Status.PASS, Severity.MEDIUM),
+    ]
+
+
+class TestServer2022Hardened:
+    def test_score_grade_b_or_better(self):
+        results = _server_2022_hardened_results()
+        score = calculate_score(results)
+        letter, _ = score_grade(score)
+        assert letter in ("A", "B"), f"Expected A or B grade, got {letter} (score={score})"
+
+    def test_score_at_least_80(self):
+        score = calculate_score(_server_2022_hardened_results())
+        assert score >= 80, f"Expected score >= 80, got {score}"
+
+    def test_no_failures(self):
+        report = _report(_server_2022_hardened_results())
+        assert report.fail_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4: Non-admin scan — admin-required checks skipped gracefully
+# ---------------------------------------------------------------------------
+
+def _non_admin_results() -> list[CheckResult]:
+    """Simulate results when scan runs without elevation."""
+    return [
+        # Checks that run without admin
+        _r("Firewall", "Domain Profile",  Status.PASS, Severity.HIGH),
+        _r("Firewall", "Public Profile",  Status.PASS, Severity.HIGH),
+        _r("Antivirus", "Defender",       Status.PASS, Severity.CRITICAL),
+        _r("UAC", "UAC Enabled",          Status.PASS, Severity.CRITICAL),
+        # Admin-required checks skipped (returned as INFO by scanner)
+        _r("Encryption", "Encryption — requires administrator", Status.INFO, Severity.INFO,
+           "Run as Administrator"),
+        _r("File Sharing", "File Sharing — requires administrator", Status.INFO, Severity.INFO,
+           "Run as Administrator"),
+    ]
+
+
+class TestNonAdminScan:
+    def test_score_not_penalised_for_skipped_checks(self):
+        """INFO results must not deduct from score."""
+        results = _non_admin_results()
+        score = calculate_score(results)
+        # All non-INFO results are PASS, so score should stay high
+        assert score == 100, f"Skipped (INFO) checks should not deduct points, got {score}"
+
+    def test_report_is_admin_false(self):
+        report = _report(_non_admin_results(), is_admin=False)
+        assert report.is_admin is False
+
+    def test_no_errors_in_non_admin_scan(self):
+        report = _report(_non_admin_results(), is_admin=False)
+        assert report.error_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario 5: HTML and JSON round-trip
+# ---------------------------------------------------------------------------
+
+class TestReportRoundTrip:
+    def test_html_report_contains_all_categories(self):
+        import tempfile, os
+        from winposture.reporter import Reporter
+
+        results = _clean_win11_pro_results()
+        report = _report(results)
+        reporter = Reporter()
+
+        with tempfile.NamedTemporaryFile(suffix=".html", delete=False) as f:
+            html_path = f.name
+        try:
+            reporter.generate_html_report(report, html_path)
+            content = open(html_path, encoding="utf-8").read()
+        finally:
+            os.unlink(html_path)
+
+        categories = {r.category for r in results}
+        for cat in categories:
+            assert cat in content, f"Category '{cat}' not found in HTML report"
+
+    def test_json_report_preserves_all_results(self):
+        import json, tempfile, os
+        from winposture.reporter import Reporter
+
+        results = _clean_win11_pro_results()
+        report = _report(results)
+        reporter = Reporter()
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            json_path = f.name
+        try:
+            reporter.generate_json_report(report, json_path)
+            data = json.loads(open(json_path, encoding="utf-8").read())
+        finally:
+            os.unlink(json_path)
+
+        assert len(data["results"]) == len(results)
+        assert data["score"] == report.score
+        assert data["hostname"] == "SCENARIO-PC"


### PR DESCRIPTION
## Summary
- Admin detection: scanner skips `REQUIRES_ADMIN` modules when not elevated, returns INFO result; reporter shows warning banner
- Per-check timing: `check_duration` set on all `CheckResult` objects via `time.monotonic()` in scanner
- `AuditReport` gains `is_admin` flag and `error_count` property; footer shows error summary
- Pending-updates PS timeout increased 30s → 60s for slow COM object
- 4 new test files: `test_scanner.py`, `test_cli.py`, `test_reporter.py`, `test_scenarios.py` — 511 tests, all passing

## Test plan
- [x] `pytest tests/ -q` → 511 passed, 0 failed
- [x] Run as standard user — verify non-admin warning and skipped checks
- [x] Run as Administrator — verify full scan with no skipped checks
- [x] Run with `--html out.html` and open report

🤖 Generated with [Claude Code](https://claude.com/claude-code)