### PR TITLE
ci: add PyPI trusted-publishing workflow on version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,58 @@
+name: Publish to PyPI
+
+# Publishes the package to PyPI whenever a version tag (v*) is pushed.
+# Uses PyPI Trusted Publishing (OIDC) — no API token or secret is stored.
+# A matching "trusted publisher" must be configured on PyPI for this to work:
+#   PyPI project "apotrope" → owner hexorcist404, repo apotrope,
+#   workflow "publish.yml", environment "pypi".
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build twine
+          python -m build
+          python -m twine check dist/*
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    # The environment must match the one named in the PyPI trusted publisher.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/apotrope
+    permissions:
+      id-token: write  # required for OIDC trusted publishing
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Adds `.github/workflows/publish.yml` — publishes the package to PyPI via **Trusted Publishing (OIDC)** whenever a `v*` tag is pushed. No API token or secret is stored in the repo.

## How it works
- **build** job: `python -m build` + `twine check dist/*`, uploads the artifacts
- **publish** job: downloads the artifacts and runs `pypa/gh-action-pypi-publish@release/v1` with `id-token: write`, scoped to the `pypi` environment

## ⚠️ One-time setup required on PyPI before this can publish
Because `apotrope` doesn't exist on PyPI yet, add a **pending publisher** at https://pypi.org/manage/account/publishing/ with exactly:

| Field | Value |
|-------|-------|
| PyPI Project Name | `apotrope` |
| Owner | `hexorcist404` |
| Repository name | `apotrope` |
| Workflow name | `publish.yml` |
| Environment name | `pypi` |

After that, pushing a new tag (e.g. `v0.1.5`) triggers an automatic release. The existing `v0.1.4` artifacts can still be uploaded manually with `twine`; the workflow handles all future tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)