### PR TITLE
docs: fix scoring values, category names in CLAUDE.md; add CIS versions to README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,20 +58,20 @@ class CheckResult:
 
 | File | Category | Notes |
 |------|----------|-------|
-| `os_info.py` | OS | Version, build, patch level |
-| `updates.py` | Updates | Windows Update status |
+| `os_info.py` | System | Version, build, patch level |
+| `updates.py` | Patching | Windows Update status |
 | `firewall.py` | Firewall | All three profiles |
 | `antivirus.py` | Antivirus | Defender / third-party AV |
 | `encryption.py` | Encryption | BitLocker per drive |
 | `accounts.py` | Accounts | Local users, admins, guest, password policy |
 | `services.py` | Services | Risky/unnecessary running services |
 | `network.py` | Network | Open ports, listening services |
-| `startup.py` | Startup | Startup programs, scheduled tasks |
-| `smb.py` | SMB | SMBv1 disabled? Signing? |
-| `rdp.py` | RDP | Enabled? NLA enforced? |
-| `uac.py` | UAC | UAC level |
+| `startup.py` | Persistence | Startup programs, scheduled tasks |
+| `smb.py` | File Sharing | SMBv1 disabled? Signing? |
+| `rdp.py` | Remote Access | Enabled? NLA enforced? |
+| `uac.py` | Access Control | UAC level |
 | `powershell.py` | PowerShell | Execution policy, logging, constrained mode |
-| `misc.py` | Misc | AutoPlay, remote registry, LLMNR |
+| `misc.py` | Hardening | AutoPlay, remote registry, LLMNR |
 
 ## Testing
 
@@ -96,8 +96,15 @@ class CheckResult:
 
 Start at 100. Deduct points per failed/warned check weighted by severity:
 
-- CRITICAL FAIL: −20
-- HIGH FAIL: −10
-- MEDIUM FAIL: −5
-- LOW FAIL / any WARN: −2
-- Clamp to [0, 100]
+| Outcome | Severity | Deduction |
+|---------|----------|-----------|
+| FAIL    | CRITICAL | −15       |
+| FAIL    | HIGH     | −10       |
+| FAIL    | MEDIUM   | −5        |
+| FAIL    | LOW      | −2        |
+| WARN    | CRITICAL | −7        |
+| WARN    | HIGH     | −5        |
+| WARN    | MEDIUM   | −2        |
+| WARN    | LOW      | −1        |
+
+Clamp to [0, 100]. INFO and ERROR results do not affect the score.

--- a/README.md
+++ b/README.md
@@ -213,7 +213,9 @@ Where applicable, findings are mapped to CIS Microsoft Windows Benchmark control
 IDs. These references appear as blue badges in the HTML report's detailed findings
 section, making WinPosture useful for compliance documentation and audit
 preparation. Mappings are based on the CIS Microsoft Windows 11 Enterprise
-Benchmark and CIS Microsoft Windows 10 Enterprise Benchmark.
+Benchmark v5.0.0 and CIS Microsoft Windows 10 Enterprise Benchmark v4.0.0.
+The correct version is selected automatically based on the OS build number at
+scan time.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,8 @@ WinPosture is a **read-only** security auditing tool. It does not modify system 
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.1.x   | :white_check_mark: |
+| 0.1.1   | :white_check_mark: |
+| 0.1.0   | :x:                |
 
 Only the latest release is actively supported with security updates.
 


### PR DESCRIPTION
Corrects outdated documentation found during a full repository audit.

## Changes

### CLAUDE.md
- **Scoring table:** `CRITICAL FAIL` was documented as `−20` — corrected to `−15` (matches `scoring.py`). Expanded WARN rows to show per-severity deductions instead of the collapsed "any WARN: −2" line.
- **Check category table:** 7 category names corrected to match the actual `CATEGORY` constants in the check modules:
  | File | Was | Now |
  |------|-----|-----|
  | `os_info.py` | OS | System |
  | `updates.py` | Updates | Patching |
  | `startup.py` | Startup | Persistence |
  | `smb.py` | SMB | File Sharing |
  | `rdp.py` | RDP | Remote Access |
  | `uac.py` | UAC | Access Control |
  | `misc.py` | Misc | Hardening |

### README.md
- **CIS Benchmark Mapping section:** Added version numbers `v5.0.0` (Windows 11) and `v4.0.0` (Windows 10) with a note that the correct version is selected automatically at scan time.

### SECURITY.md
- Changed format from listing supported version using a wildcard, to explicitly listing each release number with a check for the supported latest release, and an 'x' for the previous, superseded versions. Enhancing clarity.

## Not changed
- `CHANGELOG.md` historical entries (27 checks / 511 tests in [0.1.0] are accurate for that release)
- Scoring values in `README.md` (already correct — match `scoring.py`)
- `docs/index.html` (already correct)
- All source code (no logic changes)