### PR TITLE
test(utils): make TestIsAdmin patches work on non-Windows

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -313,21 +313,21 @@ class TestIsAdmin:
         with patch.object(sys, "platform", "win32"):
             mock_windll = MagicMock()
             mock_windll.shell32.IsUserAnAdmin.return_value = 1
-            with patch("winposture.utils.ctypes.windll", mock_windll):
+            with patch("winposture.utils.ctypes.windll", mock_windll, create=True):
                 assert utils.is_admin() is True
 
     def test_returns_false_when_ctypes_reports_non_admin(self):
         with patch.object(sys, "platform", "win32"):
             mock_windll = MagicMock()
             mock_windll.shell32.IsUserAnAdmin.return_value = 0
-            with patch("winposture.utils.ctypes.windll", mock_windll):
+            with patch("winposture.utils.ctypes.windll", mock_windll, create=True):
                 assert utils.is_admin() is False
 
     def test_returns_false_when_ctypes_raises(self):
         with patch.object(sys, "platform", "win32"):
             mock_windll = MagicMock()
             mock_windll.shell32.IsUserAnAdmin.side_effect = OSError("access denied")
-            with patch("winposture.utils.ctypes.windll", mock_windll):
+            with patch("winposture.utils.ctypes.windll", mock_windll, create=True):
                 assert utils.is_admin() is False
 
 


### PR DESCRIPTION
Add create=True to patch("winposture.utils.ctypes.windll", ...) so the
three TestIsAdmin tests run on Linux/macOS, not just Windows. Without
it, mock raises AttributeError because ctypes.windll only exists on
Windows.

Restores the cross-platform-tests invariant in CLAUDE.md ("tests run on
any OS, including Linux CI"). Full suite: 548 passed on Linux.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hexorcist404/winposture/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->