### PR TITLE
pages: serve site from custom domain apotrope.sh

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+apotrope.sh


### PR DESCRIPTION
Adds `docs/CNAME` = `apotrope.sh` so GitHub Pages serves the site from the apex custom domain. Pages source is `main:/docs`, so the CNAME file belongs in `docs/`. Committing it via PR is the equivalent of setting the custom domain in **Settings → Pages** (needed because `main` is protected).

## After merge — DNS to configure at the registrar for `apotrope.sh`
**Apex `apotrope.sh`** — A records (IPv4):
```
185.199.108.153
185.199.109.153
185.199.110.153
185.199.111.153
```
Optionally AAAA records (IPv6):
```
2606:50c0:8000::153
2606:50c0:8001::153
2606:50c0:8002::153
2606:50c0:8003::153
```
**`www.apotrope.sh`** — CNAME → `hexorcist404.github.io` (so www redirects to the apex).

Then in **Settings → Pages**, tick **Enforce HTTPS** once the cert provisions (can take a few minutes to ~24h after DNS propagates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)