### PR TITLE
Unquoted services path empty output patch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,13 @@
 # WinPosture — Claude Code Project Context
 
 ## Project Overview
+
 WinPosture is a portable Windows security posture auditor. It runs locally on a
 Windows machine, audits common security configurations, scores the result (0–100),
 and produces a terminal report (Rich) and/or HTML/JSON output.
 
 ## Language & Runtime
+
 - Python 3.12+
 - Type hints on **all** functions and methods (no bare `Any` unless unavoidable)
 - Docstrings on all public functions/classes
@@ -21,7 +23,9 @@ cli.py  →  scanner.py  →  checks/*.py  →  models.CheckResult
 ```
 
 ### Check Modules (`src/winposture/checks/`)
+
 Each file is an independent audit module. Conventions:
+
 - Expose a `run() -> list[CheckResult]` function (the scanner calls this)
 - Never call `sys.exit()` or raise unhandled exceptions — return a result with
   `status=Status.ERROR` and the exception message in `details` instead
@@ -29,12 +33,15 @@ Each file is an independent audit module. Conventions:
 - A single module may return multiple `CheckResult` objects
 
 ### `utils.py`
+
 Shared helpers only. Key functions to build out:
+
 - `run_powershell(script: str) -> str` — runs a PS snippet, returns stdout
 - `read_registry(hive, key, value)` — reads a registry value safely
 - `is_admin() -> bool` — checks for elevated privileges
 
 ### Data Model (`models.py`)
+
 ```python
 @dataclass
 class CheckResult:
@@ -48,6 +55,7 @@ class CheckResult:
 ```
 
 ## Check Categories (files in `checks/`)
+
 | File | Category | Notes |
 |------|----------|-------|
 | `os_info.py` | OS | Version, build, patch level |
@@ -66,6 +74,7 @@ class CheckResult:
 | `misc.py` | Misc | AutoPlay, remote registry, LLMNR |
 
 ## Testing
+
 - Framework: **pytest**
 - Mock all subprocess / WMI / registry calls with `unittest.mock` so tests run on
   any OS (including Linux CI)
@@ -73,16 +82,20 @@ class CheckResult:
 - `tests/conftest.py` holds shared fixtures (sample `CheckResult`, mock PS output…)
 
 ## Target Platforms
+
 - Windows 10 (21H2+) and Windows 11
 - Windows Server 2019 and 2022
 
 ## Output Formats
+
 - **Terminal**: Rich tables with color-coded status/severity
 - **HTML**: Jinja2 template at `templates/report.html.j2`
 - **JSON**: Serialized `AuditReport` dataclass (use `dataclasses.asdict`)
 
 ## Scoring Logic (`scoring.py`)
+
 Start at 100. Deduct points per failed/warned check weighted by severity:
+
 - CRITICAL FAIL: −20
 - HIGH FAIL: −10
 - MEDIUM FAIL: −5

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ If you discover a security vulnerability in WinPosture, **please do not open a p
 
 Instead, please report it using GitHub's private vulnerability reporting feature, OR via email at:
 
-### hexorcist404@pm.me
+### <hexorcist404@pm.me>
 
 Include the following in your report:
 

--- a/src/winposture/checks/services.py
+++ b/src/winposture/checks/services.py
@@ -122,7 +122,10 @@ def _check_unquoted_paths() -> list[CheckResult]:
     try:
         data = run_powershell_json(_PS_UNQUOTED)
     except WinPostureError as exc:
-        return [_error("Unquoted Service Paths", str(exc))]
+        if "empty output" in str(exc):
+            data = []
+        else:
+            return [_error("Unquoted Service Paths", str(exc))]
 
     items = data if isinstance(data, list) else ([data] if data else [])
 

--- a/tests/test_checks/test_services.py
+++ b/tests/test_checks/test_services.py
@@ -121,6 +121,13 @@ class TestCheckUnquotedPaths:
             r = services._check_unquoted_paths()[0]
         assert r.status == Status.ERROR
 
+    def test_empty_powershell_output_is_pass(self):
+        """Empty PS output (no matches) should be PASS, not ERROR."""
+        with patch("winposture.checks.services.run_powershell_json",
+                   side_effect=WinPostureError("PowerShell command returned empty output (expected JSON)")):
+            r = services._check_unquoted_paths()[0]
+        assert r.status == Status.PASS
+
 
 # ---------------------------------------------------------------------------
 # run()


### PR DESCRIPTION
Fixed edge case where the Unquoted Service Paths check in checks/services.py returned an ERROR when the PowerShell query found zero unquoted service paths (empty output). It now returns a PASS with details.