### PR TITLE
release: v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.1.1] - 2026-03-27
+
+### Fixed
+- Fixed Defender Tamper Protection check using wrong property (`TamperProtectionEnabled` → `IsTamperProtected`)
+- Fixed Unquoted Service Paths check returning ERROR when no unquoted paths found (now correctly returns PASS)
+- Fixed CIS benchmark version references (updated to current CIS Windows 11 v5.0.0 and Windows 10 v4.0.0)
+- Corrected CIS control ID mappings against latest benchmark PDFs
+- Removed non-existent `pip install winposture` from README (not yet on PyPI)
+
+### Changed
+- Updated README checks table to include all 53 checks (was missing ~20)
+- Added CIS Benchmark Mapping section to README
+- Updated scoring table in README to match actual code deductions
+- Added admin privilege note to "Why WinPosture?" section
+- WARN deductions now broken out by severity level in documentation
+
+---
+
 ## [0.1.0] - 2026-03-17
 
 Initial public release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "winposture"
-version = "0.1.0"
+version = "0.1.1"
 description = "A portable Windows security posture auditor"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/winposture/__init__.py
+++ b/src/winposture/__init__.py
@@ -1,4 +1,4 @@
 """WinPosture — Windows Security Posture Auditor."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 __all__ = ["__version__"]


### PR DESCRIPTION
Version bump and changelog for v0.1.1.

## Changes
- Bumped version to 0.1.1 in `__init__.py` and `pyproject.toml`
- Added v0.1.1 entry to `CHANGELOG.md`

## Verified
- `winposture.exe --version` → `winposture 0.1.1`
- 547 tests passing
- SHA256: `da2e577530e639a44cd17ac7088b050ba6f674945bfdaca92c38caf28965d4ab`