### PR TITLE
docs: clarify quick start — add cd step before running winposture.exe

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,15 @@ score with plain-English remediation advice.
 No Python required.
 
 1. Download `winposture.exe` from the [Releases](https://github.com/hexorcist404/winposture/releases) page
-2. Open a terminal (Command Prompt or PowerShell) **as Administrator** for full results
-3. Run:
+2. Open **Command Prompt** or **PowerShell** as Administrator
+   (Right-click the Start button → *Terminal (Admin)* or search for *cmd* → *Run as administrator*)
+3. Navigate to the folder where you saved the file — for example, if it's in Downloads:
+
+```
+cd %USERPROFILE%\Downloads
+```
+
+4. Run:
 
 ```
 winposture.exe

--- a/docs/index.html
+++ b/docs/index.html
@@ -406,7 +406,7 @@
         <div class="step-num">1</div>
         <div class="step-body">
           <h3>Download the executable</h3>
-          <p>Grab <code>winposture.exe</code> from the <a href="https://github.com/hexorcist404/winposture/releases/latest">latest release</a>. No installer needed.</p>
+          <p>Grab <code>winposture.exe</code> from the <a href="https://github.com/hexorcist404/winposture/releases/latest">latest release</a> and save it somewhere easy to find — your Desktop or Downloads folder works fine.</p>
         </div>
       </div>
 
@@ -421,13 +421,23 @@
       <div class="step">
         <div class="step-num">3</div>
         <div class="step-body">
+          <h3>Navigate to the folder where you saved the file</h3>
+          <p>For example, if you saved it in Downloads:</p>
+          <pre>cd %USERPROFILE%\Downloads</pre>
+          <p style="margin-top:0.4rem; font-size:0.85rem; color:var(--muted);">Tip: in File Explorer, navigate to the folder, then type <code>cmd</code> in the address bar and press Enter to open a terminal there directly.</p>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-num">4</div>
+        <div class="step-body">
           <h3>Run a scan</h3>
           <pre>winposture.exe</pre>
         </div>
       </div>
 
       <div class="step">
-        <div class="step-num">4</div>
+        <div class="step-num">5</div>
         <div class="step-body">
           <h3>Generate an HTML report (optional)</h3>
           <pre>winposture.exe --html report.html --verbose</pre>
@@ -436,7 +446,7 @@
       </div>
 
       <div class="step">
-        <div class="step-num">5</div>
+        <div class="step-num">6</div>
         <div class="step-body">
           <h3>Track changes over time</h3>
           <pre>winposture.exe --baseline before.json


### PR DESCRIPTION
## Summary

Fixes the exact issue reported after v0.1.2 testing: users following the README and GitHub Pages instructions got `'winposture.exe' is not recognized` because both sets of docs said to open a terminal and run the exe without explaining how to navigate to where it was downloaded.

## Changes

- **README.md**: added explicit step 3 (`cd %USERPROFILE%\Downloads`) between "open a terminal" and "run winposture.exe", with a note about running as Administrator
- **docs/index.html**: inserted a new step 3 with the `cd` command and a File Explorer tip ("type `cmd` in the address bar"), renumbered subsequent steps 4–6

No code changes.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hexorcist404/winposture/pull/30" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
