### PR TITLE
release: v0.1.5 — first automated PyPI publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.1.5] - 2026-06-02
+
+### Changed
+- First release published to PyPI through the automated trusted-publishing
+  workflow (`pip install apotrope`). No functional changes from 0.1.4 — this
+  release exists to exercise the OIDC publishing pipeline end to end.
+
+---
+
 ## [0.1.4] - 2026-06-02
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apotrope"
-version = "0.1.4"
+version = "0.1.5"
 description = "A portable Windows security posture auditor"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/apotrope/__init__.py
+++ b/src/apotrope/__init__.py
@@ -1,4 +1,4 @@
 """Apotrope — Windows Security Posture Auditor."""
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 __all__ = ["__version__"]


### PR DESCRIPTION
Bumps to **0.1.5** to trigger the trusted-publishing workflow added in #37.

No functional changes from 0.1.4 — this release exists to validate the OIDC PyPI pipeline end to end. After merge, tagging `v0.1.5` will publish the package to PyPI automatically (no token).

- `pyproject.toml` + `__version__` → 0.1.5
- CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)