### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ jobs:
   test:
     name: pytest (Python ${{ matrix.python-version }})
     runs-on: windows-latest
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Potential fix for [https://github.com/hexorcist404/winposture/security/code-scanning/2](https://github.com/hexorcist404/winposture/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block that grants only the minimal access required. This job checks out the repository and runs tests; it does not create releases, push commits, or modify issues/PRs. The minimal required permission is `contents: read` (to allow `actions/checkout` to read the repository). No write permissions appear necessary.

The best way to fix this without changing functionality is to add a `permissions` block under the `test` job definition (line 10) so it applies only to this job. Insert:

```yaml
permissions:
  contents: read
```

between `runs-on: windows-latest` (line 12) and `strategy:` (line 14). This keeps the workflow behavior identical (checkout and tests still work) while constraining `GITHUB_TOKEN` to read-only repository contents. No imports or additional methods are needed, as this is purely a YAML configuration change inside `.github/workflows/test.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
