### PR TITLE
ci: also run tests on ubuntu-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,15 @@ on:
 
 jobs:
   test:
-    name: pytest (Python ${{ matrix.python-version }})
-    runs-on: windows-latest
+    name: pytest (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
 
     strategy:
       fail-fast: false
       matrix:
+        os: ["windows-latest", "ubuntu-latest"]
         python-version: ["3.12", "3.13"]
 
     steps:


### PR DESCRIPTION
## Summary
- Extend the `test.yml` matrix to `ubuntu-latest` in addition to `windows-latest`, so the cross-platform-tests invariant from `CLAUDE.md` ("tests run on any OS, including Linux CI") is actually enforced. Without this, regressions that break the suite on non-Windows go undetected — exactly how the `TestIsAdmin` issue fixed in #31 slipped through.
- Matrix is now `{windows-latest, ubuntu-latest} × {3.12, 3.13}` = 4 jobs.

## Test plan
- [x] CI runs the new `ubuntu-latest` jobs on this PR and they pass for both 3.12 and 3.13.
- [x] Existing `windows-latest` jobs continue to pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_012pHkEVqsY3Pvm2LskB9xSg)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hexorcist404/winposture/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->