### PR TITLE
docs: link apotrope.sh and surface pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,12 @@ auditing, talks to no network, and hands back a scored terminal report — or a
 self-contained HTML report you can send to someone who wasn't in the room.
 
 [![Tests](https://github.com/hexorcist404/apotrope/actions/workflows/test.yml/badge.svg)](https://github.com/hexorcist404/apotrope/actions/workflows/test.yml)
+[![PyPI](https://img.shields.io/pypi/v/apotrope.svg)](https://pypi.org/project/apotrope/)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![Website](https://img.shields.io/badge/web-apotrope.sh-5b21b6.svg)](https://apotrope.sh)
+
+**Website: [apotrope.sh](https://apotrope.sh)**
 
 ---
 
@@ -74,7 +78,14 @@ Then open `report.html` in your browser.
 
 Requires Python 3.12+ and Windows 10/11 or Server 2019/2022.
 
-Install from source:
+Install from [PyPI](https://pypi.org/project/apotrope/):
+
+```bash
+pip install apotrope
+apotrope
+```
+
+Or install from source:
 
 ```bash
 git clone https://github.com/hexorcist404/apotrope.git
@@ -82,8 +93,6 @@ cd apotrope
 pip install -e .
 apotrope
 ```
-
-PyPI package coming soon.
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -300,6 +300,9 @@
         View on GitHub
       </a>
     </div>
+    <p style="font-size:0.85rem; color:var(--muted); margin-top:1rem;">
+      or, with Python 3.12+: <code>pip install apotrope</code>
+    </p>
 
     <!-- Score demo -->
     <div class="score-strip">
@@ -403,6 +406,13 @@
   <div class="container">
     <h2>Get Started</h2>
     <p class="section-sub">Up and running in under a minute.</p>
+
+    <p style="text-align:center; font-size:0.95rem; color:var(--muted); margin-bottom:2rem;">
+      Have Python 3.12+? Install from PyPI instead &mdash;
+      <code>pip install apotrope</code>, then run <code>apotrope</code>.
+      The steps below are for the standalone <code>apotrope.exe</code> (no Python required).
+    </p>
+
     <div class="steps">
 
       <div class="step">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,12 @@ dependencies = [
     "psutil>=5.9",
 ]
 
+[project.urls]
+Homepage = "https://apotrope.sh"
+Repository = "https://github.com/hexorcist404/apotrope"
+Changelog = "https://github.com/hexorcist404/apotrope/blob/main/CHANGELOG.md"
+Issues = "https://github.com/hexorcist404/apotrope/issues"
+
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",


### PR DESCRIPTION
Now that the package is on PyPI and the site has a custom domain, point the docs at both.

## Changes
- **README**
  - Add **PyPI** and **Website** badges + a `Website: apotrope.sh` line
  - Replace *"PyPI package coming soon"* with `pip install apotrope` as the primary install path (source install kept as the alternative)
- **docs/index.html** (the apotrope.sh site)
  - Hero: `or, with Python 3.12+: pip install apotrope` under the download buttons
  - Get Started: a note offering the pip route alongside the standalone-exe steps
- **pyproject.toml**
  - Add `[project.urls]` (Homepage = https://apotrope.sh, Repository, Changelog, Issues) so the links render on the PyPI project page on the next release

## Verification
- `python -m build` + `twine check dist/*` → PASSED (both); `Project-URL: Homepage, https://apotrope.sh` present in wheel metadata
- Docs/metadata-only change — no code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)