### PR TITLE
Redesign: unified CRT/terminal aesthetic across CLI, HTML report, and site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ $RECYCLE.BIN/
 *.html
 *.json
 !docs/index.html
+# committed sample report served by the marketing site
+!docs/report.html
 apotrope_report_*
 
 # Design review scaffolding

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ apotrope_report_*
 # Design review scaffolding
 gen_sample_report.py
 sample_report.html
+.gstack/

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ self-contained HTML report you can send to someone who wasn't in the room.
 
 ## Why Apotrope?
 
-Some charms ward off harm. This one audits Windows.
-
 Most posture tools want something before they'll help you: a cloud account, a
 license key, an agent to install, your data shipped off to a dashboard somewhere.
 Apotrope wants none of it. It's a single executable. Drop it on a USB stick, run it

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,490 +6,533 @@
   <meta name="description" content="Apotrope — portable Windows security posture auditor. Single executable, no cloud, actionable remediation." />
   <meta name="google-site-verification" content="N68F_sJSRaPAUmW1m4vSVKj0BwJBtOEP6m9mwE1SAwA" />
   <title>Apotrope — Windows Security Posture Auditor</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;600;700&display=swap" rel="stylesheet" />
   <style>
-    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
-    :root {
-      --bg:        #0d1117;
-      --surface:   #161b22;
-      --border:    #30363d;
-      --accent:    #58a6ff;
-      --accent2:   #3fb950;
-      --warn:      #d29922;
-      --danger:    #f85149;
-      --text:      #c9d1d9;
-      --muted:     #8b949e;
-      --heading:   #e6edf3;
-    }
+  :root {
+    --void:#03060a; --bg:#05090c; --panel:#080d11; --panel-2:#0b1218;
+    --line:rgba(0,255,102,0.10); --line-soft:rgba(120,200,170,0.07);
+    --green:#2bff88; --cyan:#44e0e6; --amber:#ffb23d; --red:#ff5147; --crit:#ff2d6b; --orange:#ff7a18;
+    --text:#c4d6cd; --bright:#e8fff2; --muted:#5d776c; --faint:#2f4138;
+    --accent:#2bff88;
+    --maxw:1140px; --r:3px;
+  }
+  html { scroll-behavior:smooth; }
+  body {
+    background:
+      radial-gradient(1100px 640px at 82% -6%, rgba(255,122,24,0.07), transparent 58%),
+      radial-gradient(900px 600px at -6% 2%, rgba(43,255,136,0.06), transparent 55%),
+      var(--bg);
+    color:var(--text); font-family:"IBM Plex Sans",system-ui,sans-serif; font-size:16px;
+    line-height:1.6; min-height:100vh; -webkit-font-smoothing:antialiased; overflow-x:hidden;
+  }
+  .mono { font-family:"IBM Plex Mono",monospace; }
+  a { color:var(--accent); text-decoration:none; }
+  ::selection { background:var(--accent); color:#00120a; }
+  ::-webkit-scrollbar { width:11px; height:11px; }
+  ::-webkit-scrollbar-track { background:var(--void); }
+  ::-webkit-scrollbar-thumb { background:#16241d; border:2px solid var(--void); border-radius:6px; }
 
-    html { scroll-behavior: smooth; }
+  /* CRT overlays */
+  .crt-overlay { pointer-events:none; position:fixed; inset:0; z-index:9000;
+    background:repeating-linear-gradient(to bottom, rgba(0,0,0,0) 0 2px, rgba(0,30,18,0.15) 3px 3px);
+    mix-blend-mode:multiply; }
+  .crt-vignette { pointer-events:none; position:fixed; inset:0; z-index:9001;
+    box-shadow:inset 0 0 240px 40px rgba(0,0,0,0.9); opacity:0.6; }
+  .bin-rain { pointer-events:none; position:fixed; inset:0; z-index:0; overflow:hidden; opacity:0.55; }
+  @keyframes rain { from { transform:translateY(0);} to { transform:translateY(170vh);} }
 
-    body {
-      background: var(--bg);
-      color: var(--text);
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
-      font-size: 1rem;
-      line-height: 1.6;
-      min-height: 100vh;
-    }
+  .wrap { max-width:var(--maxw); margin:0 auto; padding:0 26px; position:relative; z-index:1; }
 
-    a { color: var(--accent); text-decoration: none; }
-    a:hover { text-decoration: underline; }
+  /* labels */
+  .kicker { font-family:"IBM Plex Mono",monospace; font-size:11px; letter-spacing:0.32em;
+            text-transform:uppercase; color:var(--accent); font-weight:600; }
+  .label { font-family:"IBM Plex Mono",monospace; font-size:10.5px; letter-spacing:0.22em;
+           text-transform:uppercase; color:var(--muted); font-weight:500; }
 
-    /* ── Layout ── */
-    .container { max-width: 860px; margin: 0 auto; padding: 0 1.5rem; }
+  /* cursor + glitch */
+  .cursor { display:inline-block; width:9px; height:1em; background:var(--accent); vertical-align:-1px;
+            margin-left:2px; animation:blink 1.05s steps(2) infinite; }
+  @keyframes blink { 0%,50%{opacity:1;} 51%,100%{opacity:0;} }
+  .glitch { position:relative; }
+  .glitch[data-txt]::before, .glitch[data-txt]::after {
+    content:attr(data-txt); position:absolute; left:0; top:0; width:100%; pointer-events:none; }
+  .glitch[data-txt]::before { color:var(--cyan); clip-path:inset(0 0 55% 0); mix-blend-mode:screen; animation:gx 4.2s infinite steps(40); }
+  .glitch[data-txt]::after  { color:var(--red);  clip-path:inset(55% 0 0 0); mix-blend-mode:screen; animation:gx 3.1s infinite reverse steps(40); }
+  @keyframes gx { 0%,92%,100%{transform:translate(0,0);} 93%{transform:translate(-2px,1px);} 95%{transform:translate(2px,-1px);} 97%{transform:translate(-1px,0);} }
+  @media (prefers-reduced-motion:reduce){ .glitch::before,.glitch::after{animation:none;} }
 
-    /* ── Nav ── */
-    nav {
-      border-bottom: 1px solid var(--border);
-      padding: 0.9rem 0;
-      position: sticky;
-      top: 0;
-      background: rgba(13, 17, 23, 0.92);
-      backdrop-filter: blur(6px);
-      z-index: 100;
-    }
-    nav .container {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-    }
-    .nav-brand {
-      font-weight: 700;
-      font-size: 1.05rem;
-      color: var(--heading);
-      letter-spacing: 0.02em;
-    }
-    .nav-brand span { color: var(--accent); }
-    nav ul {
-      list-style: none;
-      display: flex;
-      gap: 1.5rem;
-    }
-    nav ul a {
-      color: var(--muted);
-      font-size: 0.9rem;
-      transition: color 0.15s;
-    }
-    nav ul a:hover { color: var(--heading); text-decoration: none; }
+  /* ── Nav ─────────────────────────────────────────────────────────────────── */
+  nav { position:sticky; top:0; z-index:200; border-bottom:1px solid var(--line);
+        background:rgba(5,9,12,0.82); backdrop-filter:blur(9px); }
+  nav .wrap { display:flex; align-items:center; justify-content:space-between; height:62px; }
+  .brand { display:flex; align-items:center; gap:11px; }
+  .brand .dia { color:var(--accent); font-size:18px; filter:drop-shadow(0 0 7px var(--accent)); }
+  .brand .nm { font-family:"IBM Plex Mono",monospace; font-weight:700; font-size:15px; letter-spacing:0.34em;
+               text-transform:uppercase; color:var(--bright); }
+  .nav-links { display:flex; align-items:center; gap:26px; }
+  .nav-links a { font-family:"IBM Plex Mono",monospace; font-size:12px; letter-spacing:0.12em; color:var(--muted);
+                 text-transform:uppercase; transition:color .15s; }
+  .nav-links a:hover, .nav-links a.active { color:var(--bright); }
+  .nav-links a.active { color:var(--accent); }
+  .nav-cta { font-family:"IBM Plex Mono",monospace; font-size:12px; letter-spacing:0.08em; font-weight:600;
+             color:var(--void); background:var(--accent); padding:8px 15px; border-radius:2px;
+             box-shadow:0 0 16px rgba(43,255,136,0.3); transition:transform .12s; white-space:nowrap; }
+  .nav-cta:hover { transform:translateY(-1px); }
+  @media (max-width:760px){ .nav-links { display:none; } }
 
-    /* ── Hero ── */
-    .hero {
-      padding: 5rem 0 4rem;
-      text-align: center;
-    }
-    .hero-badge {
-      display: inline-block;
-      background: rgba(88, 166, 255, 0.1);
-      border: 1px solid rgba(88, 166, 255, 0.3);
-      color: var(--accent);
-      font-size: 0.78rem;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      padding: 0.3rem 0.8rem;
-      border-radius: 2rem;
-      margin-bottom: 1.4rem;
-    }
-    .hero h1 {
-      font-size: clamp(2.2rem, 5vw, 3.4rem);
-      font-weight: 800;
-      color: var(--heading);
-      letter-spacing: -0.02em;
-      line-height: 1.15;
-      margin-bottom: 1.1rem;
-    }
-    .hero h1 span { color: var(--accent); }
-    .hero p {
-      font-size: 1.15rem;
-      color: var(--muted);
-      max-width: 580px;
-      margin: 0 auto 2.2rem;
-    }
-    .btn-group { display: flex; gap: 0.8rem; justify-content: center; flex-wrap: wrap; }
-    .btn {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      padding: 0.65rem 1.4rem;
-      border-radius: 6px;
-      font-size: 0.95rem;
-      font-weight: 600;
-      transition: opacity 0.15s, transform 0.1s;
-      cursor: pointer;
-      border: none;
-    }
-    .btn:hover { opacity: 0.85; transform: translateY(-1px); text-decoration: none; }
-    .btn-primary { background: var(--accent); color: #0d1117; }
-    .btn-secondary {
-      background: transparent;
-      color: var(--text);
-      border: 1px solid var(--border);
-    }
+  /* ── Hero ────────────────────────────────────────────────────────────────── */
+  .hero { padding:74px 0 60px; display:grid; grid-template-columns:1fr 1fr; gap:54px; align-items:center; }
+  @media (max-width:920px){ .hero { grid-template-columns:1fr; gap:40px; padding:52px 0 44px; } }
+  .badge { display:inline-flex; align-items:center; gap:9px; font-family:"IBM Plex Mono",monospace;
+           font-size:10.5px; letter-spacing:0.16em; text-transform:uppercase; color:var(--cyan);
+           border:1px solid rgba(68,224,230,0.3); background:rgba(68,224,230,0.05); padding:6px 12px;
+           border-radius:2px; margin-bottom:24px; }
+  .badge .dot { width:6px; height:6px; border-radius:50%; background:var(--cyan); box-shadow:0 0 8px var(--cyan); }
+  h1 { font-family:"IBM Plex Sans",sans-serif; font-weight:700; font-size:clamp(2.3rem,4.6vw,3.5rem);
+       line-height:1.08; letter-spacing:-0.02em; color:var(--bright); margin-bottom:20px; }
+  h1 .g { color:var(--accent); text-shadow:0 0 26px rgba(43,255,136,0.35); }
+  .lead { font-size:1.06rem; color:var(--text); max-width:520px; margin-bottom:30px; }
+  .cta-row { display:flex; gap:13px; flex-wrap:wrap; align-items:center; }
+  .btn { display:inline-flex; align-items:center; gap:9px; font-family:"IBM Plex Mono",monospace;
+         font-size:13px; font-weight:600; letter-spacing:0.04em; padding:12px 20px; border-radius:2px;
+         transition:transform .12s, box-shadow .2s; cursor:pointer; }
+  .btn-primary { background:var(--accent); color:var(--void); box-shadow:0 0 20px rgba(43,255,136,0.28); }
+  .btn-primary:hover { transform:translateY(-2px); box-shadow:0 0 30px rgba(43,255,136,0.5); }
+  .btn-ghost { border:1px solid var(--line); color:var(--text); }
+  .btn-ghost:hover { border-color:var(--accent); color:var(--bright); }
+  .pip { font-family:"IBM Plex Mono",monospace; font-size:12.5px; color:var(--muted); margin-top:16px;
+         display:flex; align-items:center; gap:8px; }
+  .pip code { color:var(--green); background:var(--void); border:1px solid var(--line); padding:4px 9px; border-radius:2px; }
+  .pip .cp { cursor:pointer; color:var(--muted); border:1px solid var(--line); padding:3px 7px; border-radius:2px;
+             font-size:9.5px; letter-spacing:0.1em; text-transform:uppercase; }
+  .pip .cp:hover { color:var(--accent); border-color:var(--accent); }
 
-    /* ── Score demo strip ── */
-    .score-strip {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 10px;
-      padding: 1.5rem 2rem;
-      margin: 3rem 0;
-      display: flex;
-      align-items: center;
-      gap: 2rem;
-      flex-wrap: wrap;
-    }
-    .score-block { text-align: center; min-width: 80px; }
-    .score-num {
-      font-size: 2.8rem;
-      font-weight: 800;
-      color: var(--accent2);
-      line-height: 1;
-    }
-    .score-label { font-size: 0.78rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; margin-top: 0.2rem; }
-    .score-bar-wrap { flex: 1; min-width: 200px; }
-    .score-bar-label { display: flex; justify-content: space-between; font-size: 0.8rem; color: var(--muted); margin-bottom: 0.4rem; }
-    .score-bar { height: 8px; background: var(--border); border-radius: 4px; overflow: hidden; }
-    .score-bar-fill { height: 100%; background: linear-gradient(90deg, var(--accent2), var(--accent)); border-radius: 4px; width: 76%; }
-    .score-pills { display: flex; gap: 0.6rem; flex-wrap: wrap; }
-    .pill {
-      font-size: 0.78rem;
-      font-weight: 600;
-      padding: 0.25rem 0.65rem;
-      border-radius: 1rem;
-    }
-    .pill-pass  { background: rgba(63,185,80,.15);  color: var(--accent2); }
-    .pill-fail  { background: rgba(248,81,73,.15);  color: var(--danger); }
-    .pill-warn  { background: rgba(210,153,34,.15); color: var(--warn); }
-    .pill-info  { background: rgba(88,166,255,.15); color: var(--accent); }
+  /* terminal window */
+  .term { background:linear-gradient(180deg, rgba(43,255,136,0.02), transparent 90px), #04080b;
+          border:1px solid var(--line); border-radius:6px; overflow:hidden; position:relative;
+          box-shadow:0 30px 80px -30px rgba(0,0,0,0.9), 0 0 0 1px rgba(0,0,0,0.4); }
+  .term-bar { display:flex; align-items:center; gap:8px; padding:11px 14px; border-bottom:1px solid var(--line);
+              background:rgba(0,0,0,0.3); }
+  .term-bar .tdot { width:11px; height:11px; border-radius:50%; }
+  .term-bar .t1 { background:#ff5f56; } .term-bar .t2 { background:#ffbd2e; } .term-bar .t3 { background:#27c93f; }
+  .term-bar .ttitle { margin-left:10px; font-family:"IBM Plex Mono",monospace; font-size:11px; color:var(--muted); letter-spacing:0.06em; }
+  .term-body { padding:16px 18px 18px; font-family:"IBM Plex Mono",monospace; font-size:12.5px; line-height:1.55;
+               white-space:pre; overflow-x:auto; }
+  .term-body .tl { display:block; }
+  .g-prompt { color:var(--cyan); } .g-cmd { color:var(--bright); }
+  .g-green { color:var(--green); } .g-red { color:var(--red); } .g-amber { color:var(--amber); }
+  .g-cyan { color:var(--cyan); } .g-dim { color:var(--muted); } .g-box { color:#16281f; }
+  .g-bigD { color:var(--amber); font-weight:700; }
+  .g-rail { color:var(--accent); } .g-kick { color:var(--accent); letter-spacing:0.12em; }
+  .g-faint { color:var(--faint); } .g-bright { color:var(--bright); }
 
-    /* ── Sections ── */
-    section { padding: 3.5rem 0; border-top: 1px solid var(--border); }
-    section h2 {
-      font-size: 1.6rem;
-      font-weight: 700;
-      color: var(--heading);
-      margin-bottom: 0.4rem;
-    }
-    .section-sub { color: var(--muted); margin-bottom: 2rem; font-size: 0.95rem; }
+  /* ── Trust strip ─────────────────────────────────────────────────────────── */
+  .trust { border-top:1px solid var(--line); border-bottom:1px solid var(--line); background:rgba(0,0,0,0.25); }
+  .trust .wrap { display:flex; flex-wrap:wrap; gap:10px 30px; align-items:center; justify-content:center;
+                 padding:16px 26px; font-family:"IBM Plex Mono",monospace; font-size:12px; letter-spacing:0.06em; }
+  .trust span { color:var(--muted); display:inline-flex; align-items:center; gap:10px; }
+  .trust span::before { content:"◈"; color:var(--accent); font-size:10px; opacity:0.7; }
+  .trust b { color:var(--text); font-weight:500; }
 
-    /* ── Features grid ── */
-    .features-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      gap: 1rem;
-    }
-    .feature-card {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 8px;
-      padding: 1.2rem 1.3rem;
-      transition: border-color 0.15s;
-    }
-    .feature-card:hover { border-color: var(--accent); }
-    .feature-icon { font-size: 1.4rem; margin-bottom: 0.6rem; }
-    .feature-card h3 { font-size: 0.95rem; font-weight: 600; color: var(--heading); margin-bottom: 0.3rem; }
-    .feature-card p  { font-size: 0.85rem; color: var(--muted); line-height: 1.5; }
+  /* ── Sections ────────────────────────────────────────────────────────────── */
+  section { padding:84px 0; }
+  .sec-head { margin-bottom:42px; max-width:640px; }
+  .sec-head h2 { font-family:"IBM Plex Sans"; font-weight:700; font-size:clamp(1.7rem,3vw,2.3rem);
+                 color:var(--bright); letter-spacing:-0.01em; margin:12px 0 10px; }
+  .sec-head p { color:var(--muted); font-size:1rem; }
 
-    /* ── Getting started ── */
-    .steps { display: flex; flex-direction: column; gap: 1rem; }
-    .step {
-      display: flex;
-      gap: 1rem;
-      align-items: flex-start;
-    }
-    .step-num {
-      flex-shrink: 0;
-      width: 2rem;
-      height: 2rem;
-      border-radius: 50%;
-      background: rgba(88, 166, 255, 0.15);
-      border: 1px solid rgba(88, 166, 255, 0.3);
-      color: var(--accent);
-      font-weight: 700;
-      font-size: 0.85rem;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-    .step-body h3 { font-size: 0.95rem; font-weight: 600; color: var(--heading); margin-bottom: 0.25rem; }
-    .step-body p  { font-size: 0.88rem; color: var(--muted); }
-    pre, code {
-      font-family: "Cascadia Code", "Fira Code", "Consolas", monospace;
-    }
-    pre {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      padding: 0.9rem 1.1rem;
-      font-size: 0.87rem;
-      color: var(--accent2);
-      overflow-x: auto;
-      margin-top: 0.5rem;
-    }
+  /* reveal */
+  [data-reveal] { opacity:0; transform:translateY(16px); transition:opacity .6s, transform .6s; }
+  [data-reveal].in { opacity:1; transform:none; }
+  @media (prefers-reduced-motion:reduce){ [data-reveal]{ opacity:1; transform:none; } }
 
-    /* ── Checks table ── */
-    .modules-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
-      gap: 0.5rem;
-    }
-    .module-tag {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 5px;
-      padding: 0.45rem 0.8rem;
-      font-size: 0.83rem;
-      color: var(--text);
-      display: flex;
-      align-items: center;
-      gap: 0.4rem;
-    }
-    .module-tag::before { content: ""; width: 6px; height: 6px; border-radius: 50%; background: var(--accent2); flex-shrink: 0; }
+  /* features */
+  .feat-grid { display:grid; grid-template-columns:repeat(4,1fr); gap:14px; }
+  @media (max-width:920px){ .feat-grid { grid-template-columns:repeat(2,1fr); } }
+  @media (max-width:560px){ .feat-grid { grid-template-columns:1fr; } }
+  .feat { background:var(--panel); border:1px solid var(--line); border-radius:var(--r); padding:20px 18px;
+          position:relative; transition:border-color .18s, transform .18s; overflow:hidden; }
+  .feat:hover { border-color:rgba(43,255,136,0.35); transform:translateY(-3px); }
+  .feat .idx { font-family:"IBM Plex Mono",monospace; font-size:11px; color:var(--accent); letter-spacing:0.1em; }
+  .feat h3 { font-family:"IBM Plex Sans"; font-size:0.98rem; font-weight:600; color:var(--bright); margin:14px 0 8px; }
+  .feat p { font-size:0.86rem; color:var(--muted); line-height:1.55; }
+  .feat::after { content:""; position:absolute; right:-1px; bottom:-1px; width:12px; height:12px;
+    border-right:1px solid var(--accent); border-bottom:1px solid var(--accent); opacity:0; transition:opacity .18s; }
+  .feat:hover::after { opacity:0.6; }
 
-    /* ── Footer ── */
-    footer {
-      border-top: 1px solid var(--border);
-      padding: 2rem 0;
-      text-align: center;
-      font-size: 0.83rem;
-      color: var(--muted);
-    }
-    footer a { color: var(--muted); }
-    footer a:hover { color: var(--text); }
+  /* checks */
+  .checks-top { display:flex; align-items:baseline; gap:26px; flex-wrap:wrap; margin-bottom:30px; }
+  .bignum { font-family:"IBM Plex Mono",monospace; font-weight:700; font-size:3.4rem; color:var(--accent);
+            line-height:1; text-shadow:0 0 24px rgba(43,255,136,0.3); }
+  .bignum small { display:block; font-size:0.8rem; color:var(--muted); letter-spacing:0.2em; text-transform:uppercase; font-weight:500; margin-top:6px; }
+  .cat-grid { display:grid; grid-template-columns:repeat(3,1fr); gap:12px; }
+  @media (max-width:880px){ .cat-grid { grid-template-columns:repeat(2,1fr); } }
+  @media (max-width:560px){ .cat-grid { grid-template-columns:1fr; } }
+  .cat-card { background:var(--panel); border:1px solid var(--line); border-radius:var(--r); padding:15px 16px;
+              transition:border-color .18s; }
+  .cat-card:hover { border-color:rgba(43,255,136,0.3); }
+  .cat-card .ch { display:flex; align-items:center; justify-content:space-between; margin-bottom:9px; }
+  .cat-card .cn { font-family:"IBM Plex Mono",monospace; font-size:12.5px; color:var(--bright); letter-spacing:0.06em; text-transform:uppercase; }
+  .cat-card .cc { font-family:"IBM Plex Mono",monospace; font-size:11px; color:var(--accent); }
+  .cat-card .cl { font-size:0.82rem; color:var(--muted); line-height:1.55; }
 
-    @media (max-width: 600px) {
-      .score-strip { flex-direction: column; align-items: flex-start; gap: 1rem; }
-      nav ul { gap: 1rem; }
-    }
+  /* scoring */
+  .score-wrap { display:grid; grid-template-columns:1.15fr 0.85fr; gap:24px; }
+  @media (max-width:880px){ .score-wrap { grid-template-columns:1fr; } }
+  .score-panel { background:var(--panel); border:1px solid var(--line); border-radius:var(--r); padding:22px 22px 8px; }
+  .score-panel h3 { font-family:"IBM Plex Mono"; font-size:12px; letter-spacing:0.14em; text-transform:uppercase; color:var(--muted); margin-bottom:16px; }
+  table.dt { width:100%; border-collapse:collapse; font-family:"IBM Plex Mono",monospace; font-size:12.5px; }
+  table.dt th { text-align:left; color:var(--faint); font-weight:500; letter-spacing:0.1em; text-transform:uppercase; font-size:10px; padding:0 0 10px; }
+  table.dt td { padding:8px 0; border-top:1px solid var(--line-soft); color:var(--text); }
+  table.dt td:last-child, table.dt th:last-child { text-align:right; }
+  .ded { font-weight:700; }
+  .grade-scale { display:flex; flex-direction:column; gap:9px; }
+  .grow { display:grid; grid-template-columns:30px 1fr auto; align-items:center; gap:14px;
+          background:var(--panel); border:1px solid var(--line); border-radius:var(--r); padding:12px 16px; }
+  .gletter { font-family:"IBM Plex Mono"; font-weight:700; font-size:18px; text-align:center; }
+  .grange { font-family:"IBM Plex Mono"; font-size:13px; color:var(--bright); }
+  .glabel { font-family:"IBM Plex Mono"; font-size:11px; letter-spacing:0.12em; text-transform:uppercase; color:var(--muted); }
+
+  /* report teaser */
+  .report-cta { background:linear-gradient(180deg, rgba(43,255,136,0.04), transparent), var(--panel);
+                border:1px solid var(--line); border-radius:6px; padding:34px; display:grid;
+                grid-template-columns:1fr auto; gap:30px; align-items:center; position:relative; overflow:hidden; }
+  @media (max-width:760px){ .report-cta { grid-template-columns:1fr; } }
+  .report-cta h3 { font-family:"IBM Plex Sans"; font-size:1.4rem; font-weight:700; color:var(--bright); margin-bottom:10px; }
+  .report-cta p { color:var(--muted); max-width:460px; margin-bottom:18px; font-size:0.95rem; }
+  .mini-score { display:flex; align-items:center; gap:18px; }
+  .mini-ring { width:104px; height:104px; flex-shrink:0; }
+  .mini-meta .mt { font-family:"IBM Plex Mono"; font-size:11px; color:var(--muted); letter-spacing:0.1em; text-transform:uppercase; }
+  .mini-pills { display:flex; flex-direction:column; gap:6px; margin-top:4px; }
+  .mp { font-family:"IBM Plex Mono"; font-size:11px; display:flex; gap:8px; }
+
+  /* get started */
+  .steps { display:flex; flex-direction:column; gap:16px; max-width:760px; }
+  .step { display:grid; grid-template-columns:38px 1fr; gap:18px; align-items:start; }
+  .step-n { width:38px; height:38px; border-radius:2px; border:1px solid rgba(43,255,136,0.3);
+            background:rgba(43,255,136,0.06); color:var(--accent); font-family:"IBM Plex Mono"; font-weight:700;
+            display:flex; align-items:center; justify-content:center; font-size:14px; }
+  .step h3 { font-family:"IBM Plex Sans"; font-size:1rem; font-weight:600; color:var(--bright); margin-bottom:5px; }
+  .step p { font-size:0.9rem; color:var(--muted); }
+  .code { font-family:"IBM Plex Mono"; font-size:12.5px; background:#02060a; border:1px solid var(--line);
+          border-left:2px solid var(--accent); border-radius:2px; padding:11px 13px; color:var(--green);
+          margin-top:9px; position:relative; white-space:pre-wrap; }
+  .code .cp { position:absolute; top:7px; right:8px; font-size:9.5px; letter-spacing:0.1em; text-transform:uppercase;
+              color:var(--muted); border:1px solid var(--line); padding:3px 7px; border-radius:2px; background:var(--void); cursor:pointer; }
+  .code .cp:hover { color:var(--accent); border-color:var(--accent); }
+
+  /* footer */
+  footer { border-top:1px solid var(--line); padding:36px 0 48px; }
+  footer .wrap { display:flex; justify-content:space-between; align-items:center; gap:20px; flex-wrap:wrap;
+                 font-family:"IBM Plex Mono"; font-size:12px; color:var(--muted); letter-spacing:0.04em; }
+  footer a { color:var(--muted); border-bottom:1px dashed transparent; }
+  footer a:hover { color:var(--accent); border-bottom-color:var(--accent); }
+  footer .nodata { color:var(--green); font-weight:600; text-shadow:0 0 9px rgba(43,255,136,0.45); }
+  .foot-auth { color:var(--faint); margin-top:10px; font-size:11px; }
   </style>
 </head>
 <body>
+  <div class="bin-rain" id="binRain"></div>
 
-<!-- ── Navigation ── -->
-<nav>
-  <div class="container">
-    <span class="nav-brand">Apo<span>trope</span></span>
-    <ul>
-      <li><a href="#features">Features</a></li>
-      <li><a href="#checks">Checks</a></li>
-      <li><a href="#start">Get Started</a></li>
-      <li><a href="https://github.com/hexorcist404/apotrope">GitHub</a></li>
-    </ul>
-  </div>
-</nav>
-
-<!-- ── Hero ── -->
-<header class="hero">
-  <div class="container">
-    <div class="hero-badge">Open Source &middot; Windows 10 / 11</div>
-    <h1>Security posture auditing<br/>for <span>Windows</span>, offline.</h1>
-    <p>
-      A single executable that scores your Windows security configuration against
-      CIS Benchmark controls and gives you plain-English remediation steps —
-      no cloud, no agent, no license.
-    </p>
-    <p style="font-size:0.9rem; color:var(--muted); margin-bottom:2rem;">
-      <em>apotrope</em> &middot; some charms ward off harm
-    </p>
-    <div class="btn-group">
-      <a class="btn btn-primary" href="https://github.com/hexorcist404/apotrope/releases/latest">
-        &#8659; Download apotrope.exe
+  <!-- ── Nav ─────────────────────────────────────────────────────────────── -->
+  <nav>
+    <div class="wrap">
+      <a class="brand" href="#top">
+        <span class="dia">◈</span>
+        <span class="nm glitch" data-txt="APOTROPE">APOTROPE</span>
       </a>
-      <a class="btn btn-secondary" href="https://github.com/hexorcist404/apotrope">
-        View on GitHub
-      </a>
+      <div class="nav-links">
+        <a href="#features">Features</a>
+        <a href="#checks">Checks</a>
+        <a href="#scoring">Scoring</a>
+        <a href="#report">Report</a>
+        <a href="#start">Get Started</a>
+        <a href="https://github.com/hexorcist404/apotrope">GitHub ↗</a>
+      </div>
+      <a class="nav-cta" href="https://github.com/hexorcist404/apotrope/releases/latest">↓ Download</a>
     </div>
-    <p style="font-size:0.85rem; color:var(--muted); margin-top:1rem;">
-      or, with Python 3.12+: <code>pip install apotrope</code>
-    </p>
+  </nav>
 
-    <!-- Score demo -->
-    <div class="score-strip">
-      <div class="score-block">
-        <div class="score-num">76</div>
-        <div class="score-label">/ 100 &nbsp; C&nbsp;&middot;&nbsp;Fair</div>
-      </div>
-      <div class="score-bar-wrap">
-        <div class="score-bar-label">
-          <span>Security Score</span>
-          <span>53 checks &middot; 22s</span>
+  <!-- ── Hero ────────────────────────────────────────────────────────────── -->
+  <header id="top">
+    <div class="wrap hero">
+      <div data-reveal>
+        <span class="badge"><span class="dot"></span>Open source · Windows 10/11 · Offline</span>
+        <h1>Security posture auditing for Windows, <span class="g">entirely offline.</span></h1>
+        <p class="lead">
+          A single executable that scores your Windows security configuration against
+          CIS Benchmark controls and gives you plain-English remediation steps —
+          no cloud, no agent, no license.
+        </p>
+        <div class="cta-row">
+          <a class="btn btn-primary" href="https://github.com/hexorcist404/apotrope/releases/latest">↓ Download apotrope.exe</a>
+          <a class="btn btn-ghost" href="https://github.com/hexorcist404/apotrope">View on GitHub ↗</a>
         </div>
-        <div class="score-bar"><div class="score-bar-fill"></div></div>
-        <div class="score-pills" style="margin-top:0.7rem;">
-          <span class="pill pill-pass">&#10003; 35 passed</span>
-          <span class="pill pill-fail">&#215; 3 failed</span>
-          <span class="pill pill-warn">&#33; 2 warnings</span>
-          <span class="pill pill-info">i 13 info</span>
+        <div class="pip">
+          or with Python 3.12+: <code>pip install apotrope</code>
+          <button class="cp" data-copy="pip install apotrope">copy</button>
         </div>
       </div>
+
+      <div data-reveal>
+        <div class="term">
+    <div class="term-bar">
+      <span class="tdot t1"></span><span class="tdot t2"></span><span class="tdot t3"></span>
+      <span class="ttitle">Administrator: Windows Terminal</span>
+    </div>
+    <div class="term-body" id="scanTerm"><span class="tl">  <span class="g-prompt">PS C:\&gt;</span> <span class="g-cmd">apotrope.exe --html report.html</span></span><span class="tl"> </span><span class="tl">  <span class="g-green">◈ APOTROPE</span>  <span class="g-dim">v0.1.5</span></span><span class="tl">  <span class="g-dim">Windows Security Posture Auditor</span></span><span class="tl"> </span><span class="tl" data-pause="650">  <span class="g-dim">scanning 56 controls </span><span class="g-cyan">[████████████████████]</span> <span class="g-dim">done · 21.7s</span></span><span class="tl"> </span><span class="tl">  <span class="g-rail">▌</span> <span class="g-kick">SECURITY SCORE</span>                <span class="g-dim">WORKSTATION-07</span></span><span class="tl">  <span class="g-rail">▌</span> <span class="g-dim">Windows 11 Pro 23H2 · CORP.local</span></span><span class="tl">  <span class="g-rail">▌</span></span><span class="tl" data-pause="320">  <span class="g-rail">▌</span> <span class="g-bigD">69 / 100</span>   <span class="g-amber">D · POOR</span></span><span class="tl">  <span class="g-rail">▌</span> <span class="g-amber">█████████████████</span><span class="g-box">░░░░░░░</span></span><span class="tl">  <span class="g-rail">▌</span></span><span class="tl">  <span class="g-rail">▌</span> <span class="g-green">✓ 35 pass</span>   <span class="g-red">✗ 3 fail</span>   <span class="g-amber">! 4 warn</span>   <span class="g-cyan">i 14 info</span></span><span class="tl">  <span class="g-rail">▌</span> <span class="g-faint">56 checks evaluated</span></span><span class="tl"> </span><span class="tl" data-pause="280">  <span class="g-red">⚑ TOP FAILURES</span></span><span class="tl">  <span class="g-red">✗</span> <span class="g-red">HIGH </span>Public inbound = Allow     <span class="g-faint">CIS 9.3.2</span></span><span class="tl">  <span class="g-red">✗</span> <span class="g-amber">MED  </span>SMB signing not required   <span class="g-faint">CIS 2.3.8.1</span></span><span class="tl">  <span class="g-red">✗</span> <span class="g-amber">MED  </span>Script-block logging off   <span class="g-faint">CIS 18.9.95.1</span></span><span class="tl"> </span><span class="tl" data-pause="320">  <span class="g-green">→ report.html written</span> <span class="g-dim">· open to triage all 7 issues</span></span><span class="tl">  <span class="g-prompt">PS C:\&gt;</span> <span class="cursor"></span></span></div>
+  </div>
+      </div>
+    </div>
+  </header>
+
+  <!-- ── Trust strip ─────────────────────────────────────────────────────── -->
+  <div class="trust">
+    <div class="wrap">
+      <span><b>No cloud</b></span>
+      <span><b>No agent</b></span>
+      <span><b>No telemetry</b></span>
+      <span><b>No license key</b></span>
+      <span><b>Single executable</b></span>
+      <span><b>Read-only</b></span>
     </div>
   </div>
-</header>
 
-<!-- ── Features ── -->
-<section id="features">
-  <div class="container">
-    <h2>Features</h2>
-    <p class="section-sub">Everything you need for a fast, credible security assessment.</p>
-    <div class="features-grid">
-      <div class="feature-card">
-        <div class="feature-icon">&#127959;</div>
-        <h3>Single Executable</h3>
-        <p>Drop <code>apotrope.exe</code> on a USB drive and run it on any Windows machine. No installation, no Python, no dependencies.</p>
+  <!-- ── Features ────────────────────────────────────────────────────────── -->
+  <section id="features">
+    <div class="wrap">
+      <div class="sec-head" data-reveal>
+        <span class="kicker">// Features</span>
+        <h2>Everything you need for a fast, credible assessment.</h2>
+        <p>No setup, no accounts, no data leaving the machine — just an honest read on the box in front of you.</p>
       </div>
-      <div class="feature-card">
-        <div class="feature-icon">&#128274;</div>
-        <h3>Fully Offline</h3>
-        <p>No data leaves the machine. No telemetry, no cloud APIs, no license servers — your audit data stays yours.</p>
-      </div>
-      <div class="feature-card">
-        <div class="feature-icon">&#128203;</div>
-        <h3>CIS Benchmark Mapping</h3>
-        <p>Every finding is annotated with the corresponding CIS Benchmark control ID — v5.0.0 for Windows 11, v4.0.0 for Windows 10 — detected automatically at scan time.</p>
-      </div>
-      <div class="feature-card">
-        <div class="feature-icon">&#128200;</div>
-        <h3>Scored &amp; Graded</h3>
-        <p>A 0–100 security score with letter grade gives you an at-a-glance picture of the system's risk posture.</p>
-      </div>
-      <div class="feature-card">
-        <div class="feature-icon">&#128196;</div>
-        <h3>HTML &amp; JSON Reports</h3>
-        <p>Export a self-contained HTML report for stakeholders or a structured JSON report for pipeline integration.</p>
-      </div>
-      <div class="feature-card">
-        <div class="feature-icon">&#128260;</div>
-        <h3>Comparative Scanning</h3>
-        <p>Save a baseline and diff against it later to track remediation progress over time with <code>--baseline</code> and <code>--compare</code>.</p>
-      </div>
-      <div class="feature-card">
-        <div class="feature-icon">&#9881;</div>
-        <h3>Custom Profiles</h3>
-        <p>A <code>apotrope.toml</code> config lets you disable checks, override severities, and tune thresholds for your environment.</p>
-      </div>
-      <div class="feature-card">
-        <div class="feature-icon">&#128295;</div>
-        <h3>Actionable Remediation</h3>
-        <p>Every failing check includes a concrete fix command or Group Policy path — not just a problem description.</p>
+      <div class="feat-grid">
+        <div class="feat" data-reveal>
+          <span class="idx">01</span>
+          <h3>Single Executable</h3>
+          <p>Drop <span class="mono">apotrope.exe</span> on a USB stick and run it on any Windows machine. No install, no Python, no dependencies.</p>
+        </div>
+        <div class="feat" data-reveal>
+          <span class="idx">02</span>
+          <h3>Fully Offline</h3>
+          <p>No data leaves the machine. No telemetry, no cloud APIs, no license servers — your audit data stays yours.</p>
+        </div>
+        <div class="feat" data-reveal>
+          <span class="idx">03</span>
+          <h3>CIS Benchmark Mapping</h3>
+          <p>Every finding is annotated with its CIS Benchmark control ID — v5.0.0 for Windows 11, v4.0.0 for Windows 10 — detected automatically at scan time.</p>
+        </div>
+        <div class="feat" data-reveal>
+          <span class="idx">04</span>
+          <h3>Scored &amp; Graded</h3>
+          <p>A 0–100 security score with an A–F letter grade gives you an at-a-glance read on the system's risk posture.</p>
+        </div>
+        <div class="feat" data-reveal>
+          <span class="idx">05</span>
+          <h3>HTML &amp; JSON Reports</h3>
+          <p>Export a self-contained HTML report for stakeholders or a structured JSON report for pipeline integration.</p>
+        </div>
+        <div class="feat" data-reveal>
+          <span class="idx">06</span>
+          <h3>Comparative Scanning</h3>
+          <p>Save a baseline and diff against it later to track remediation progress with <span class="mono">--baseline</span> and <span class="mono">--compare</span>.</p>
+        </div>
+        <div class="feat" data-reveal>
+          <span class="idx">07</span>
+          <h3>Custom Profiles</h3>
+          <p>An <span class="mono">apotrope.toml</span> profile lets you disable checks, override severities, and tune thresholds for your environment.</p>
+        </div>
+        <div class="feat" data-reveal>
+          <span class="idx">08</span>
+          <h3>Actionable Remediation</h3>
+          <p>Every failing check ships a concrete fix command or Group Policy path — not just a description of the problem.</p>
+        </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<!-- ── Check modules ── -->
-<section id="checks">
-  <div class="container">
-    <h2>14 Check Modules</h2>
-    <p class="section-sub">Covers the most impactful Windows security controls out of the box.</p>
-    <div class="modules-grid">
-      <div class="module-tag">Access Control (UAC)</div>
-      <div class="module-tag">Local Accounts</div>
-      <div class="module-tag">Password Policy</div>
-      <div class="module-tag">Windows Defender</div>
-      <div class="module-tag">Tamper Protection</div>
-      <div class="module-tag">BitLocker (per drive)</div>
-      <div class="module-tag">Firewall Profiles</div>
-      <div class="module-tag">SMB v1 / Signing</div>
-      <div class="module-tag">RDP &amp; NLA</div>
-      <div class="module-tag">Windows Updates</div>
-      <div class="module-tag">Startup Programs</div>
-      <div class="module-tag">Risky Services</div>
-      <div class="module-tag">PowerShell Logging</div>
-      <div class="module-tag">Network Hardening</div>
+  <!-- ── Checks ──────────────────────────────────────────────────────────── -->
+  <section id="checks">
+    <div class="wrap">
+      <div class="sec-head" data-reveal>
+        <span class="kicker">// Checks</span>
+        <h2>One scan, the controls that actually move risk.</h2>
+        <p>Fourteen categories of Windows security posture, mapped to CIS and scored by severity.</p>
+      </div>
+      <div class="checks-top" data-reveal>
+        <div class="bignum">55+<small>Checks</small></div>
+        <div class="bignum">14<small>Categories</small></div>
+        <div class="bignum">~22s<small>Per scan</small></div>
+      </div>
+      <div class="cat-grid">
+        <div class="cat-card" data-reveal><div class="ch"><span class="cn">Access Control</span><span class="cc">4 checks</span></div><div class="cl">UAC elevation prompts, admin approval mode, secure desktop.</div></div>
+        <div class="cat-card" data-reveal><div class="ch"><span class="cn">Accounts</span><span class="cc">6 checks</span></div><div class="cl">Local accounts, guest status, password &amp; lockout policy.</div></div>
+        <div class="cat-card" data-reveal><div class="ch"><span class="cn">Antivirus</span><span class="cc">4 checks</span></div><div class="cl">Defender real-time protection, signature age, tamper protection.</div></div>
+        <div class="cat-card" data-reveal><div class="ch"><span class="cn">Encryption</span><span class="cc">2 checks</span></div><div class="cl">BitLocker drive encryption status, per volume.</div></div>
+        <div class="cat-card" data-reveal><div class="ch"><span class="cn">File Sharing</span><span class="cc">4 checks</span></div><div class="cl">SMB signing, legacy SMBv1, and exposed shares.</div></div>
+        <div class="cat-card" data-reveal><div class="ch"><span class="cn">Firewall</span><span class="cc">6 checks</span></div><div class="cl">Domain, private &amp; public profile state and inbound posture.</div></div>
+        <div class="cat-card" data-reveal><div class="ch"><span class="cn">Hardening</span><span class="cc">5 checks</span></div><div class="cl">LSA protection, autorun, and miscellaneous OS hardening.</div></div>
+        <div class="cat-card" data-reveal><div class="ch"><span class="cn">Network</span><span class="cc">4 checks</span></div><div class="cl">Protocol hardening, discovery, and exposure reduction.</div></div>
+        <div class="cat-card" data-reveal><div class="ch"><span class="cn">Patching</span><span class="cc">3 checks</span></div><div class="cl">Windows Update health, pending updates &amp; reboots.</div></div>
+        <div class="cat-card" data-reveal><div class="ch"><span class="cn">Persistence</span><span class="cc">2 checks</span></div><div class="cl">Startup programs and autorun entries.</div></div>
+        <div class="cat-card" data-reveal><div class="ch"><span class="cn">PowerShell</span><span class="cc">5 checks</span></div><div class="cl">Script-block / module logging and execution policy.</div></div>
+        <div class="cat-card" data-reveal><div class="ch"><span class="cn">Remote Access</span><span class="cc">3 checks</span></div><div class="cl">RDP exposure and Network Level Authentication.</div></div>
+        <div class="cat-card" data-reveal><div class="ch"><span class="cn">Services</span><span class="cc">2 checks</span></div><div class="cl">Risky or unnecessary running services.</div></div>
+        <div class="cat-card" data-reveal><div class="ch"><span class="cn">System</span><span class="cc">6 checks</span></div><div class="cl">OS edition, build number, and support lifecycle.</div></div>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<!-- ── Getting started ── -->
-<section id="start">
-  <div class="container">
-    <h2>Get Started</h2>
-    <p class="section-sub">Up and running in under a minute.</p>
-
-    <p style="text-align:center; font-size:0.95rem; color:var(--muted); margin-bottom:2rem;">
-      Have Python 3.12+? Install from PyPI instead &mdash;
-      <code>pip install apotrope</code>, then run <code>apotrope</code>.
-      The steps below are for the standalone <code>apotrope.exe</code> (no Python required).
-    </p>
-
-    <div class="steps">
-
-      <div class="step">
-        <div class="step-num">1</div>
-        <div class="step-body">
-          <h3>Download the executable</h3>
-          <p>Grab <code>apotrope.exe</code> from the <a href="https://github.com/hexorcist404/apotrope/releases/latest">latest release</a> and save it somewhere easy to find — your Desktop or Downloads folder works fine.</p>
+  <!-- ── Scoring ─────────────────────────────────────────────────────────── -->
+  <section id="scoring">
+    <div class="wrap">
+      <div class="sec-head" data-reveal>
+        <span class="kicker">// Scoring</span>
+        <h2>A transparent score you can reason about.</h2>
+        <p>Start at 100. Each failing or warning check deducts points weighted by severity. The total maps to a letter grade.</p>
+      </div>
+      <div class="score-wrap">
+        <div class="score-panel" data-reveal>
+          <h3>Point deductions</h3>
+          <table class="dt">
+            <thead><tr><th>Severity</th><th>Fail</th><th>Warn</th></tr></thead>
+            <tbody>
+              <tr><td style="color:var(--crit)">Critical</td><td class="ded" style="color:var(--red)">−15</td><td class="ded" style="color:var(--amber)">−7</td></tr>
+              <tr><td style="color:var(--red)">High</td><td class="ded" style="color:var(--red)">−10</td><td class="ded" style="color:var(--amber)">−5</td></tr>
+              <tr><td style="color:var(--amber)">Medium</td><td class="ded" style="color:var(--red)">−5</td><td class="ded" style="color:var(--amber)">−2</td></tr>
+              <tr><td style="color:var(--cyan)">Low</td><td class="ded" style="color:var(--red)">−2</td><td class="ded" style="color:var(--amber)">−1</td></tr>
+              <tr><td style="color:var(--muted)">Info</td><td class="ded" style="color:var(--muted)">0</td><td class="ded" style="color:var(--muted)">0</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="grade-scale" data-reveal>
+          <div class="grow"><span class="gletter" style="color:var(--green)">A</span><span class="grange">90 – 100</span><span class="glabel">Excellent</span></div>
+          <div class="grow"><span class="gletter" style="color:var(--green)">B</span><span class="grange">80 – 89</span><span class="glabel">Good</span></div>
+          <div class="grow"><span class="gletter" style="color:var(--amber)">C</span><span class="grange">70 – 79</span><span class="glabel">Fair</span></div>
+          <div class="grow"><span class="gletter" style="color:var(--amber)">D</span><span class="grange">60 – 69</span><span class="glabel">Poor</span></div>
+          <div class="grow"><span class="gletter" style="color:var(--red)">F</span><span class="grange">0 – 59</span><span class="glabel">Critical</span></div>
         </div>
       </div>
+    </div>
+  </section>
 
-      <div class="step">
-        <div class="step-num">2</div>
-        <div class="step-body">
-          <h3>Open an Administrator terminal</h3>
-          <p>Right-click Command Prompt or PowerShell &rarr; <em>Run as administrator</em>. Some checks (BitLocker, local accounts, services) require elevation for full results.</p>
+  <!-- ── Report teaser ───────────────────────────────────────────────────── -->
+  <section id="report">
+    <div class="wrap">
+      <div class="sec-head" data-reveal>
+        <span class="kicker">// Report</span>
+        <h2>A report you can email to someone who wasn't in the room.</h2>
+        <p>One self-contained HTML file — gauge, prioritised findings, CIS mappings, remediation — that opens in any browser with no server and no network.</p>
+      </div>
+      <div class="report-cta" data-reveal>
+        <div>
+          <h3>See the full sample report.</h3>
+          <p>Filterable findings, copy-ready fixes, and a score you can defend. Generated entirely on the audited machine.</p>
+          <a class="btn btn-primary" href="report.html">Open live sample report →</a>
+        </div>
+        <div class="mini-score">
+          <svg class="mini-ring" viewBox="0 0 104 104">
+            <circle cx="52" cy="52" r="46" fill="none" stroke="#0c1610" stroke-width="7"/>
+            <circle cx="52" cy="52" r="46" fill="none" stroke="var(--amber)" stroke-width="7" stroke-linecap="round"
+              stroke-dasharray="289.0" stroke-dashoffset="89.6" transform="rotate(-90 52 52)"
+              style="filter:drop-shadow(0 0 6px var(--amber))"/>
+            <text x="52" y="50" text-anchor="middle" fill="var(--amber)" font-family="IBM Plex Mono,monospace" font-size="26" font-weight="700">69</text>
+            <text x="52" y="66" text-anchor="middle" fill="var(--muted)" font-family="IBM Plex Mono,monospace" font-size="9" letter-spacing="1.4">D · POOR</text>
+          </svg>
+          <div class="mini-meta">
+            <div class="mt">Result mix</div>
+            <div class="mini-pills">
+              <span class="mp" style="color:var(--green)">✓ 35 pass</span>
+              <span class="mp" style="color:var(--red)">✗ 3 fail</span>
+              <span class="mp" style="color:var(--amber)">! 4 warn</span>
+              <span class="mp" style="color:var(--cyan)">i 14 info</span>
+            </div>
+          </div>
         </div>
       </div>
+    </div>
+  </section>
 
-      <div class="step">
-        <div class="step-num">3</div>
-        <div class="step-body">
-          <h3>Navigate to the folder where you saved the file</h3>
-          <p>For example, if you saved it in Downloads:</p>
-          <pre>cd %USERPROFILE%\Downloads</pre>
-          <p style="margin-top:0.4rem; font-size:0.85rem; color:var(--muted);">Tip: in File Explorer, navigate to the folder, then type <code>cmd</code> in the address bar and press Enter to open a terminal there directly.</p>
-        </div>
+  <!-- ── Get started ─────────────────────────────────────────────────────── -->
+  <section id="start">
+    <div class="wrap">
+      <div class="sec-head" data-reveal>
+        <span class="kicker">// Get Started</span>
+        <h2>Up and running in under a minute.</h2>
+        <p>Standalone <span class="mono">apotrope.exe</span> below — no Python required. Have Python 3.12+? <span class="mono">pip install apotrope</span> and run <span class="mono">apotrope</span> instead.</p>
       </div>
-
-      <div class="step">
-        <div class="step-num">4</div>
-        <div class="step-body">
-          <h3>Run a scan</h3>
-          <pre>apotrope.exe</pre>
+      <div class="steps">
+        <div class="step" data-reveal>
+          <div class="step-n">1</div>
+          <div>
+            <h3>Download the executable</h3>
+            <p>Grab <span class="mono">apotrope.exe</span> from the <a href="https://github.com/hexorcist404/apotrope/releases/latest">latest release</a> and save it somewhere easy to find — Desktop or Downloads works fine.</p>
+          </div>
         </div>
-      </div>
-
-      <div class="step">
-        <div class="step-num">5</div>
-        <div class="step-body">
-          <h3>Generate an HTML report (optional)</h3>
-          <pre>apotrope.exe --html report.html --verbose</pre>
-          <p style="margin-top:0.4rem; font-size:0.85rem; color:var(--muted);">Opens as a standalone file in any browser — no server required.</p>
+        <div class="step" data-reveal>
+          <div class="step-n">2</div>
+          <div>
+            <h3>Open an Administrator terminal</h3>
+            <p>Right-click PowerShell or Command Prompt → <em>Run as administrator</em>. Some checks (BitLocker, local accounts, services) need elevation for full results.</p>
+          </div>
         </div>
-      </div>
-
-      <div class="step">
-        <div class="step-num">6</div>
-        <div class="step-body">
-          <h3>Track changes over time</h3>
-          <pre>apotrope.exe --baseline before.json
+        <div class="step" data-reveal>
+          <div class="step-n">3</div>
+          <div>
+            <h3>Go to the folder you saved it in</h3>
+            <div class="code">cd %USERPROFILE%\Downloads<button class="cp" data-copy="cd %USERPROFILE%\Downloads">copy</button></div>
+          </div>
+        </div>
+        <div class="step" data-reveal>
+          <div class="step-n">4</div>
+          <div>
+            <h3>Run a scan</h3>
+            <div class="code">apotrope.exe<button class="cp" data-copy="apotrope.exe">copy</button></div>
+          </div>
+        </div>
+        <div class="step" data-reveal>
+          <div class="step-n">5</div>
+          <div>
+            <h3>Generate an HTML report</h3>
+            <div class="code">apotrope.exe --html report.html --verbose<button class="cp" data-copy="apotrope.exe --html report.html --verbose">copy</button></div>
+            <p style="margin-top:8px">Opens as a standalone file in any browser — no server required.</p>
+          </div>
+        </div>
+        <div class="step" data-reveal>
+          <div class="step-n">6</div>
+          <div>
+            <h3>Track changes over time</h3>
+            <div class="code">apotrope.exe --baseline before.json
 # ... remediate findings ...
-apotrope.exe --compare before.json</pre>
+apotrope.exe --compare before.json<button class="cp" data-copy="apotrope.exe --baseline before.json">copy</button></div>
+          </div>
         </div>
       </div>
-
     </div>
-  </div>
-</section>
+  </section>
 
-<!-- ── Footer ── -->
-<footer>
-  <div class="container">
-    <p>
-      Apotrope is open source software released under the
-      <a href="https://github.com/hexorcist404/apotrope/blob/main/LICENSE">MIT License</a>.
-      &nbsp;&middot;&nbsp;
-      <a href="https://github.com/hexorcist404/apotrope">GitHub</a>
-      &nbsp;&middot;&nbsp;
-      <a href="https://github.com/hexorcist404/apotrope/releases">Releases</a>
-      &nbsp;&middot;&nbsp;
-      <a href="https://github.com/hexorcist404/apotrope/issues">Issues</a>
-    </p>
-    <p style="margin-top:0.5rem; color:#484f58;">
-      For authorized security assessment use only.
-    </p>
-  </div>
-</footer>
+  <!-- ── Footer ──────────────────────────────────────────────────────────── -->
+  <footer>
+    <div class="wrap">
+      <div>
+        <div>
+          Released under the <a href="https://github.com/hexorcist404/apotrope/blob/main/LICENSE">MIT License</a>
+          · <a href="https://github.com/hexorcist404/apotrope">GitHub</a>
+          · <a href="https://github.com/hexorcist404/apotrope/releases">Releases</a>
+          · <a href="https://github.com/hexorcist404/apotrope/issues">Issues</a>
+        </div>
+        <div class="foot-auth">For authorized security assessment use only · <span class="nodata">No data left this machine</span></div>
+      </div>
+      <div>◈ apotrope.sh</div>
+    </div>
+  </footer>
 
+  <div class="crt-overlay"></div>
+  <div class="crt-vignette"></div>
+  <script src="site.js"></script>
 </body>
 </html>

--- a/docs/report.html
+++ b/docs/report.html
@@ -1,0 +1,2155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Apotrope — Security Posture Report · WORKSTATION-07</title>
+<style>
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  :root {
+    /* near-black, faint blue-green */
+    --void:      #03060a;
+    --bg:        #05090c;
+    --panel:     #080d11;
+    --panel-2:   #0b1218;
+    --line:      rgba(0, 255, 102, 0.10);
+    --line-soft: rgba(120, 200, 170, 0.07);
+
+    /* status / semantic */
+    --green:  #2bff88;   /* PASS / good     */
+    --cyan:   #44e0e6;   /* INFO            */
+    --amber:  #ffb23d;   /* WARN / fair     */
+    --red:    #ff5147;   /* FAIL            */
+    --crit:   #ff2d6b;   /* CRITICAL        */
+    --orange: #ff7a18;   /* decorative glow */
+
+    --text:   #c4d6cd;
+    --bright: #e8fff2;
+    --muted:  #5d776c;
+    --faint:  #2f4138;
+
+    /* accent (tweakable) — defaults to terminal green */
+    --accent: #2bff88;
+    --accent-dim: rgba(43, 255, 136, 0.14);
+
+    /* offline font stacks — no Google Fonts, no embedding required */
+    --mono: "IBM Plex Mono","Cascadia Code","Consolas",ui-monospace,monospace;
+    --sans: "IBM Plex Sans",system-ui,-apple-system,"Segoe UI",sans-serif;
+
+    --r: 3px;
+    --gap: 22px;
+    --pad: 22px;
+    --maxw: 1180px;
+
+    --glitch: 1;       /* 0..1 scanline/glow intensity */
+    --row-pad: 13px;   /* density */
+    --fs: 15px;
+  }
+
+  html { scroll-behavior: smooth; }
+
+  body {
+    background:
+      radial-gradient(1200px 700px at 78% -8%, rgba(255, 122, 24, 0.07), transparent 60%),
+      radial-gradient(900px 600px at -5% 4%, rgba(43, 255, 136, 0.05), transparent 55%),
+      var(--bg);
+    color: var(--text);
+    font-family: var(--mono);
+    font-size: var(--fs);
+    line-height: 1.55;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+  }
+
+  /* ── CRT / scanline overlay ────────────────────────────────────────────── */
+  .crt-overlay {
+    pointer-events: none;
+    position: fixed; inset: 0; z-index: 9000;
+    background: repeating-linear-gradient(
+      to bottom,
+      rgba(0,0,0,0) 0px,
+      rgba(0,0,0,0) 2px,
+      rgba(0, 30, 18, calc(0.16 * var(--glitch))) 3px,
+      rgba(0, 30, 18, calc(0.16 * var(--glitch))) 3px
+    );
+    mix-blend-mode: multiply;
+    opacity: var(--glitch);
+  }
+  .crt-vignette {
+    pointer-events: none;
+    position: fixed; inset: 0; z-index: 9001;
+    box-shadow: inset 0 0 240px 40px rgba(0,0,0,0.9);
+    opacity: calc(0.7 * var(--glitch));
+  }
+  .crt-flicker {
+    pointer-events: none;
+    position: fixed; inset: 0; z-index: 8999;
+    background: rgba(43,255,136,0.012);
+    animation: flicker 7s infinite steps(60);
+    opacity: var(--glitch);
+  }
+  @keyframes flicker {
+    0%,100%{opacity:calc(0.5*var(--glitch));} 3%{opacity:calc(0.2*var(--glitch));}
+    6%{opacity:calc(0.6*var(--glitch));} 9%{opacity:calc(0.3*var(--glitch));}
+    50%{opacity:calc(0.55*var(--glitch));} 53%{opacity:calc(0.25*var(--glitch));}
+  }
+  @media (prefers-reduced-motion: reduce) { .crt-flicker { animation: none; } }
+
+  /* faint binary rain behind everything */
+  .bin-rain {
+    pointer-events: none;
+    position: fixed; inset: 0; z-index: 0;
+    overflow: hidden;
+    opacity: calc(0.5 * var(--glitch));
+  }
+
+  /* ── Layout ─────────────────────────────────────────────────────────────── */
+  .wrap { position: relative; z-index: 1; max-width: var(--maxw); margin: 0 auto; padding: 0 24px 120px; }
+
+  ::selection { background: var(--accent); color: #00120a; }
+
+  a { color: var(--accent); text-decoration: none; }
+
+  /* ── Scrollbar ──────────────────────────────────────────────────────────── */
+  ::-webkit-scrollbar { width: 11px; height: 11px; }
+  ::-webkit-scrollbar-track { background: var(--void); }
+  ::-webkit-scrollbar-thumb { background: #16241d; border: 2px solid var(--void); border-radius: 6px; }
+  ::-webkit-scrollbar-thumb:hover { background: #1d3329; }
+
+  /* ── Panel primitive ────────────────────────────────────────────────────── */
+  .panel {
+    background:
+      linear-gradient(180deg, rgba(43,255,136,0.018), transparent 120px),
+      var(--panel);
+    border: 1px solid var(--line);
+    border-radius: var(--r);
+    position: relative;
+  }
+  .panel::before {
+    /* corner ticks */
+    content: "";
+    position: absolute; top: -1px; left: -1px;
+    width: 12px; height: 12px;
+    border-top: 1px solid var(--accent); border-left: 1px solid var(--accent);
+    opacity: 0.55;
+  }
+  .panel::after {
+    content: "";
+    position: absolute; bottom: -1px; right: -1px;
+    width: 12px; height: 12px;
+    border-bottom: 1px solid var(--accent); border-right: 1px solid var(--accent);
+    opacity: 0.55;
+  }
+
+  .mono { font-family: var(--mono); }
+  .sans { font-family: var(--sans); }
+
+  .label {
+    font-size: 10.5px; letter-spacing: 0.22em; text-transform: uppercase;
+    color: var(--muted); font-weight: 500;
+  }
+  .kicker {
+    font-size: 11px; letter-spacing: 0.3em; text-transform: uppercase;
+    color: var(--accent); font-weight: 600;
+  }
+
+  /* blinking cursor */
+  .cursor { display:inline-block; width:9px; height:1.05em; background: var(--accent);
+            vertical-align: -2px; margin-left: 3px; animation: blink 1.05s steps(2) infinite; }
+  @keyframes blink { 0%,50%{opacity:1;} 51%,100%{opacity:0;} }
+
+  /* focus rings */
+  button, input, select { font-family: inherit; color: inherit; }
+  button { cursor: pointer; background: none; border: none; }
+  input:focus-visible, button:focus-visible { outline: 1px solid var(--accent); outline-offset: 2px; }
+
+  /* ── Header ─────────────────────────────────────────────────────────────── */
+  .topbar { display:flex; align-items:center; justify-content:space-between; gap:24px;
+            padding:20px 0 18px; border-bottom:1px solid var(--line); flex-wrap:wrap; }
+  .brand { display:flex; align-items:center; gap:13px; }
+  .brand .diamond { color:var(--accent); font-size:22px; filter:drop-shadow(0 0 7px var(--accent)); }
+  .brand .name { font-size:19px; font-weight:700; letter-spacing:0.42em; color:var(--bright);
+                 text-transform:uppercase; }
+  .brand .ver { font-size:10.5px; color:var(--muted); letter-spacing:0.12em; align-self:flex-end; padding-bottom:3px; }
+  .topbar-meta { display:flex; gap:26px; flex-wrap:wrap; align-items:center; }
+  .meta-item { display:flex; flex-direction:column; gap:2px; }
+  .meta-item .v { color:var(--text); font-size:13px; }
+  .meta-item .v b { color:var(--bright); font-weight:600; }
+  .ro-tag { display:inline-flex; align-items:center; gap:7px; font-size:10px; letter-spacing:0.18em;
+            text-transform:uppercase; color:var(--cyan); border:1px solid rgba(68,224,230,0.3);
+            background:rgba(68,224,230,0.06); padding:5px 10px; border-radius:2px; white-space:nowrap; }
+  .ro-tag .dot { width:6px; height:6px; border-radius:50%; background:var(--cyan); box-shadow:0 0 7px var(--cyan); }
+
+  /* hero grid */
+  .hero { display:grid; grid-template-columns: 320px 1fr; gap:var(--gap); margin-top:var(--gap); align-items:start; }
+  @media (max-width: 880px){ .hero { grid-template-columns: 1fr; } }
+
+  .gauge-panel { padding:26px 20px 22px; display:flex; flex-direction:column; align-items:center; gap:6px; }
+  .gauge-wrap { position:relative; width:230px; height:230px; }
+  .gauge-center { position:absolute; inset:0; display:flex; flex-direction:column; align-items:center; justify-content:center; }
+  .gauge-score { font-size:64px; font-weight:700; line-height:0.9; letter-spacing:-0.02em; }
+  .gauge-of { font-size:12px; color:var(--muted); letter-spacing:0.18em; margin-top:4px; }
+  .gauge-grade { margin-top:9px; display:flex; align-items:center; gap:8px; }
+  .grade-chip { font-size:15px; font-weight:700; padding:2px 10px; border-radius:2px; letter-spacing:0.05em; }
+  .grade-label { font-size:11px; letter-spacing:0.24em; text-transform:uppercase; color:var(--muted); }
+  .gauge-cat { font-size:10.5px; color:var(--faint); letter-spacing:0.2em; text-transform:uppercase; margin-top:6px; }
+
+  /* right column */
+  .hero-right { display:flex; flex-direction:column; gap:var(--gap); }
+  .summary-panel { padding:18px 20px 20px; flex:1; }
+  .summary-head { display:flex; align-items:center; justify-content:space-between; margin-bottom:12px; }
+  .summary-body { font-size:13.5px; line-height:1.72; color:var(--text); }
+  .summary-body .hl-crit { color:var(--crit); font-weight:600; }
+  .summary-body .hl-high { color:var(--red); font-weight:600; }
+  .summary-body .hl-ok { color:var(--green); font-weight:600; }
+
+  .stat-strip { display:grid; grid-template-columns: 1.1fr 1fr; gap:var(--gap); }
+  @media (max-width: 560px){ .stat-strip { grid-template-columns:1fr; } }
+  .donut-panel, .bars-panel { padding:16px 18px 18px; }
+  .panel-h { display:flex; align-items:center; justify-content:space-between; margin-bottom:12px; }
+
+  /* count pills */
+  .pills { display:flex; gap:8px; flex-wrap:wrap; }
+  .pill { display:inline-flex; align-items:center; gap:7px; font-size:12px; font-weight:500;
+          padding:5px 11px; border-radius:2px; border:1px solid transparent; letter-spacing:0.02em; }
+  .pill .n { font-weight:700; font-variant-numeric: tabular-nums; }
+  .pill-pass { color:var(--green); border-color:rgba(43,255,136,0.28); background:rgba(43,255,136,0.06); }
+  .pill-fail { color:var(--red);   border-color:rgba(255,81,71,0.3);  background:rgba(255,81,71,0.07); }
+  .pill-warn { color:var(--amber); border-color:rgba(255,178,61,0.3); background:rgba(255,178,61,0.06); }
+  .pill-info { color:var(--cyan);  border-color:rgba(68,224,230,0.28);background:rgba(68,224,230,0.05); }
+
+  /* donut */
+  .donut-row { display:flex; align-items:center; gap:18px; }
+  .donut-legend { display:flex; flex-direction:column; gap:7px; flex:1; }
+  .leg { display:flex; align-items:center; gap:9px; font-size:12px; }
+  .leg .sw { width:9px; height:9px; border-radius:1px; flex-shrink:0; }
+  .leg .lk { color:var(--muted); flex:1; letter-spacing:0.08em; }
+  .leg .lv { color:var(--bright); font-weight:600; font-variant-numeric:tabular-nums; }
+
+  /* category bars */
+  .cbar { display:grid; grid-template-columns: 116px 1fr 42px; align-items:center; gap:11px;
+          padding:6px 0; cursor:pointer; border:none; width:100%; text-align:left; }
+  .cbar:hover .cbar-name { color:var(--bright); }
+  .cbar:hover .cbar-track { box-shadow: inset 0 0 0 1px var(--line); }
+  .cbar-name { font-size:11.5px; color:var(--text); letter-spacing:0.04em; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .cbar-track { height:13px; background:#0a130d; border:1px solid rgba(43,255,136,0.12); border-radius:2px; overflow:hidden; position:relative; }
+  .cbar-fill { height:100%; border-radius:0; transition:width .6s cubic-bezier(.2,.7,.2,1); }
+  /* HP-bar segmentation: 20 cells, score maps to filled cells */
+  .cbar-track::after { content:""; position:absolute; inset:0; pointer-events:none; z-index:2;
+     background: repeating-linear-gradient(90deg, transparent 0 calc(5% - 2px), var(--panel) calc(5% - 2px) 5%); }
+  .cbar-val { font-size:11.5px; text-align:right; font-variant-numeric:tabular-nums; font-weight:600; }
+  .cbar.flagged .cbar-name::before { content:"› "; color:var(--accent); }
+
+  /* toolbar */
+  .toolbar { display:flex; align-items:center; gap:14px; flex-wrap:wrap; margin:var(--gap) 0 14px;
+             padding:13px 16px; }
+  .filters { display:flex; gap:7px; flex-wrap:wrap; }
+  .fchip { display:inline-flex; align-items:center; gap:8px; font-size:11.5px; letter-spacing:0.08em;
+           padding:6px 12px; border:1px solid var(--line); border-radius:2px; color:var(--muted);
+           text-transform:uppercase; transition:all .15s; }
+  .fchip:hover { color:var(--text); border-color:rgba(120,200,170,0.25); }
+  .fchip[data-on="true"] { color:var(--void); font-weight:700; }
+  .fchip .fn { font-variant-numeric:tabular-nums; font-weight:700; opacity:0.9; }
+  .fchip.f-all[data-on="true"]  { background:var(--accent); border-color:var(--accent); }
+  .fchip.f-fail[data-on="true"] { background:var(--red);   border-color:var(--red); }
+  .fchip.f-warn[data-on="true"] { background:var(--amber); border-color:var(--amber); }
+  .fchip.f-pass[data-on="true"] { background:var(--green); border-color:var(--green); }
+  .fchip.f-info[data-on="true"] { background:var(--cyan);  border-color:var(--cyan); }
+
+  .search { display:flex; align-items:center; gap:8px; border:1px solid var(--line); border-radius:2px;
+            padding:6px 11px; min-width:210px; flex:1; max-width:340px; }
+  .search:focus-within { border-color:var(--accent); }
+  .search input { background:none; border:none; outline:none; width:100%; font-size:13px; color:var(--bright); }
+  .search input::placeholder { color:var(--faint); }
+  .search .pr { color:var(--accent); font-size:13px; }
+  .tool-right { display:flex; align-items:center; gap:14px; margin-left:auto; }
+  .linkbtn { font-size:11px; letter-spacing:0.1em; text-transform:uppercase; color:var(--muted); border-bottom:1px dashed transparent; }
+  .linkbtn:hover { color:var(--accent); border-bottom-color:var(--accent); }
+  .showing { font-size:11px; color:var(--faint); letter-spacing:0.06em; white-space:nowrap; }
+
+  /* top issues */
+  .top-issues { margin:var(--gap) 0; padding:18px 20px 20px; border-color:rgba(255,81,71,0.22)!important; }
+  .top-issues::before, .top-issues::after { border-color:var(--red)!important; }
+  .ti-head { display:flex; align-items:center; gap:10px; margin-bottom:14px; }
+  .ti-flag { color:var(--red); font-size:14px; letter-spacing:0.2em; text-transform:uppercase; font-weight:700; }
+  .ti-list { display:flex; flex-direction:column; gap:10px; }
+  .ti-item { display:grid; grid-template-columns: 26px 1fr; gap:12px; padding:11px 13px;
+             background:rgba(255,81,71,0.035); border:1px solid rgba(255,81,71,0.14); border-radius:2px; }
+  .ti-num { font-size:13px; font-weight:700; color:var(--red); }
+  .ti-name { font-size:13.5px; color:var(--bright); font-weight:600; margin-bottom:3px; }
+  .ti-tags { display:flex; gap:8px; align-items:center; margin-bottom:6px; flex-wrap:wrap; }
+  .ti-fix { font-size:12px; color:var(--muted); line-height:1.6; }
+  .ti-fix b { color:var(--text); font-weight:500; }
+
+  /* category section */
+  .cat-section { margin-top:var(--gap); }
+  .cat-bar { display:flex; align-items:center; gap:14px; padding:11px 16px;
+             border:1px solid var(--line); border-top-left-radius:var(--r); border-top-right-radius:var(--r);
+             background:var(--panel-2); position:sticky; top:0; z-index:5; }
+  .cat-name { font-size:13.5px; font-weight:600; letter-spacing:0.08em; color:var(--bright); text-transform:uppercase; }
+  .cat-meta { display:flex; align-items:center; gap:10px; margin-left:auto; }
+  .cat-score { font-size:12px; font-weight:700; font-variant-numeric:tabular-nums; }
+  .cat-tally { display:flex; gap:9px; font-size:11px; }
+  .cat-tally span { font-variant-numeric:tabular-nums; }
+
+  /* finding rows */
+  .findings { border:1px solid var(--line); border-top:none;
+              border-bottom-left-radius:var(--r); border-bottom-right-radius:var(--r); overflow:hidden; }
+  .frow { border-top:1px solid var(--line-soft); }
+  .frow:first-child { border-top:none; }
+  .fhead { display:grid; grid-template-columns: 30px 86px 1fr auto; align-items:center; gap:13px;
+           padding:var(--row-pad) 16px; width:100%; text-align:left; transition:background .12s; }
+  .fhead:hover { background:rgba(43,255,136,0.025); }
+  .fhead.is-open { background:rgba(43,255,136,0.03); }
+  .ficon { font-size:14px; text-align:center; font-weight:700; }
+  .fsev { font-size:10px; letter-spacing:0.1em; font-weight:600; text-transform:uppercase;
+          padding:3px 7px; border-radius:2px; text-align:center; white-space:nowrap; }
+  .fname { font-size:13.5px; color:var(--text); }
+  .fname .fcat { color:var(--faint); font-size:11px; margin-right:8px; letter-spacing:0.06em; }
+  .fname .fsnip { color:var(--muted); font-size:12px; margin-top:2px; }
+  .fname b { color:var(--bright); font-weight:500; }
+  .fright { display:flex; align-items:center; gap:12px; }
+  .chev { color:var(--muted); font-size:11px; transition:transform .2s; }
+  .fhead.is-open .chev { transform:rotate(90deg); color:var(--accent); }
+
+  .fbody { padding:2px 16px 18px 59px; display:grid; gap:13px;
+           border-top:1px solid var(--line-soft); background:rgba(0,0,0,0.18); }
+  .fbody .fld { display:grid; grid-template-columns: 82px 1fr; gap:14px; align-items:start; }
+  .fbody .fld .k { font-size:10.5px; letter-spacing:0.14em; text-transform:uppercase; color:var(--faint); padding-top:2px; }
+  .fbody .fld .vv { font-size:13px; color:var(--text); line-height:1.65; }
+  .code { font-size:12.5px; background:#02060a; border:1px solid var(--line); border-left:2px solid var(--accent);
+          border-radius:2px; padding:11px 13px; color:var(--green); white-space:pre-wrap; word-break:break-word;
+          position:relative; }
+  .code .copy { position:absolute; top:7px; right:8px; font-size:9.5px; letter-spacing:0.1em; text-transform:uppercase;
+                color:var(--muted); border:1px solid var(--line); padding:3px 7px; border-radius:2px; background:var(--void); }
+  .code .copy:hover { color:var(--accent); border-color:var(--accent); }
+  .cis { display:inline-flex; align-items:center; gap:6px; font-size:11px; letter-spacing:0.06em;
+         color:var(--cyan); border:1px solid rgba(68,224,230,0.28); background:rgba(68,224,230,0.05);
+         padding:3px 9px; border-radius:2px; }
+
+  .empty { padding:46px 20px; text-align:center; color:var(--faint); font-size:13px; letter-spacing:0.08em; }
+
+  /* footer */
+  .foot { margin-top:46px; padding-top:22px; border-top:1px solid var(--line);
+          display:flex; justify-content:space-between; align-items:center; gap:20px; flex-wrap:wrap;
+          font-size:11.5px; color:var(--muted); letter-spacing:0.05em; }
+  .foot .auth { color:var(--faint); }
+  .foot a { color:var(--muted); border-bottom:1px dashed transparent; }
+  .foot a:hover { color:var(--accent); border-bottom-color:var(--accent); }
+
+  /* fade-in */
+  .rise { animation: rise .5s cubic-bezier(.2,.7,.2,1) both; }
+  @keyframes rise { from { transform: translateY(10px); } to { transform:none; } }
+  @media (prefers-reduced-motion: reduce){ .rise { animation:none; } }
+
+  /* ── Print: drop the CRT atmosphere, expand every finding, ink-friendly ─── */
+  @media print {
+    .crt-overlay, .crt-vignette, .crt-flicker, .bin-rain { display:none !important; }
+    html, body { background:#fff !important; color:#111 !important; }
+    .wrap { padding-bottom:0; }
+    .panel { background:#fff !important; border-color:#bbb !important; }
+    .panel::before, .panel::after { display:none; }
+    .toolbar, .tool-right, .search, .filters { display:none !important; }
+    .cat-bar { position:static; background:#f2f2f2 !important; }
+    .cat-name, .brand .name, .ti-name, .fname b, .meta-item .v b { color:#111 !important; }
+    .fbody[hidden] { display:grid !important; }   /* show all details on paper */
+    .code { background:#f6f6f6 !important; color:#111 !important; }
+  }
+</style>
+</head>
+<body>
+  <div class="bin-rain" id="binRain"></div>
+  <div class="crt-flicker"></div>
+
+  <div class="wrap">
+
+    <!-- ── Header ──────────────────────────────────────────────────────── -->
+    <div class="topbar">
+      <div class="brand">
+        <span class="diamond">◈</span>
+        <span class="name">APOTROPE</span>
+        <span class="ver">v0.1.5</span>
+      </div>
+      <div class="topbar-meta">
+        <div class="meta-item"><span class="label">Host</span><span class="v"><b>WORKSTATION-07</b></span></div>
+        <div class="meta-item"><span class="label">System</span><span class="v">Windows 11 Pro 10.0.22631</span></div>
+        <div class="meta-item"><span class="label">Scan</span><span class="v">2026-06-06 14:30 UTC <span style="color:var(--faint)">· 21.7s</span></span></div>
+        <span class="ro-tag"><span class="dot"></span>Read-only audit</span>
+      </div>
+    </div>
+
+    <!-- ── Hero: score gauge + executive summary + stat strip ──────────── -->
+    <div class="hero">
+      <div class="gauge-panel panel rise">
+        <div class="kicker" style="align-self:flex-start">Security Score</div>
+        <div class="gauge-wrap">
+          <svg width="230" height="230" viewBox="0 0 230 230" style="position:absolute;inset:0">
+            <defs><filter id="gl"><feGaussianBlur stdDeviation="3.2" result="b"/>
+              <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter></defs>
+            <line x1="115.0" y1="12.0" x2="115.0" y2="3.0" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="131.11" y1="13.27" x2="132.52" y2="4.38" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="146.83" y1="17.04" x2="149.61" y2="8.48" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="161.76" y1="23.23" x2="165.85" y2="15.21" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="175.54" y1="31.67" x2="180.83" y2="24.39" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="187.83" y1="42.17" x2="194.2" y2="35.8" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="198.33" y1="54.46" x2="205.61" y2="49.17" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="206.77" y1="68.24" x2="214.79" y2="64.15" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="212.96" y1="83.17" x2="221.52" y2="80.39" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="216.73" y1="98.89" x2="225.62" y2="97.48" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="218.0" y1="115.0" x2="227.0" y2="115.0" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="216.73" y1="131.11" x2="225.62" y2="132.52" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="212.96" y1="146.83" x2="221.52" y2="149.61" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="206.77" y1="161.76" x2="214.79" y2="165.85" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="198.33" y1="175.54" x2="205.61" y2="180.83" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="187.83" y1="187.83" x2="194.2" y2="194.2" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="175.54" y1="198.33" x2="180.83" y2="205.61" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="161.76" y1="206.77" x2="165.85" y2="214.79" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="146.83" y1="212.96" x2="149.61" y2="221.52" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="131.11" y1="216.73" x2="132.52" y2="225.62" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="115.0" y1="218.0" x2="115.0" y2="227.0" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="98.89" y1="216.73" x2="97.48" y2="225.62" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="83.17" y1="212.96" x2="80.39" y2="221.52" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="68.24" y1="206.77" x2="64.15" y2="214.79" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="54.46" y1="198.33" x2="49.17" y2="205.61" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="42.17" y1="187.83" x2="35.8" y2="194.2" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="31.67" y1="175.54" x2="24.39" y2="180.83" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="23.23" y1="161.76" x2="15.21" y2="165.85" stroke="#ffb23d" stroke-width="2" opacity="0.9"/><line x1="17.04" y1="146.83" x2="8.48" y2="149.61" stroke="#16241d" stroke-width="2" opacity="0.5"/><line x1="13.27" y1="131.11" x2="4.38" y2="132.52" stroke="#16241d" stroke-width="2" opacity="0.5"/><line x1="12.0" y1="115.0" x2="3.0" y2="115.0" stroke="#16241d" stroke-width="2" opacity="0.5"/><line x1="13.27" y1="98.89" x2="4.38" y2="97.48" stroke="#16241d" stroke-width="2" opacity="0.5"/><line x1="17.04" y1="83.17" x2="8.48" y2="80.39" stroke="#16241d" stroke-width="2" opacity="0.5"/><line x1="23.23" y1="68.24" x2="15.21" y2="64.15" stroke="#16241d" stroke-width="2" opacity="0.5"/><line x1="31.67" y1="54.46" x2="24.39" y2="49.17" stroke="#16241d" stroke-width="2" opacity="0.5"/><line x1="42.17" y1="42.17" x2="35.8" y2="35.8" stroke="#16241d" stroke-width="2" opacity="0.5"/><line x1="54.46" y1="31.67" x2="49.17" y2="24.39" stroke="#16241d" stroke-width="2" opacity="0.5"/><line x1="68.24" y1="23.23" x2="64.15" y2="15.21" stroke="#16241d" stroke-width="2" opacity="0.5"/><line x1="83.17" y1="17.04" x2="80.39" y2="8.48" stroke="#16241d" stroke-width="2" opacity="0.5"/><line x1="98.89" y1="13.27" x2="97.48" y2="4.38" stroke="#16241d" stroke-width="2" opacity="0.5"/>
+            <circle cx="115" cy="115" r="96" fill="none" stroke="#0c1610" stroke-width="9"/>
+            <circle cx="115" cy="115" r="96" fill="none" stroke="#ffb23d" stroke-width="9"
+              stroke-linecap="round" stroke-dasharray="603.2" stroke-dashoffset="186.99"
+              transform="rotate(-90 115 115)" filter="url(#gl)"/>
+          </svg>
+          <div class="gauge-center">
+            <div class="gauge-score" style="color:#ffb23d;text-shadow:0 0 22px #ffb23d">69</div>
+            <div class="gauge-of">/ 100</div>
+            <div class="gauge-grade">
+              <span class="grade-chip" style="color:var(--void);background:#ffb23d">D</span>
+              <span class="grade-label">Poor</span>
+            </div>
+          </div>
+        </div>
+        <div class="gauge-cat">56 checks evaluated</div>
+      </div>
+
+      <div class="hero-right">
+        <div class="summary-panel panel rise">
+          <div class="summary-head">
+            <span class="kicker">Executive Summary</span>
+            <div class="pills">
+              <span class="pill pill-pass"><span class="n">35</span> passed</span>
+              <span class="pill pill-fail"><span class="n">3</span> failed</span>
+              <span class="pill pill-warn"><span class="n">4</span> warnings</span>
+              <span class="pill pill-info"><span class="n">14</span> info</span>
+            </div>
+          </div>
+          <div class="summary-body">The security posture of <b>WORKSTATION-07</b> has been assessed as <b>Poor</b> with an overall score of <b>69/100 (D)</b> across 56 security checks. <span class="hl-high">1 high-severity finding should be addressed promptly.</span> Of the checks performed, 3 checks failed and 4 checks issued warnings. The primary areas of concern are <b>Firewall</b>, <b>File Sharing</b> and <b>PowerShell</b>. Remediation should be prioritized by severity, addressing critical and high-severity findings first.</div>
+        </div>
+
+        <div class="stat-strip">
+          <div class="donut-panel panel rise">
+            <div class="panel-h"><span class="label">Result Distribution</span><span class="label">56</span></div>
+            <div class="donut-row">
+              <svg width="128" height="128" viewBox="0 0 128 128">
+                <circle cx="64" cy="64" r="52" fill="none" stroke="#0c1610" stroke-width="13"/>
+                <circle cx="64" cy="64" r="52" fill="none" stroke="#2bff88" stroke-width="13"
+                  stroke-dasharray="204.2 122.52" stroke-dashoffset="-0.0"
+                  transform="rotate(-90 64 64)"/><circle cx="64" cy="64" r="52" fill="none" stroke="#ff5147" stroke-width="13"
+                  stroke-dasharray="17.5 309.22" stroke-dashoffset="-204.2"
+                  transform="rotate(-90 64 64)"/><circle cx="64" cy="64" r="52" fill="none" stroke="#ffb23d" stroke-width="13"
+                  stroke-dasharray="23.34 303.39" stroke-dashoffset="-221.71"
+                  transform="rotate(-90 64 64)"/><circle cx="64" cy="64" r="52" fill="none" stroke="#44e0e6" stroke-width="13"
+                  stroke-dasharray="81.68 245.04" stroke-dashoffset="-245.04"
+                  transform="rotate(-90 64 64)"/>
+                <text x="64" y="60" text-anchor="middle" fill="var(--red)" font-size="22" font-weight="700">3</text>
+                <text x="64" y="77" text-anchor="middle" fill="var(--muted)" font-size="8.5" letter-spacing="1.4">FAILED</text>
+              </svg>
+              <div class="donut-legend">
+                <div class="leg"><span class="sw" style="background:var(--green)"></span><span class="lk">PASS</span><span class="lv">35</span></div>
+                <div class="leg"><span class="sw" style="background:var(--red)"></span><span class="lk">FAIL</span><span class="lv">3</span></div>
+                <div class="leg"><span class="sw" style="background:var(--amber)"></span><span class="lk">WARN</span><span class="lv">4</span></div>
+                <div class="leg"><span class="sw" style="background:var(--cyan)"></span><span class="lk">INFO</span><span class="lv">14</span></div>
+              </div>
+            </div>
+          </div>
+
+          <div class="bars-panel panel rise">
+            <div class="panel-h"><span class="label">Category Scores</span><span class="label">14 areas</span></div>
+            
+            <button class="cbar" onclick="apoJump('Firewall')">
+              <span class="cbar-name">Firewall</span>
+              <span class="cbar-track"><span class="cbar-fill" style="width:90%;background:#2bff88;box-shadow:0 0 8px #2bff88"></span></span>
+              <span class="cbar-val" style="color:#2bff88">90</span>
+            </button>
+            
+            <button class="cbar" onclick="apoJump('File-Sharing')">
+              <span class="cbar-name">File Sharing</span>
+              <span class="cbar-track"><span class="cbar-fill" style="width:95%;background:#2bff88;box-shadow:0 0 8px #2bff88"></span></span>
+              <span class="cbar-val" style="color:#2bff88">95</span>
+            </button>
+            
+            <button class="cbar" onclick="apoJump('PowerShell')">
+              <span class="cbar-name">PowerShell</span>
+              <span class="cbar-track"><span class="cbar-fill" style="width:95%;background:#2bff88;box-shadow:0 0 8px #2bff88"></span></span>
+              <span class="cbar-val" style="color:#2bff88">95</span>
+            </button>
+            
+            <button class="cbar" onclick="apoJump('Remote-Access')">
+              <span class="cbar-name">Remote Access</span>
+              <span class="cbar-track"><span class="cbar-fill" style="width:95%;background:#2bff88;box-shadow:0 0 8px #2bff88"></span></span>
+              <span class="cbar-val" style="color:#2bff88">95</span>
+            </button>
+            
+            <button class="cbar" onclick="apoJump('Access-Control')">
+              <span class="cbar-name">Access Control</span>
+              <span class="cbar-track"><span class="cbar-fill" style="width:98%;background:#2bff88;box-shadow:0 0 8px #2bff88"></span></span>
+              <span class="cbar-val" style="color:#2bff88">98</span>
+            </button>
+            
+            <button class="cbar" onclick="apoJump('Accounts')">
+              <span class="cbar-name">Accounts</span>
+              <span class="cbar-track"><span class="cbar-fill" style="width:98%;background:#2bff88;box-shadow:0 0 8px #2bff88"></span></span>
+              <span class="cbar-val" style="color:#2bff88">98</span>
+            </button>
+            
+            <button class="cbar" onclick="apoJump('Patching')">
+              <span class="cbar-name">Patching</span>
+              <span class="cbar-track"><span class="cbar-fill" style="width:98%;background:#2bff88;box-shadow:0 0 8px #2bff88"></span></span>
+              <span class="cbar-val" style="color:#2bff88">98</span>
+            </button>
+            
+            <button class="cbar" onclick="apoJump('Antivirus')">
+              <span class="cbar-name">Antivirus</span>
+              <span class="cbar-track"><span class="cbar-fill" style="width:100%;background:#2bff88;box-shadow:0 0 8px #2bff88"></span></span>
+              <span class="cbar-val" style="color:#2bff88">100</span>
+            </button>
+            
+            <button class="cbar" onclick="apoJump('Encryption')">
+              <span class="cbar-name">Encryption</span>
+              <span class="cbar-track"><span class="cbar-fill" style="width:100%;background:#2bff88;box-shadow:0 0 8px #2bff88"></span></span>
+              <span class="cbar-val" style="color:#2bff88">100</span>
+            </button>
+            
+            <button class="cbar" onclick="apoJump('Hardening')">
+              <span class="cbar-name">Hardening</span>
+              <span class="cbar-track"><span class="cbar-fill" style="width:100%;background:#2bff88;box-shadow:0 0 8px #2bff88"></span></span>
+              <span class="cbar-val" style="color:#2bff88">100</span>
+            </button>
+            
+            <button class="cbar" onclick="apoJump('Network')">
+              <span class="cbar-name">Network</span>
+              <span class="cbar-track"><span class="cbar-fill" style="width:100%;background:#2bff88;box-shadow:0 0 8px #2bff88"></span></span>
+              <span class="cbar-val" style="color:#2bff88">100</span>
+            </button>
+            
+            <button class="cbar" onclick="apoJump('Persistence')">
+              <span class="cbar-name">Persistence</span>
+              <span class="cbar-track"><span class="cbar-fill" style="width:100%;background:#2bff88;box-shadow:0 0 8px #2bff88"></span></span>
+              <span class="cbar-val" style="color:#2bff88">100</span>
+            </button>
+            
+            <button class="cbar" onclick="apoJump('Services')">
+              <span class="cbar-name">Services</span>
+              <span class="cbar-track"><span class="cbar-fill" style="width:100%;background:#2bff88;box-shadow:0 0 8px #2bff88"></span></span>
+              <span class="cbar-val" style="color:#2bff88">100</span>
+            </button>
+            
+            <button class="cbar" onclick="apoJump('System')">
+              <span class="cbar-name">System</span>
+              <span class="cbar-track"><span class="cbar-fill" style="width:100%;background:#2bff88;box-shadow:0 0 8px #2bff88"></span></span>
+              <span class="cbar-val" style="color:#2bff88">100</span>
+            </button>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+
+    
+    <!-- ── Top issues ──────────────────────────────────────────────────── -->
+    <div class="top-issues panel">
+      <div class="ti-head">
+        <span class="ti-flag">⚑ Top Issues</span>
+        <span class="label">Prioritized remediation · 4</span>
+      </div>
+      <div class="ti-list">
+        
+        <div class="ti-item">
+          <span class="ti-num">01</span>
+          <div>
+            <div class="ti-tags">
+              <span class="fsev" style="color:#ff5147;border:1px solid #ff5147;background:transparent">HIGH</span>
+              <span style="font-size:11px;color:#ff5147;letter-spacing:0.1em">FAIL</span>
+              <button class="linkbtn" onclick="apoJump('Firewall')">Firewall ↗</button>
+            </div>
+            <div class="ti-name">Public Profile Inbound</div>
+            <div class="ti-fix"><b>Fix:</b> Set the Public profile default inbound action to Block.</div>
+          </div>
+        </div>
+        
+        <div class="ti-item">
+          <span class="ti-num">02</span>
+          <div>
+            <div class="ti-tags">
+              <span class="fsev" style="color:#ff5147;border:1px solid #ff5147;background:transparent">HIGH</span>
+              <span style="font-size:11px;color:#ffb23d;letter-spacing:0.1em">WARN</span>
+              <button class="linkbtn" onclick="apoJump('Remote-Access')">Remote Access ↗</button>
+            </div>
+            <div class="ti-name">RDP Network Level Authentication</div>
+            <div class="ti-fix"><b>Fix:</b> Require NLA for all RDP connections.</div>
+          </div>
+        </div>
+        
+        <div class="ti-item">
+          <span class="ti-num">03</span>
+          <div>
+            <div class="ti-tags">
+              <span class="fsev" style="color:#ffb23d;border:1px solid #ffb23d;background:transparent">MEDIUM</span>
+              <span style="font-size:11px;color:#ff5147;letter-spacing:0.1em">FAIL</span>
+              <button class="linkbtn" onclick="apoJump('File-Sharing')">File Sharing ↗</button>
+            </div>
+            <div class="ti-name">SMB Signing Required</div>
+            <div class="ti-fix"><b>Fix:</b> Enable &#39;Microsoft network server: Digitally sign communications (always)&#39;.</div>
+          </div>
+        </div>
+        
+        <div class="ti-item">
+          <span class="ti-num">04</span>
+          <div>
+            <div class="ti-tags">
+              <span class="fsev" style="color:#ffb23d;border:1px solid #ffb23d;background:transparent">MEDIUM</span>
+              <span style="font-size:11px;color:#ff5147;letter-spacing:0.1em">FAIL</span>
+              <button class="linkbtn" onclick="apoJump('PowerShell')">PowerShell ↗</button>
+            </div>
+            <div class="ti-name">Script Block Logging</div>
+            <div class="ti-fix"><b>Fix:</b> Enable Script Block Logging via Administrative Templates.</div>
+          </div>
+        </div>
+        
+      </div>
+    </div>
+    
+
+    <!-- ── Toolbar ─────────────────────────────────────────────────────── -->
+    <div class="toolbar panel">
+      <div class="filters">
+        <button class="fchip f-all"  data-on="true"  data-k="ALL">ALL <span class="fn">56</span></button>
+        <button class="fchip f-fail" data-on="false" data-k="FAIL">FAIL <span class="fn">3</span></button>
+        <button class="fchip f-warn" data-on="false" data-k="WARN">WARN <span class="fn">4</span></button>
+        <button class="fchip f-pass" data-on="false" data-k="PASS">PASS <span class="fn">35</span></button>
+        <button class="fchip f-info" data-on="false" data-k="INFO">INFO <span class="fn">14</span></button>
+      </div>
+      <div class="search"><span class="pr">›</span><input id="apoSearch" placeholder="filter findings…" spellcheck="false"/></div>
+      <div class="tool-right">
+        <button class="linkbtn" id="apoExpand">expand all</button>
+        <button class="linkbtn" id="apoCollapse">collapse</button>
+        <span class="showing" id="apoShowing">56 / 56 shown</span>
+      </div>
+    </div>
+
+    <!-- ── Category sections ───────────────────────────────────────────── -->
+    
+    <div class="cat-section" id="cat-Access-Control">
+      <div class="cat-bar">
+        <span class="cat-name">Access Control</span>
+        <span class="cat-meta">
+          <span class="cat-tally">
+            
+            <span style="color:var(--amber)">!1</span>
+            <span style="color:var(--green)">✓3</span>
+            
+          </span>
+          <span class="cat-score" style="color:#2bff88">98/100 A</span>
+        </span>
+      </div>
+      <div class="findings">
+        
+        <div class="frow" data-status="WARN" data-text="uac secure desktop prompt access control admin approval mode is on, but elevation prompts on the secure desktop are relaxed. cis 2.3.17.1">
+          <button class="fhead">
+            <span class="ficon" style="color:#ffb23d">!</span>
+            <span class="fsev" style="color:#ffb23d;border:1px solid #ffb23d;background:transparent">MEDIUM</span>
+            <span class="fname">
+              <b>UAC Secure Desktop Prompt</b>
+              <div class="fsnip">Admin Approval Mode is on, but elevation prompts on the secure desktop are relaxed.</div>
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 2.3.17.1</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies uac secure desktop prompt.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Admin Approval Mode is on, but elevation prompts on the secure desktop are relaxed.</span></div>
+            
+            <div class="fld"><span class="k">Remediation</span>
+              <div class="code">Set elevation prompt to &#39;Prompt for consent on the secure desktop&#39;.<button class="copy">copy</button></div></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 2.3.17.1</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="uac enabled access control configured as expected. cis 2.3.17.1">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>UAC Enabled</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 2.3.17.1</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies uac enabled.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 2.3.17.1</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="admin token filtering access control configured as expected. cis 2.3.17.2">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Admin Token Filtering</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 2.3.17.2</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies admin token filtering.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 2.3.17.2</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="detect application installs access control configured as expected. cis 2.3.17.5">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Detect Application Installs</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 2.3.17.5</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies detect application installs.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 2.3.17.5</span></span></div>
+          </div>
+        </div>
+        
+      </div>
+    </div>
+    
+    <div class="cat-section" id="cat-Accounts">
+      <div class="cat-bar">
+        <span class="cat-name">Accounts</span>
+        <span class="cat-meta">
+          <span class="cat-tally">
+            
+            <span style="color:var(--amber)">!1</span>
+            <span style="color:var(--green)">✓4</span>
+            <span style="color:var(--cyan)">i1</span>
+          </span>
+          <span class="cat-score" style="color:#2bff88">98/100 A</span>
+        </span>
+      </div>
+      <div class="findings">
+        
+        <div class="frow" data-status="WARN" data-text="guest account accounts the built-in guest account is present and should be confirmed disabled. cis 2.3.1.1">
+          <button class="fhead">
+            <span class="ficon" style="color:#ffb23d">!</span>
+            <span class="fsev" style="color:#ffb23d;border:1px solid #ffb23d;background:transparent">MEDIUM</span>
+            <span class="fname">
+              <b>Guest Account</b>
+              <div class="fsnip">The built-in Guest account is present and should be confirmed disabled.</div>
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 2.3.1.1</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies guest account.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">The built-in Guest account is present and should be confirmed disabled.</span></div>
+            
+            <div class="fld"><span class="k">Remediation</span>
+              <div class="code">Disable the Guest account.<button class="copy">copy</button></div></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 2.3.1.1</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="password length policy accounts configured as expected. cis 1.1.4">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Password Length Policy</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 1.1.4</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies password length policy.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 1.1.4</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="account lockout threshold accounts configured as expected. cis 1.2.2">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Account Lockout Threshold</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 1.2.2</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies account lockout threshold.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 1.2.2</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="blank password use restricted accounts configured as expected. cis 2.3.1.2">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Blank Password Use Restricted</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 2.3.1.2</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies blank password use restricted.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 2.3.1.2</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="administrator account renamed accounts configured as expected. cis 2.3.1.5">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Administrator Account Renamed</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 2.3.1.5</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies administrator account renamed.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 2.3.1.5</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="INFO" data-text="local administrator count accounts 2 local administrators ">
+          <button class="fhead">
+            <span class="ficon" style="color:#44e0e6">i</span>
+            <span class="fsev" style="color:#5d776c;border:1px solid #5d776c;background:transparent">INFO</span>
+            <span class="fname">
+              <b>Local Administrator Count</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies local administrator count.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">2 local administrators</span></div>
+            
+            
+          </div>
+        </div>
+        
+      </div>
+    </div>
+    
+    <div class="cat-section" id="cat-Antivirus">
+      <div class="cat-bar">
+        <span class="cat-name">Antivirus</span>
+        <span class="cat-meta">
+          <span class="cat-tally">
+            
+            
+            <span style="color:var(--green)">✓3</span>
+            <span style="color:var(--cyan)">i1</span>
+          </span>
+          <span class="cat-score" style="color:#2bff88">100/100 A</span>
+        </span>
+      </div>
+      <div class="findings">
+        
+        <div class="frow" data-status="PASS" data-text="defender real-time protection antivirus configured as expected. cis 18.10.43.10.1">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Defender Real-Time Protection</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 18.10.43.10.1</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies defender real-time protection.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 18.10.43.10.1</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="defender signatures current antivirus configured as expected. cis 18.10.43.14">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Defender Signatures Current</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 18.10.43.14</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies defender signatures current.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 18.10.43.14</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="tamper protection enabled antivirus configured as expected. ">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Tamper Protection Enabled</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies tamper protection enabled.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            
+          </div>
+        </div>
+        
+        <div class="frow" data-status="INFO" data-text="defender engine version antivirus 1.1.24050.5 ">
+          <button class="fhead">
+            <span class="ficon" style="color:#44e0e6">i</span>
+            <span class="fsev" style="color:#5d776c;border:1px solid #5d776c;background:transparent">INFO</span>
+            <span class="fname">
+              <b>Defender Engine Version</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies defender engine version.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">1.1.24050.5</span></div>
+            
+            
+          </div>
+        </div>
+        
+      </div>
+    </div>
+    
+    <div class="cat-section" id="cat-Encryption">
+      <div class="cat-bar">
+        <span class="cat-name">Encryption</span>
+        <span class="cat-meta">
+          <span class="cat-tally">
+            
+            
+            <span style="color:var(--green)">✓1</span>
+            
+          </span>
+          <span class="cat-score" style="color:#2bff88">100/100 A</span>
+        </span>
+      </div>
+      <div class="findings">
+        
+        <div class="frow" data-status="PASS" data-text="bitlocker — c: encryption configured as expected. ">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>BitLocker — C:</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies bitlocker — c:.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            
+          </div>
+        </div>
+        
+      </div>
+    </div>
+    
+    <div class="cat-section" id="cat-File-Sharing">
+      <div class="cat-bar">
+        <span class="cat-name">File Sharing</span>
+        <span class="cat-meta">
+          <span class="cat-tally">
+            <span style="color:var(--red)">✗1</span>
+            
+            <span style="color:var(--green)">✓2</span>
+            
+          </span>
+          <span class="cat-score" style="color:#2bff88">95/100 A</span>
+        </span>
+      </div>
+      <div class="findings">
+        
+        <div class="frow" data-status="FAIL" data-text="smb signing required file sharing the server does not require smb packet signing, allowing tampering and relay. cis 2.3.8.1">
+          <button class="fhead">
+            <span class="ficon" style="color:#ff5147">✗</span>
+            <span class="fsev" style="color:#ffb23d;border:1px solid #ffb23d;background:transparent">MEDIUM</span>
+            <span class="fname">
+              <b>SMB Signing Required</b>
+              <div class="fsnip">The server does not require SMB packet signing, allowing tampering and relay.</div>
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 2.3.8.1</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies smb signing required.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">The server does not require SMB packet signing, allowing tampering and relay.</span></div>
+            
+            <div class="fld"><span class="k">Remediation</span>
+              <div class="code">Enable &#39;Microsoft network server: Digitally sign communications (always)&#39;.<button class="copy">copy</button></div></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 2.3.8.1</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="smbv1 disabled file sharing configured as expected. cis 18.4.2">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>SMBv1 Disabled</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 18.4.2</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies smbv1 disabled.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 18.4.2</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="anonymous share enumeration off file sharing configured as expected. cis 2.3.10.5">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Anonymous Share Enumeration Off</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 2.3.10.5</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies anonymous share enumeration off.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 2.3.10.5</span></span></div>
+          </div>
+        </div>
+        
+      </div>
+    </div>
+    
+    <div class="cat-section" id="cat-Firewall">
+      <div class="cat-bar">
+        <span class="cat-name">Firewall</span>
+        <span class="cat-meta">
+          <span class="cat-tally">
+            <span style="color:var(--red)">✗1</span>
+            
+            <span style="color:var(--green)">✓5</span>
+            
+          </span>
+          <span class="cat-score" style="color:#2bff88">90/100 A</span>
+        </span>
+      </div>
+      <div class="findings">
+        
+        <div class="frow" data-status="FAIL" data-text="public profile inbound firewall default inbound action is allow on the public profile, exposing listening services to untrusted networks. cis 9.3.2">
+          <button class="fhead">
+            <span class="ficon" style="color:#ff5147">✗</span>
+            <span class="fsev" style="color:#ff5147;border:1px solid #ff5147;background:transparent">HIGH</span>
+            <span class="fname">
+              <b>Public Profile Inbound</b>
+              <div class="fsnip">Default inbound action is Allow on the Public profile, exposing listening services to untrusted networks.</div>
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 9.3.2</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies public profile inbound.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Default inbound action is Allow on the Public profile, exposing listening services to untrusted networks.</span></div>
+            
+            <div class="fld"><span class="k">Remediation</span>
+              <div class="code">Set the Public profile default inbound action to Block.<button class="copy">copy</button></div></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 9.3.2</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="domain profile enabled firewall configured as expected. cis 9.1.1">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Domain Profile Enabled</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 9.1.1</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies domain profile enabled.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 9.1.1</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="private profile enabled firewall configured as expected. cis 9.2.1">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Private Profile Enabled</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 9.2.1</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies private profile enabled.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 9.2.1</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="public profile enabled firewall configured as expected. cis 9.3.1">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Public Profile Enabled</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 9.3.1</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies public profile enabled.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 9.3.1</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="inbound connection logging firewall configured as expected. cis 9.3.5">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Inbound Connection Logging</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 9.3.5</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies inbound connection logging.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 9.3.5</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="firewall service running firewall configured as expected. ">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Firewall Service Running</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies firewall service running.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            
+          </div>
+        </div>
+        
+      </div>
+    </div>
+    
+    <div class="cat-section" id="cat-Hardening">
+      <div class="cat-bar">
+        <span class="cat-name">Hardening</span>
+        <span class="cat-meta">
+          <span class="cat-tally">
+            
+            
+            <span style="color:var(--green)">✓4</span>
+            <span style="color:var(--cyan)">i1</span>
+          </span>
+          <span class="cat-score" style="color:#2bff88">100/100 A</span>
+        </span>
+      </div>
+      <div class="findings">
+        
+        <div class="frow" data-status="PASS" data-text="lsa protection (runasppl) hardening configured as expected. cis 18.9.4">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>LSA Protection (RunAsPPL)</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 18.9.4</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies lsa protection (runasppl).</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 18.9.4</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="autorun disabled hardening configured as expected. cis 18.9.8.1">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>AutoRun Disabled</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 18.9.8.1</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies autorun disabled.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 18.9.8.1</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="wdigest cleartext disabled hardening configured as expected. cis 18.3.4">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>WDigest Cleartext Disabled</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 18.3.4</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies wdigest cleartext disabled.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 18.3.4</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="cached logon count limited hardening configured as expected. cis 2.3.7.4">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Cached Logon Count Limited</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 2.3.7.4</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies cached logon count limited.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 2.3.7.4</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="INFO" data-text="powershell transcription hardening not configured ">
+          <button class="fhead">
+            <span class="ficon" style="color:#44e0e6">i</span>
+            <span class="fsev" style="color:#5d776c;border:1px solid #5d776c;background:transparent">INFO</span>
+            <span class="fname">
+              <b>PowerShell Transcription</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies powershell transcription.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Not configured</span></div>
+            
+            
+          </div>
+        </div>
+        
+      </div>
+    </div>
+    
+    <div class="cat-section" id="cat-Network">
+      <div class="cat-bar">
+        <span class="cat-name">Network</span>
+        <span class="cat-meta">
+          <span class="cat-tally">
+            
+            
+            <span style="color:var(--green)">✓3</span>
+            <span style="color:var(--cyan)">i2</span>
+          </span>
+          <span class="cat-score" style="color:#2bff88">100/100 A</span>
+        </span>
+      </div>
+      <div class="findings">
+        
+        <div class="frow" data-status="PASS" data-text="llmnr disabled network configured as expected. cis 18.5.4.2">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>LLMNR Disabled</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 18.5.4.2</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies llmnr disabled.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 18.5.4.2</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="netbios over tcp/ip off network configured as expected. ">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>NetBIOS Over TCP/IP Off</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies netbios over tcp/ip off.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="ipv6 source routing off network configured as expected. cis 18.5.20.1">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>IPv6 Source Routing Off</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 18.5.20.1</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies ipv6 source routing off.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 18.5.20.1</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="INFO" data-text="primary ip address network 10.4.12.37 ">
+          <button class="fhead">
+            <span class="ficon" style="color:#44e0e6">i</span>
+            <span class="fsev" style="color:#5d776c;border:1px solid #5d776c;background:transparent">INFO</span>
+            <span class="fname">
+              <b>Primary IP Address</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies primary ip address.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">10.4.12.37</span></div>
+            
+            
+          </div>
+        </div>
+        
+        <div class="frow" data-status="INFO" data-text="configured dns servers network 10.4.0.1, 10.4.0.2 ">
+          <button class="fhead">
+            <span class="ficon" style="color:#44e0e6">i</span>
+            <span class="fsev" style="color:#5d776c;border:1px solid #5d776c;background:transparent">INFO</span>
+            <span class="fname">
+              <b>Configured DNS Servers</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies configured dns servers.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">10.4.0.1, 10.4.0.2</span></div>
+            
+            
+          </div>
+        </div>
+        
+      </div>
+    </div>
+    
+    <div class="cat-section" id="cat-Patching">
+      <div class="cat-bar">
+        <span class="cat-name">Patching</span>
+        <span class="cat-meta">
+          <span class="cat-tally">
+            
+            <span style="color:var(--amber)">!1</span>
+            <span style="color:var(--green)">✓1</span>
+            <span style="color:var(--cyan)">i1</span>
+          </span>
+          <span class="cat-score" style="color:#2bff88">98/100 A</span>
+        </span>
+      </div>
+      <div class="findings">
+        
+        <div class="frow" data-status="WARN" data-text="pending reboot patching updates are installed but a reboot is pending to finish applying them. cis 18.1.1">
+          <button class="fhead">
+            <span class="ficon" style="color:#ffb23d">!</span>
+            <span class="fsev" style="color:#ffb23d;border:1px solid #ffb23d;background:transparent">MEDIUM</span>
+            <span class="fname">
+              <b>Pending Reboot</b>
+              <div class="fsnip">Updates are installed but a reboot is pending to finish applying them.</div>
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 18.1.1</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies pending reboot.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Updates are installed but a reboot is pending to finish applying them.</span></div>
+            
+            <div class="fld"><span class="k">Remediation</span>
+              <div class="code">Reboot the machine to complete pending updates.<button class="copy">copy</button></div></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 18.1.1</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="automatic updates enabled patching configured as expected. cis 18.10.93.2.1">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Automatic Updates Enabled</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 18.10.93.2.1</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies automatic updates enabled.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 18.10.93.2.1</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="INFO" data-text="last update installed patching 2026-05-28 ">
+          <button class="fhead">
+            <span class="ficon" style="color:#44e0e6">i</span>
+            <span class="fsev" style="color:#5d776c;border:1px solid #5d776c;background:transparent">INFO</span>
+            <span class="fname">
+              <b>Last Update Installed</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies last update installed.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">2026-05-28</span></div>
+            
+            
+          </div>
+        </div>
+        
+      </div>
+    </div>
+    
+    <div class="cat-section" id="cat-Persistence">
+      <div class="cat-bar">
+        <span class="cat-name">Persistence</span>
+        <span class="cat-meta">
+          <span class="cat-tally">
+            
+            
+            <span style="color:var(--green)">✓1</span>
+            <span style="color:var(--cyan)">i1</span>
+          </span>
+          <span class="cat-score" style="color:#2bff88">100/100 A</span>
+        </span>
+      </div>
+      <div class="findings">
+        
+        <div class="frow" data-status="PASS" data-text="no unsigned startup items persistence configured as expected. ">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>No Unsigned Startup Items</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies no unsigned startup items.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            
+          </div>
+        </div>
+        
+        <div class="frow" data-status="INFO" data-text="startup item count persistence 11 startup entries ">
+          <button class="fhead">
+            <span class="ficon" style="color:#44e0e6">i</span>
+            <span class="fsev" style="color:#5d776c;border:1px solid #5d776c;background:transparent">INFO</span>
+            <span class="fname">
+              <b>Startup Item Count</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies startup item count.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">11 startup entries</span></div>
+            
+            
+          </div>
+        </div>
+        
+      </div>
+    </div>
+    
+    <div class="cat-section" id="cat-PowerShell">
+      <div class="cat-bar">
+        <span class="cat-name">PowerShell</span>
+        <span class="cat-meta">
+          <span class="cat-tally">
+            <span style="color:var(--red)">✗1</span>
+            
+            <span style="color:var(--green)">✓4</span>
+            
+          </span>
+          <span class="cat-score" style="color:#2bff88">95/100 A</span>
+        </span>
+      </div>
+      <div class="findings">
+        
+        <div class="frow" data-status="FAIL" data-text="script block logging powershell powershell script-block logging is disabled, reducing visibility into malicious scripts. cis 18.9.95.1">
+          <button class="fhead">
+            <span class="ficon" style="color:#ff5147">✗</span>
+            <span class="fsev" style="color:#ffb23d;border:1px solid #ffb23d;background:transparent">MEDIUM</span>
+            <span class="fname">
+              <b>Script Block Logging</b>
+              <div class="fsnip">PowerShell script-block logging is disabled, reducing visibility into malicious scripts.</div>
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 18.9.95.1</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies script block logging.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">PowerShell script-block logging is disabled, reducing visibility into malicious scripts.</span></div>
+            
+            <div class="fld"><span class="k">Remediation</span>
+              <div class="code">Enable Script Block Logging via Administrative Templates.<button class="copy">copy</button></div></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 18.9.95.1</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="module logging powershell configured as expected. cis 18.9.95.2">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Module Logging</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 18.9.95.2</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies module logging.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 18.9.95.2</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="execution policy remotesigned powershell configured as expected. ">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Execution Policy RemoteSigned</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies execution policy remotesigned.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="powershell v2 disabled powershell configured as expected. cis 18.10.43">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>PowerShell v2 Disabled</b>
+              
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 18.10.43</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies powershell v2 disabled.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 18.10.43</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="constrained language mode powershell configured as expected. ">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Constrained Language Mode</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies constrained language mode.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            
+          </div>
+        </div>
+        
+      </div>
+    </div>
+    
+    <div class="cat-section" id="cat-Remote-Access">
+      <div class="cat-bar">
+        <span class="cat-name">Remote Access</span>
+        <span class="cat-meta">
+          <span class="cat-tally">
+            
+            <span style="color:var(--amber)">!1</span>
+            
+            <span style="color:var(--cyan)">i1</span>
+          </span>
+          <span class="cat-score" style="color:#2bff88">95/100 A</span>
+        </span>
+      </div>
+      <div class="findings">
+        
+        <div class="frow" data-status="WARN" data-text="rdp network level authentication remote access remote desktop is enabled but network level authentication is not enforced. cis 9.5.1">
+          <button class="fhead">
+            <span class="ficon" style="color:#ffb23d">!</span>
+            <span class="fsev" style="color:#ff5147;border:1px solid #ff5147;background:transparent">HIGH</span>
+            <span class="fname">
+              <b>RDP Network Level Authentication</b>
+              <div class="fsnip">Remote Desktop is enabled but Network Level Authentication is not enforced.</div>
+            </span>
+            <span class="fright">
+              <span class="cis">CIS 9.5.1</span>
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies rdp network level authentication.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Remote Desktop is enabled but Network Level Authentication is not enforced.</span></div>
+            
+            <div class="fld"><span class="k">Remediation</span>
+              <div class="code">Require NLA for all RDP connections.<button class="copy">copy</button></div></div>
+            
+            <div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">CIS 9.5.1</span></span></div>
+          </div>
+        </div>
+        
+        <div class="frow" data-status="INFO" data-text="rdp listener port remote access 3389 (default) ">
+          <button class="fhead">
+            <span class="ficon" style="color:#44e0e6">i</span>
+            <span class="fsev" style="color:#5d776c;border:1px solid #5d776c;background:transparent">INFO</span>
+            <span class="fname">
+              <b>RDP Listener Port</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies rdp listener port.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">3389 (default)</span></div>
+            
+            
+          </div>
+        </div>
+        
+      </div>
+    </div>
+    
+    <div class="cat-section" id="cat-Services">
+      <div class="cat-bar">
+        <span class="cat-name">Services</span>
+        <span class="cat-meta">
+          <span class="cat-tally">
+            
+            
+            <span style="color:var(--green)">✓2</span>
+            
+          </span>
+          <span class="cat-score" style="color:#2bff88">100/100 A</span>
+        </span>
+      </div>
+      <div class="findings">
+        
+        <div class="frow" data-status="PASS" data-text="no unquoted service paths services configured as expected. ">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>No Unquoted Service Paths</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies no unquoted service paths.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="telnet service absent services configured as expected. ">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Telnet Service Absent</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies telnet service absent.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            
+          </div>
+        </div>
+        
+      </div>
+    </div>
+    
+    <div class="cat-section" id="cat-System">
+      <div class="cat-bar">
+        <span class="cat-name">System</span>
+        <span class="cat-meta">
+          <span class="cat-tally">
+            
+            
+            <span style="color:var(--green)">✓2</span>
+            <span style="color:var(--cyan)">i6</span>
+          </span>
+          <span class="cat-score" style="color:#2bff88">100/100 A</span>
+        </span>
+      </div>
+      <div class="findings">
+        
+        <div class="frow" data-status="PASS" data-text="supported os build system configured as expected. ">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Supported OS Build</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies supported os build.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            
+          </div>
+        </div>
+        
+        <div class="frow" data-status="PASS" data-text="latest cumulative update installed system configured as expected. ">
+          <button class="fhead">
+            <span class="ficon" style="color:#2bff88">✓</span>
+            <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
+            <span class="fname">
+              <b>Latest Cumulative Update Installed</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies latest cumulative update installed.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Configured as expected.</span></div>
+            
+            
+          </div>
+        </div>
+        
+        <div class="frow" data-status="INFO" data-text="os edition system windows 11 pro ">
+          <button class="fhead">
+            <span class="ficon" style="color:#44e0e6">i</span>
+            <span class="fsev" style="color:#5d776c;border:1px solid #5d776c;background:transparent">INFO</span>
+            <span class="fname">
+              <b>OS Edition</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies os edition.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Windows 11 Pro</span></div>
+            
+            
+          </div>
+        </div>
+        
+        <div class="frow" data-status="INFO" data-text="os build number system 22631.4317 ">
+          <button class="fhead">
+            <span class="ficon" style="color:#44e0e6">i</span>
+            <span class="fsev" style="color:#5d776c;border:1px solid #5d776c;background:transparent">INFO</span>
+            <span class="fname">
+              <b>OS Build Number</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies os build number.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">22631.4317</span></div>
+            
+            
+          </div>
+        </div>
+        
+        <div class="frow" data-status="INFO" data-text="secure boot state system enabled ">
+          <button class="fhead">
+            <span class="ficon" style="color:#44e0e6">i</span>
+            <span class="fsev" style="color:#5d776c;border:1px solid #5d776c;background:transparent">INFO</span>
+            <span class="fname">
+              <b>Secure Boot State</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies secure boot state.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Enabled</span></div>
+            
+            
+          </div>
+        </div>
+        
+        <div class="frow" data-status="INFO" data-text="tpm presence system tpm 2.0 present and ready ">
+          <button class="fhead">
+            <span class="ficon" style="color:#44e0e6">i</span>
+            <span class="fsev" style="color:#5d776c;border:1px solid #5d776c;background:transparent">INFO</span>
+            <span class="fname">
+              <b>TPM Presence</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies tpm presence.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">TPM 2.0 present and ready</span></div>
+            
+            
+          </div>
+        </div>
+        
+        <div class="frow" data-status="INFO" data-text="firmware mode system uefi ">
+          <button class="fhead">
+            <span class="ficon" style="color:#44e0e6">i</span>
+            <span class="fsev" style="color:#5d776c;border:1px solid #5d776c;background:transparent">INFO</span>
+            <span class="fname">
+              <b>Firmware Mode</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies firmware mode.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">UEFI</span></div>
+            
+            
+          </div>
+        </div>
+        
+        <div class="frow" data-status="INFO" data-text="system uptime system 3 days, 4 hours ">
+          <button class="fhead">
+            <span class="ficon" style="color:#44e0e6">i</span>
+            <span class="fsev" style="color:#5d776c;border:1px solid #5d776c;background:transparent">INFO</span>
+            <span class="fname">
+              <b>System Uptime</b>
+              
+            </span>
+            <span class="fright">
+              
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">Verifies system uptime.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">3 days, 4 hours</span></div>
+            
+            
+          </div>
+        </div>
+        
+      </div>
+    </div>
+    
+
+    <!-- ── Footer ──────────────────────────────────────────────────────── -->
+    <div class="foot">
+      <span class="auth">For authorized security assessment use only · <strong style="color:var(--green);font-weight:600;text-shadow:0 0 9px rgba(43,255,136,0.45)">No data left this machine</strong> · CIS Benchmark v5.0.0</span>
+      <span>apotrope.sh · <a href="https://github.com/hexorcist404/apotrope">github.com/hexorcist404/apotrope</a> · MIT</span>
+    </div>
+
+  </div>
+
+  <div class="crt-overlay"></div>
+  <div class="crt-vignette"></div>
+
+  <script>
+(function(){
+  var rows = [].slice.call(document.querySelectorAll('.frow'));
+  var chips = [].slice.call(document.querySelectorAll('.fchip'));
+  var search = document.getElementById('apoSearch');
+  var showing = document.getElementById('apoShowing');
+  var active = 'ALL';
+
+  function apply(){
+    var q = (search.value||'').trim().toLowerCase();
+    var shown = 0;
+    rows.forEach(function(row){
+      var okStatus = active === 'ALL' || row.dataset.status === active;
+      var okText = !q || (row.dataset.text||'').indexOf(q) > -1;
+      var vis = okStatus && okText;
+      row.style.display = vis ? '' : 'none';
+      if (vis) shown++;
+    });
+    document.querySelectorAll('.cat-section').forEach(function(sec){
+      var any = [].some.call(sec.querySelectorAll('.frow'), function(r){ return r.style.display !== 'none'; });
+      sec.style.display = any ? '' : 'none';
+    });
+    showing.textContent = shown + ' / ' + rows.length + ' shown';
+  }
+
+  chips.forEach(function(chip){
+    chip.addEventListener('click', function(){
+      active = chip.dataset.k;
+      chips.forEach(function(c){ c.dataset.on = String(c === chip); });
+      apply();
+    });
+  });
+  search.addEventListener('input', apply);
+
+  rows.forEach(function(row){
+    var head = row.querySelector('.fhead'), body = row.querySelector('.fbody');
+    head.addEventListener('click', function(e){
+      if (e.target.closest('.copy')) return;
+      var open = body.hasAttribute('hidden');
+      if (open){ body.removeAttribute('hidden'); head.classList.add('is-open'); }
+      else { body.setAttribute('hidden',''); head.classList.remove('is-open'); }
+    });
+  });
+  document.getElementById('apoExpand').addEventListener('click', function(){
+    rows.forEach(function(r){ if (r.style.display==='none') return;
+      r.querySelector('.fbody').removeAttribute('hidden'); r.querySelector('.fhead').classList.add('is-open'); });
+  });
+  document.getElementById('apoCollapse').addEventListener('click', function(){
+    rows.forEach(function(r){ r.querySelector('.fbody').setAttribute('hidden',''); r.querySelector('.fhead').classList.remove('is-open'); });
+  });
+
+  document.querySelectorAll('.code .copy').forEach(function(btn){
+    btn.addEventListener('click', function(e){
+      e.stopPropagation();
+      var code = btn.parentNode.textContent.replace(/copy$/, '').trim();
+      if (navigator.clipboard) navigator.clipboard.writeText(code);
+      var t = btn.textContent; btn.textContent = 'copied'; setTimeout(function(){ btn.textContent = t; }, 1300);
+    });
+  });
+
+  window.apoJump = function(slug){
+    var el = document.getElementById('cat-' + slug);
+    if (!el) return;
+    window.scrollTo({ top: el.getBoundingClientRect().top + window.scrollY - 12, behavior: 'smooth' });
+  };
+})();
+</script>
+</body>
+</html>

--- a/docs/site.js
+++ b/docs/site.js
@@ -1,0 +1,106 @@
+/* Apotrope website — interaction layer. Capture-safe: all content is visible
+   without JS; this only adds motion, reveal, and copy affordances. */
+(function () {
+  "use strict";
+
+  /* ── Binary rain ─────────────────────────────────────────────────────────── */
+  function binaryRain() {
+    var host = document.getElementById("binRain");
+    if (!host) return;
+    var cols = Math.floor(window.innerWidth / 28);
+    var frag = document.createDocumentFragment();
+    for (var i = 0; i < cols; i++) {
+      var span = document.createElement("div");
+      var len = 16 + Math.floor(Math.random() * 22), txt = "";
+      for (var j = 0; j < len; j++) txt += (Math.random() > 0.5 ? "1" : "0") + " ";
+      span.textContent = txt.trim();
+      span.style.cssText =
+        "position:absolute;top:-40%;left:" + ((i / cols) * 100) + "%;" +
+        "writing-mode:vertical-rl;font-family:'IBM Plex Mono',monospace;font-size:12px;" +
+        "line-height:1.1;color:#0d6b3f;opacity:" + (0.10 + Math.random() * 0.14) + ";" +
+        "white-space:nowrap;letter-spacing:1px;animation:rain " +
+        (12 + Math.random() * 16) + "s linear " + (-Math.random() * 16) + "s infinite;";
+      frag.appendChild(span);
+    }
+    host.appendChild(frag);
+  }
+
+  /* ── Reveal on scroll ────────────────────────────────────────────────────── */
+  function reveal() {
+    var els = Array.prototype.slice.call(document.querySelectorAll("[data-reveal]"));
+    function show(e) { e.classList.add("in"); }
+    if (!("IntersectionObserver" in window)) { els.forEach(show); return; }
+    // Reveal anything already on screen immediately (covers above-the-fold).
+    var vh = window.innerHeight || document.documentElement.clientHeight;
+    els.forEach(function (e) { var r = e.getBoundingClientRect(); if (r.top < vh * 0.92) show(e); });
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (en) {
+        if (en.isIntersecting) { show(en.target); io.unobserve(en.target); }
+      });
+    }, { threshold: 0.12, rootMargin: "0px 0px -8% 0px" });
+    els.forEach(function (e) { if (!e.classList.contains("in")) io.observe(e); });
+    // Failsafe: never strand content if the observer is throttled (background tab).
+    setTimeout(function () { els.forEach(show); }, 1600);
+  }
+
+  /* ── Terminal: progressive line reveal (enhancement only) ─────────────────── */
+  function terminal() {
+    if (window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    var term = document.getElementById("scanTerm");
+    if (!term) return;
+    var lines = Array.prototype.slice.call(term.querySelectorAll(".tl"));
+    var started = false;
+    function play() {
+      if (started) return; started = true;
+      lines.forEach(function (ln) { ln.style.opacity = "0"; });
+      var i = 0;
+      (function step() {
+        if (i >= lines.length) return;
+        lines[i].style.transition = "opacity .18s ease";
+        lines[i].style.opacity = "1";
+        var delay = lines[i].dataset.pause ? parseInt(lines[i].dataset.pause, 10) : 95;
+        i++; setTimeout(step, delay);
+      })();
+    }
+    if ("IntersectionObserver" in window) {
+      var io = new IntersectionObserver(function (e) {
+        if (e[0].isIntersecting) { play(); io.disconnect(); }
+      }, { threshold: 0.3 });
+      io.observe(term);
+    } else { play(); }
+  }
+
+  /* ── Copy buttons ────────────────────────────────────────────────────────── */
+  function copies() {
+    document.querySelectorAll("[data-copy]").forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var txt = btn.getAttribute("data-copy");
+        if (navigator.clipboard) navigator.clipboard.writeText(txt).catch(function () {});
+        var old = btn.textContent;
+        btn.textContent = "copied ✓";
+        setTimeout(function () { btn.textContent = old; }, 1300);
+      });
+    });
+  }
+
+  /* ── Nav active section ──────────────────────────────────────────────────── */
+  function navHighlight() {
+    var links = Array.prototype.slice.call(document.querySelectorAll(".nav-links a[href^='#']"));
+    var map = {};
+    links.forEach(function (a) { var id = a.getAttribute("href").slice(1); var s = document.getElementById(id); if (s) map[id] = a; });
+    if (!("IntersectionObserver" in window)) return;
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (en) {
+        if (en.isIntersecting) {
+          links.forEach(function (a) { a.classList.remove("active"); });
+          if (map[en.target.id]) map[en.target.id].classList.add("active");
+        }
+      });
+    }, { rootMargin: "-45% 0px -50% 0px" });
+    Object.keys(map).forEach(function (id) { io.observe(document.getElementById(id)); });
+  }
+
+  function init() { binaryRain(); reveal(); terminal(); copies(); navHighlight(); }
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", init);
+  else init();
+})();

--- a/src/apotrope/cis_map.py
+++ b/src/apotrope/cis_map.py
@@ -68,6 +68,25 @@ NEEDS MANUAL REVIEW (no direct CIS admin template control in v5.0.0):
 
 from __future__ import annotations
 
+# CIS Benchmark editions these IDs are verified against, by OS family.
+# Windows 11 uses the v5.0.0 benchmark; Windows 10 / Server 2019 uses v4.0.0.
+CIS_VERSION_WIN11 = "v5.0.0"
+CIS_VERSION_WIN10 = "v4.0.0"
+
+
+def benchmark_version(is_win10: bool = False) -> str:
+    """Return the CIS Benchmark edition string for the audited OS family.
+
+    Args:
+        is_win10: ``True`` for Windows 10 / Server 2019 hosts (build < 22000),
+                  ``False`` for Windows 11.
+
+    Returns:
+        ``"v4.0.0"`` for Windows 10, ``"v5.0.0"`` for Windows 11.
+    """
+    return CIS_VERSION_WIN10 if is_win10 else CIS_VERSION_WIN11
+
+
 # Win10 v4.0.0 IDs that differ from the Win11 v5.0.0 base map.
 # Section offsets that changed: Defender (42→43), PowerShell (88→87),
 # WinRM (90→89), Windows Update (94→93).  SMB Encryption (18.6.8.7)

--- a/src/apotrope/models.py
+++ b/src/apotrope/models.py
@@ -72,6 +72,7 @@ class AuditReport:
     results: list[CheckResult] = field(default_factory=list)
     score: int = 0
     is_admin: bool = False
+    cis_version: str = ""  # CIS Benchmark edition used (e.g. "v5.0.0" / "v4.0.0")
 
     # ------------------------------------------------------------------
     # Convenience helpers

--- a/src/apotrope/reporter.py
+++ b/src/apotrope/reporter.py
@@ -102,6 +102,33 @@ def _grade_hex(score: int) -> str:
     return _RED         # F
 
 
+# Colour band shared by the HTML gauge, category bars, and scores.
+_band = _grade_hex
+
+# ── HTML report presentation maps (status glyph/colour, severity colour) ──────
+# Note: the HTML report colours LOW severity cyan (vs muted in the terminal);
+# this mirrors the report spec exactly.
+
+_HTML_STATUS: dict[Status, tuple[str, str]] = {
+    Status.PASS:  ("✓", _GREEN),
+    Status.FAIL:  ("✗", _RED),
+    Status.WARN:  ("!", _AMBER),
+    Status.INFO:  ("i", _CYAN),
+    Status.ERROR: ("?", _MUTED),
+}
+
+_HTML_SEVERITY: dict[Severity, str] = {
+    Severity.CRITICAL: _CRIT,
+    Severity.HIGH:     _RED,
+    Severity.MEDIUM:   _AMBER,
+    Severity.LOW:      _CYAN,
+    Severity.INFO:     _MUTED,
+}
+
+# CIS Benchmark edition the cis_map IDs are verified against (see cis_map.py).
+_CIS_VERSION = "v5.0.0"
+
+
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 def _console_is_unicode(console) -> bool:
@@ -378,11 +405,19 @@ class Reporter:
     # ── Internal rendering helpers ────────────────────────────────────────────
 
     def _build_template_context(self, report: AuditReport) -> dict:
-        """Build the full Jinja2 template variable dict for the HTML report."""
+        """Build the full Jinja2 template variable dict for the HTML report.
+
+        Everything the report needs is computed here (server-side): per-finding
+        presentation, category groupings, the gauge tick ring, the donut arcs,
+        and the prioritised top-issues list. The template only loops and prints.
+        """
+        import math
+        import re
         from collections import defaultdict
 
         letter, label = score_grade(report.score)
         cat_scores = calculate_category_scores(report.results)
+        total = len(report.results)
 
         _sev_ord: dict[Severity, int] = {
             Severity.CRITICAL: 0, Severity.HIGH: 1,
@@ -396,7 +431,31 @@ class Reporter:
         def _sort_key(r: CheckResult) -> tuple[int, int]:
             return (_sta_ord.get(r.status, 5), _sev_ord.get(r.severity, 5))
 
-        # Per-category data (sorted by category name, results by status/severity)
+        def _slug(name: str) -> str:
+            # Mirror the JS: collapse whitespace runs to '-'. Used for ids/anchors.
+            return re.sub(r"\s+", "-", name.strip())
+
+        def _finding_view(r: CheckResult) -> dict:
+            glyph, scolor = _HTML_STATUS.get(r.status, ("?", _MUTED))
+            snippet = ""
+            if r.status in (Status.FAIL, Status.WARN) and r.details:
+                snippet = r.details.split("\n")[0].split(". ")[0]
+            return {
+                "status":       r.status.value,
+                "status_glyph": glyph,
+                "status_color": scolor,
+                "severity":     r.severity.value,
+                "sev_color":    _HTML_SEVERITY.get(r.severity, _MUTED),
+                "category":     r.category,
+                "check_name":   r.check_name,
+                "description":  r.description,
+                "details":      r.details,
+                "remediation":  r.remediation,
+                "cis":          r.cis_reference,
+                "snippet":      snippet,
+            }
+
+        # ── Categories: alphabetical page order; results sorted within ────────
         by_cat: dict[str, list[CheckResult]] = defaultdict(list)
         for r in report.results:
             by_cat[r.category].append(r)
@@ -405,36 +464,81 @@ class Reporter:
         for cat_name in sorted(by_cat):
             cat_results = sorted(by_cat[cat_name], key=_sort_key)
             cs = cat_scores.get(cat_name, 100)
-            cl, clbl = score_grade(cs)
+            cl, _ = score_grade(cs)
             category_data.append({
-                "name":        cat_name,
-                "score":       cs,
-                "grade":       cl,
-                "grade_label": clbl,
-                "results":     cat_results,
-                "fail_count":  sum(1 for r in cat_results if r.status == Status.FAIL),
-                "warn_count":  sum(1 for r in cat_results if r.status == Status.WARN),
-                "pass_count":  sum(1 for r in cat_results if r.status == Status.PASS),
-                "error_count": sum(1 for r in cat_results if r.status == Status.ERROR),
+                "name":         cat_name,
+                "slug":         _slug(cat_name),
+                "score":        cs,
+                "band":         _band(cs),
+                "grade_letter": cl,
+                "fail":         sum(1 for r in cat_results if r.status == Status.FAIL),
+                "warn":         sum(1 for r in cat_results if r.status == Status.WARN),
+                "pass":         sum(1 for r in cat_results if r.status == Status.PASS),
+                "info":         sum(1 for r in cat_results if r.status == Status.INFO),
+                "findings":     [_finding_view(r) for r in cat_results],
             })
 
-        # Top findings: CRITICAL+HIGH FAIL/WARN, up to 5
-        issues = [r for r in report.results if r.status in (Status.FAIL, Status.WARN)]
-        issues.sort(key=lambda r: (_sev_ord.get(r.severity, 5),
-                                   0 if r.status == Status.FAIL else 1))
-        top_findings = [
-            r for r in issues
-            if r.severity in (Severity.CRITICAL, Severity.HIGH)
-        ][:5]
-
-        # All FAIL+WARN for detailed findings section
-        fail_warn_results = sorted(
-            [r for r in report.results if r.status in (Status.FAIL, Status.WARN)],
-            key=_sort_key,
+        # Category-score bars: worst score first.
+        category_bars = sorted(
+            ({"name": c["name"], "slug": c["slug"],
+              "score": c["score"], "band": c["band"]} for c in category_data),
+            key=lambda c: c["score"],
         )
 
-        # INFO results for appendix
-        info_results = [r for r in report.results if r.status == Status.INFO]
+        # ── Top issues: FAIL/WARN with remediation, CRITICAL/HIGH or any FAIL ─
+        candidates = [
+            r for r in report.results
+            if r.status in (Status.FAIL, Status.WARN) and r.remediation
+            and (r.severity in (Severity.CRITICAL, Severity.HIGH)
+                 or r.status == Status.FAIL)
+        ]
+        candidates.sort(key=lambda r: (_sev_ord.get(r.severity, 5),
+                                       0 if r.status == Status.FAIL else 1))
+        top_issues = [
+            {
+                "num":           f"{i + 1:02d}",
+                "severity":      r.severity.value,
+                "sev_color":     _HTML_SEVERITY.get(r.severity, _MUTED),
+                "status":        r.status.value,
+                "status_color":  _HTML_STATUS.get(r.status, ("", _MUTED))[1],
+                "category":      r.category,
+                "category_slug": _slug(r.category),
+                "check_name":    r.check_name,
+                "remediation":   r.remediation,
+            }
+            for i, r in enumerate(candidates[:5])
+        ]
+
+        # ── Score gauge: 40-tick ring + arc dash offset ───────────────────────
+        band = _band(report.score)
+        gauge_ticks = []
+        for i in range(40):
+            on  = (i / 40) <= (report.score / 100)
+            ang = math.radians(-90 + i * 9)
+            gauge_ticks.append({
+                "x1": round(115 + 103 * math.cos(ang), 2),
+                "y1": round(115 + 103 * math.sin(ang), 2),
+                "x2": round(115 + 112 * math.cos(ang), 2),
+                "y2": round(115 + 112 * math.sin(ang), 2),
+                "color":   band if on else "#16241d",
+                "opacity": 0.9 if on else 0.5,
+            })
+        gauge_dashoffset = round(603.2 * (1 - report.score / 100), 2)
+
+        # ── Result-distribution donut (r=52, C≈326.7) ─────────────────────────
+        circ = 2 * math.pi * 52
+        donut, accum = [], 0.0
+        for st, color in ((Status.PASS, _GREEN), (Status.FAIL, _RED),
+                          (Status.WARN, _AMBER), (Status.INFO, _CYAN)):
+            cnt = sum(1 for r in report.results if r.status == st)
+            seg = (cnt / total * circ) if total else 0.0
+            donut.append({
+                "color":  color,
+                "dash":   round(seg, 2),
+                "gap":    round(circ - seg, 2),
+                "offset": round(-accum, 2),
+            })
+            accum += seg
 
         ts = report.scan_timestamp
         generated_at = (
@@ -443,16 +547,32 @@ class Reporter:
         )
 
         return {
-            "report":            report,
-            "version":           __version__,
-            "score_grade":       letter,
-            "score_label":       label,
-            "executive_summary": self._build_executive_summary(report),
-            "category_data":     category_data,
-            "top_findings":      top_findings,
-            "fail_warn_results": fail_warn_results,
-            "info_results":      info_results,
-            "generated_at":      generated_at,
+            "report":             report,
+            "version":            __version__,
+            "hostname":           report.hostname,
+            "os_version":         report.os_version,
+            "scan_timestamp":     generated_at,
+            "scan_duration":      f"{report.scan_duration:.1f}",
+            "score":              report.score,
+            "grade_letter":       letter,
+            "grade_label":        label,
+            "band_color":         band,
+            "total_checks":       total,
+            "pass_count":         report.pass_count,
+            "fail_count":         report.fail_count,
+            "warn_count":         report.warn_count,
+            "info_count":         sum(1 for r in report.results if r.status == Status.INFO),
+            "error_count":        report.error_count,
+            "exec_summary_html":  self._build_executive_summary_html(report),
+            "gauge_ticks":        gauge_ticks,
+            "gauge_dashoffset":   gauge_dashoffset,
+            "donut":              donut,
+            "donut_center":       report.fail_count,
+            "category_data":      category_data,
+            "category_bars":      category_bars,
+            "n_cats":             len(category_data),
+            "top_issues":         top_issues,
+            "cis_version":        _CIS_VERSION,
         }
 
     def _build_executive_summary(self, report: AuditReport) -> str:
@@ -540,6 +660,95 @@ class Reporter:
             )
 
         return "  ".join(parts)
+
+    def _build_executive_summary_html(self, report: AuditReport):
+        """Executive summary as escaped HTML with semantic highlight spans.
+
+        Same narrative as :meth:`_build_executive_summary`, but emits `<b>` for
+        host/grade/areas and `.hl-crit` / `.hl-high` / `.hl-ok` spans. All
+        scan-derived text (the hostname) is HTML-escaped; the markup is ours.
+        """
+        from collections import Counter
+
+        from markupsafe import Markup, escape
+
+        letter, label = score_grade(report.score)
+        total = len(report.results)
+        host  = escape(report.hostname)
+
+        critical_fails = sum(
+            1 for r in report.results
+            if r.status == Status.FAIL and r.severity == Severity.CRITICAL
+        )
+        high_fails = sum(
+            1 for r in report.results
+            if r.status == Status.FAIL and r.severity == Severity.HIGH
+        )
+        issue_cats = Counter(
+            r.category for r in report.results
+            if r.status in (Status.FAIL, Status.WARN)
+        )
+
+        parts: list[str] = [
+            f"The security posture of <b>{host}</b> has been assessed as "
+            f"<b>{label}</b> with an overall score of "
+            f"<b>{report.score}/100 ({letter})</b> across {total} security checks."
+        ]
+
+        if report.fail_count == 0 and report.warn_count == 0:
+            parts.append(
+                '<span class="hl-ok">All checks passed with no failures or '
+                "warnings detected — the system is configured in line with "
+                "Windows security best practices.</span>"
+            )
+            return Markup(" ".join(parts))
+
+        if critical_fails > 0:
+            noun = "finding" if critical_fails == 1 else "findings"
+            verb = "requires" if critical_fails == 1 else "require"
+            parts.append(
+                f'<span class="hl-crit">{critical_fails} critical {noun} '
+                f"{verb} immediate remediation.</span>"
+            )
+        elif high_fails > 0:
+            noun = "finding" if high_fails == 1 else "findings"
+            parts.append(
+                f'<span class="hl-high">{high_fails} high-severity {noun} '
+                "should be addressed promptly.</span>"
+            )
+
+        detail_parts: list[str] = []
+        if report.fail_count > 0:
+            n = report.fail_count
+            detail_parts.append(f"{n} check{'s' if n != 1 else ''} failed")
+        if report.warn_count > 0:
+            n = report.warn_count
+            detail_parts.append(f"{n} check{'s' if n != 1 else ''} issued warnings")
+        if detail_parts:
+            parts.append(f"Of the checks performed, {' and '.join(detail_parts)}.")
+
+        if issue_cats:
+            top_cats = [escape(cat) for cat, _ in issue_cats.most_common(3)]
+            if len(top_cats) == 1:
+                parts.append(f"The primary area of concern is <b>{top_cats[0]}</b>.")
+            else:
+                joined = (", ".join(f"<b>{c}</b>" for c in top_cats[:-1])
+                          + f" and <b>{top_cats[-1]}</b>")
+                parts.append(f"The primary areas of concern are {joined}.")
+
+        parts.append(
+            "Remediation should be prioritized by severity, "
+            "addressing critical and high-severity findings first."
+        )
+
+        if report.error_count:
+            n = report.error_count
+            parts.append(
+                f"Note: {n} check{'s' if n != 1 else ''} could not complete "
+                "— run as Administrator for full results."
+            )
+
+        return Markup(" ".join(parts))
 
     def _make_console(self):
         from rich.console import Console

--- a/src/apotrope/reporter.py
+++ b/src/apotrope/reporter.py
@@ -24,16 +24,49 @@ from apotrope.scoring import calculate_category_scores, score_grade
 
 log = logging.getLogger(__name__)
 
-# ── Status display config ─────────────────────────────────────────────────────
+# ── Palette (truecolor hex — identical to the HTML report) ─────────────────────
+# Rich emits these as 24-bit ANSI on capable terminals and silently degrades /
+# strips them when no_color, NO_COLOR, or a non-tty stdout is detected.
 
-_STATUS_COLOR: dict[Status, str] = {
-    Status.PASS:  "green",
-    Status.FAIL:  "red",
-    Status.WARN:  "yellow",
-    Status.INFO:  "cyan",
-    Status.ERROR: "dim",
+_GREEN  = "#2bff88"   # PASS · A–B grade · rail · done
+_CYAN   = "#44e0e6"   # INFO · progress bar
+_AMBER  = "#ffb23d"   # WARN · C–D grade · MEDIUM
+_RED    = "#ff5147"   # FAIL · F grade · HIGH
+_CRIT   = "#ff2d6b"   # CRITICAL severity
+_TEXT   = "#c4d6cd"   # default body text
+_BRIGHT = "#e8fff2"   # command echo · emphasis
+_MUTED  = "#5d776c"   # labels · meta · secondary
+_FAINT  = "#2f4138"   # footnotes · CIS tags · "evaluated"
+_BAR0   = "#16281f"   # unfilled bar cells
+
+# ── Status / severity display config ──────────────────────────────────────────
+
+_STATUS_HEX: dict[Status, str] = {
+    Status.PASS:  _GREEN,
+    Status.FAIL:  _RED,
+    Status.WARN:  _AMBER,
+    Status.INFO:  _CYAN,
+    Status.ERROR: _MUTED,
 }
 
+_SEVERITY_HEX: dict[Severity, str] = {
+    Severity.CRITICAL: _CRIT,
+    Severity.HIGH:     _RED,
+    Severity.MEDIUM:   _AMBER,
+    Severity.LOW:      _MUTED,
+    Severity.INFO:     _MUTED,
+}
+
+# Compact severity labels so the top-findings column stays width-5.
+_SEVERITY_ABBR: dict[Severity, str] = {
+    Severity.CRITICAL: "CRIT",
+    Severity.HIGH:     "HIGH",
+    Severity.MEDIUM:   "MED",
+    Severity.LOW:      "LOW",
+    Severity.INFO:     "INFO",
+}
+
+# Plain-text fallback icons (used only by _print_plain when Rich is absent).
 _STATUS_ICON: dict[Status, str] = {
     Status.PASS:  "✓",
     Status.FAIL:  "✗",
@@ -42,24 +75,7 @@ _STATUS_ICON: dict[Status, str] = {
     Status.ERROR: "?",
 }
 
-_SEVERITY_COLOR: dict[Severity, str] = {
-    Severity.CRITICAL: "bold red",
-    Severity.HIGH:     "red",
-    Severity.MEDIUM:   "yellow",
-    Severity.LOW:      "blue",
-    Severity.INFO:     "dim",
-}
-
-# Letter grade → Rich color
-_GRADE_COLOR: dict[str, str] = {
-    "A": "bold green",
-    "B": "green",
-    "C": "yellow",
-    "D": "dark_orange",
-    "F": "bold red",
-}
-
-# Severity sort key for top-issues ranking
+# Severity sort key for top-findings ranking (CRITICAL first).
 _SEV_ORDER: dict[Severity, int] = {
     Severity.CRITICAL: 0,
     Severity.HIGH:     1,
@@ -68,10 +84,22 @@ _SEV_ORDER: dict[Severity, int] = {
     Severity.INFO:     4,
 }
 
-_TOP_ISSUES_COUNT  = 5
-_SCORE_BAR_WIDTH   = 34
-_DETAIL_INLINE_MAX = 60
-_REM_WRAP_WIDTH    = 72
+_TOP_N        = 5    # cap on rows in TOP FAILURES / TOP WARNINGS
+_BAR_CELLS    = 24   # score-panel bar width (spec)
+_PROG_CELLS   = 20   # banner progress bar width
+_SEV_WIDTH    = 5    # severity column width in top findings (spec)
+_DESC_WIDTH   = 27   # description column width in top findings (spec)
+_PANEL_WIDTH  = 56   # inner width for right-aligned hostname / grade
+_REM_WRAP_WIDTH = 72  # detail / remediation wrap width (verbose)
+
+
+def _grade_hex(score: int) -> str:
+    """Grade colour for a 0–100 score (number + badge share it)."""
+    if score >= 80:
+        return _GREEN   # A, B
+    if score >= 60:
+        return _AMBER   # C, D
+    return _RED         # F
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -87,10 +115,37 @@ def _u(console, unicode_char: str, ascii_char: str) -> str:
     return unicode_char if _console_is_unicode(console) else ascii_char
 
 
-def _score_bar(score: int, filled_char: str = "=", empty_char: str = "-") -> str:
-    """Return a filled/empty progress bar string for *score* (0–100)."""
-    filled = round(score / 100 * _SCORE_BAR_WIDTH)
-    return filled_char * filled + empty_char * (_SCORE_BAR_WIDTH - filled)
+def _glyphs(console) -> dict[str, str]:
+    """Resolve the glyph set for *console*, falling back to ASCII when needed."""
+    if _console_is_unicode(console):
+        return {
+            "brand": "◈", "rail": "▌", "bar_full": "█", "bar_empty": "░",
+            "pass": "✓", "fail": "✗", "warn": "!", "info": "i", "error": "·",
+            "flag": "⚑", "arrow": "→", "sep": "·",
+        }
+    return {
+        "brand": "*", "rail": "|", "bar_full": "#", "bar_empty": "-",
+        "pass": "[+]", "fail": "[x]", "warn": "[!]", "info": "[i]", "error": "[.]",
+        "flag": "", "arrow": "->", "sep": "-",
+    }
+
+
+def _text(*segments):
+    """Build a Rich Text from (str) or (str, style) segments.
+
+    User-supplied strings (check names, CIS tags) are appended as data, never
+    parsed as markup — so a `[` in a check name can't corrupt the line.
+    """
+    from rich.text import Text
+
+    t = Text()
+    for seg in segments:
+        if isinstance(seg, tuple):
+            chunk, style = seg
+            t.append(chunk, style=style)
+        else:
+            t.append(seg)
+    return t
 
 
 def _truncate(text: str, maxlen: int) -> str:
@@ -127,19 +182,12 @@ class Reporter:
             Completed :class:`~apotrope.models.AuditReport`.
         """
         try:
-            from rich.progress import (
-                BarColumn,
-                MofNCompleteColumn,
-                Progress,
-                SpinnerColumn,
-                TextColumn,
-                TimeElapsedColumn,
-                TimeRemainingColumn,
-            )
+            from rich.progress import BarColumn, Progress, TextColumn
         except ImportError:
             return scanner.run()
 
         console = self._make_console()
+        g       = _glyphs(console)
         modules = scanner.discover_modules()
         total   = len(modules)
 
@@ -149,25 +197,31 @@ class Reporter:
             self._print_non_admin_warning(console)
         console.print()
 
+        # A single inline bar — no spinner, no stacked columns. It tracks module
+        # completion live, then is erased and replaced by the static "done" line.
         with Progress(
-            SpinnerColumn(style="cyan"),
-            TextColumn("[cyan]{task.description:<24}[/cyan]"),
-            BarColumn(bar_width=28, style="dim blue", complete_style="cyan"),
-            MofNCompleteColumn(),
-            TimeElapsedColumn(),
-            TimeRemainingColumn(),
+            TextColumn(f"  [{_MUTED}]scanning controls[/]"),
+            BarColumn(bar_width=_PROG_CELLS, style=_BAR0,
+                      complete_style=_CYAN, finished_style=_CYAN),
+            TextColumn(f"[{_MUTED}]{{task.completed}}/{{task.total}}[/]"),
             console=console,
-            transient=False,
+            transient=True,
         ) as progress:
-            task = progress.add_task("Initializing…", total=total)
+            task = progress.add_task("scan", total=total)
 
             def _on_module(module) -> None:
-                cat = getattr(module, "CATEGORY", module.__name__)
-                progress.update(task, description=cat, advance=1)
+                progress.update(task, advance=1)
 
             report = scanner.run(modules=modules, on_module_start=_on_module)
-            progress.update(task, description="Scan complete")
 
+        # Static completion line (mirrors the site's terminal demo).
+        bar = g["bar_full"] * _PROG_CELLS
+        console.print(_text(
+            "  ",
+            (f"scanning {len(report.results)} controls ", _MUTED),
+            (f"[{bar}]", _CYAN),
+            (f" done {g['sep']} {report.scan_duration:.1f}s", _MUTED),
+        ))
         console.print()
         return report
 
@@ -193,8 +247,13 @@ class Reporter:
 
         console = self._make_console()
         self._print_score_panel(console, report)
-        self._print_category_panels(console, report)
-        self._print_top_issues(console, report)
+        if self.verbose:
+            # Full per-category detail lives here (and in the HTML report).
+            self._print_category_detail(console, report)
+        else:
+            # Default view stays concise: prioritised failures, then warnings.
+            self._print_top_findings(console, report, Status.FAIL)
+            self._print_top_findings(console, report, Status.WARN)
         self._print_footer(console, report, html_path, json_path)
 
     def generate_html_report(self, report: AuditReport, path: str) -> None:
@@ -487,202 +546,181 @@ class Reporter:
         return Console(no_color=self.no_color, highlight=False)
 
     def _print_non_admin_warning(self, console) -> None:
-        """Print a warning panel when the scan is running without elevation."""
-        from rich.panel import Panel
-        warn = _u(console, "⚠  ", "! ")
-        console.print(Panel(
-            f"  {warn}[yellow bold]Running without administrator privileges.[/yellow bold]\n"
-            "  Some checks (BitLocker, SMB configuration) will be skipped.\n"
-            "  For a complete audit, right-click and [bold]Run as Administrator[/bold].",
-            border_style="yellow",
-            padding=(0, 1),
+        """Note (no box) that the scan is running without elevation."""
+        g = _glyphs(console)
+        console.print(_text(
+            "  ",
+            (f"{g['warn']} running without administrator privileges", _AMBER),
+        ))
+        console.print(_text(
+            "    ",
+            ("some checks (BitLocker, SMB) will be skipped — "
+             "run elevated for a full audit", _MUTED),
         ))
 
     def _print_banner(self, console) -> None:
-        """Print the Apotrope logo panel."""
-        from rich.align import Align
-        from rich.panel import Panel
-        from rich.text import Text
+        """Print the Apotrope wordmark — two lines, no frame."""
+        g = _glyphs(console)
+        console.print(_text(
+            "  ",
+            (f"{g['brand']} APOTROPE", f"bold {_GREEN}"),
+            (f"  v{__version__}", _MUTED),
+        ))
+        console.print(_text(
+            "  ",
+            ("Windows Security Posture Auditor", _MUTED),
+        ))
 
-        diamond = _u(console, "◈", "*")
-        logo = Text(f"{diamond}  A P O T R O P E  {diamond}", style="bold blue")
-        sub  = Text(f"Windows Security Posture Auditor  {_u(console, '·', '-')}  v{__version__}", style="dim")
-        # Build two-line content; Text.append returns self so we can chain
-        content = logo.copy()
-        content.append("\n")
-        content.append(sub)
-        console.print(Align.center(Panel(
-            Align.center(content),
-            border_style="blue",
-            padding=(1, 6),
-        )))
+    def _rail(self, console, body) -> None:
+        """Print *body* (a Rich Text) prefixed by the green ▌ accent rail."""
+        g = _glyphs(console)
+        line = _text("  ", (g["rail"] + " ", _GREEN))
+        line.append_text(body)
+        console.print(line)
 
     def _print_score_panel(self, console, report: AuditReport) -> None:
-        """Print the prominent security-score panel."""
-        from rich.panel import Panel
-
+        """Print the security-score block, accented by the ▌ rail."""
+        g = _glyphs(console)
         letter, label = score_grade(report.score)
-        gc  = _GRADE_COLOR.get(letter, "white")
-        bar = _score_bar(
-            report.score,
-            filled_char=_u(console, "█", "="),
-            empty_char=_u(console, "░", "-"),
-        )
+        gc = _grade_hex(report.score)
 
-        ts     = report.scan_timestamp
-        ts_str = ts.strftime("%Y-%m-%d %H:%M UTC") if ts.tzinfo else ts.strftime("%Y-%m-%d %H:%M")
-        total  = len(report.results)
-        errors = sum(1 for r in report.results if r.status == Status.ERROR)
+        total      = len(report.results)
+        info_count = sum(1 for r in report.results if r.status == Status.INFO)
 
-        meta = (
-            f"  [dim]Host:[/dim]  [bold]{report.hostname}[/bold]"
-            f"   [dim]OS:[/dim] {report.os_version}\n"
-            f"  [dim]Scan:[/dim] {ts_str}"
-            f"   [dim]Duration:[/dim] {report.scan_duration:.1f}s"
-            f"   [dim]Total checks:[/dim] {total}"
-        )
-
-        score_line = f"\n  [{gc}]{report.score:>3} / 100    {letter}  {label}[/{gc}]\n"
-        bar_line   = f"  [{gc}]{bar}[/{gc}]\n"
-
-        ck = _u(console, "✓", "+")
-        xk = _u(console, "✗", "x")
-        counts = (
-            f"  [green]{ck}  {report.pass_count:>3} passed[/green]"
-            f"   [red]{xk}  {report.fail_count:>3} failed[/red]"
-            f"   [yellow]!  {report.warn_count:>3} warnings[/yellow]"
-        )
-        if errors:
-            counts += f"   [dim]?  {errors} error(s)[/dim]"
-
-        console.print(Panel(
-            meta + score_line + bar_line + counts,
-            title="[bold]Security Score[/bold]",
-            border_style=gc.replace("bold ", ""),
-            padding=(0, 1),
+        # Header: SECURITY SCORE .......... HOSTNAME (right-aligned)
+        host = report.hostname
+        pad  = max(2, _PANEL_WIDTH - len("SECURITY SCORE") - len(host))
+        self._rail(console, _text(
+            ("SECURITY SCORE", f"bold {_GREEN}"),
+            (" " * pad, None),
+            (host, _MUTED),
         ))
+        self._rail(console, _text((report.os_version, _MUTED)))
+        self._rail(console, _text(" "))
+
+        # Score number + grade badge (share the grade colour).
+        self._rail(console, _text(
+            (f"{report.score} / 100", f"bold {gc}"),
+            ("   ", None),
+            (f"{letter} {g['sep']} {label.upper()}", gc),
+        ))
+
+        # Score bar: 24 cells, filled in grade colour, empty in bar0.
+        filled = round(report.score / 100 * _BAR_CELLS)
+        self._rail(console, _text(
+            (g["bar_full"] * filled, gc),
+            (g["bar_empty"] * (_BAR_CELLS - filled), _BAR0),
+        ))
+        self._rail(console, _text(" "))
+
+        # Distribution — each count in its status colour.
+        dist = _text(
+            (f"{g['pass']} {report.pass_count} pass", _GREEN),
+            ("   ", None),
+            (f"{g['fail']} {report.fail_count} fail", _RED),
+            ("   ", None),
+            (f"{g['warn']} {report.warn_count} warn", _AMBER),
+            ("   ", None),
+            (f"{g['info']} {info_count} info", _CYAN),
+        )
+        if report.error_count:
+            dist.append(f"   {g['sep']} {report.error_count} error", style=_MUTED)
+        self._rail(console, dist)
+        self._rail(console, _text((f"{total} checks evaluated", _FAINT)))
         console.print()
 
-    def _print_category_panels(self, console, report: AuditReport) -> None:
-        """Print one Rich Panel per check category."""
-        from rich.panel import Panel
-
-        cat_scores = calculate_category_scores(report.results)
-        categories = sorted({r.category for r in report.results})
-
-        for category in categories:
-            results    = [r for r in report.results if r.category == category]
-            cat_score  = cat_scores.get(category, 100)
-            letter, _  = score_grade(cat_score)
-            score_color = _GRADE_COLOR.get(letter, "white")
-
-            _icon: dict[Status, str] = {
-                Status.PASS:  _u(console, "✓", "+"),
-                Status.FAIL:  _u(console, "✗", "x"),
-                Status.WARN:  "!",
-                Status.INFO:  "i",
-                Status.ERROR: "?",
-            }
-            lines: list[str] = []
-            for result in results:
-                sc   = _STATUS_COLOR[result.status]
-                icon = _icon[result.status]
-
-                # Bold red icon for CRITICAL failures
-                if result.status == Status.FAIL and result.severity == Severity.CRITICAL:
-                    icon_markup = f"[bold red]{icon}[/bold red]"
-                else:
-                    icon_markup = f"[{sc}]{icon}[/{sc}]"
-
-                name_markup = f"[{sc}]{result.check_name}[/{sc}]"
-
-                # One-line detail snippet for FAIL/WARN in normal mode
-                inline = ""
-                if not self.verbose and result.details and result.status in (
-                    Status.FAIL, Status.WARN
-                ):
-                    snippet = result.details.split("\n")[0]
-                    for sep in (".", ";", " - ", " -- "):
-                        if sep in snippet:
-                            snippet = snippet.split(sep)[0]
-                            break
-                    inline = f"  [dim]{_truncate(snippet, _DETAIL_INLINE_MAX)}[/dim]"
-
-                lines.append(f"  {icon_markup}  {name_markup}{inline}")
-
-                if self.verbose:
-                    sev_c = _SEVERITY_COLOR.get(result.severity, "white")
-                    lines.append(
-                        f"     [dim]Severity:[/dim]  [{sev_c}]{result.severity.value}[/{sev_c}]"
-                    )
-                    if result.details:
-                        wrapped = textwrap.wrap(result.details, 72)
-                        lines.append(f"     [dim]Details:[/dim]   {wrapped[0]}")
-                        for cont in wrapped[1:]:
-                            lines.append(f"               {cont}")
-                    if result.remediation:
-                        wrapped = textwrap.wrap(result.remediation, 72)
-                        lines.append(
-                            f"     [dim]Fix:[/dim]       [italic]{wrapped[0]}[/italic]"
-                        )
-                        for cont in wrapped[1:]:
-                            lines.append(f"               [italic]{cont}[/italic]")
-                    lines.append("")
-
-            title = (
-                f"[bold]{category}[/bold]"
-                f"   [{score_color}]{cat_score}/100  {letter}[/{score_color}]"
-            )
-            console.print(Panel(
-                "\n".join(lines),
-                title=title,
-                border_style="blue",
-                padding=(0, 1),
-            ))
-            console.print()
-
-    def _print_top_issues(self, console, report: AuditReport) -> None:
-        """Print the top-N highest-severity findings with remediation guidance."""
-        from rich.panel import Panel
-
-        issues = [
-            r for r in report.results
-            if r.status in (Status.FAIL, Status.WARN) and r.remediation
-        ]
-        issues.sort(key=lambda r: (
-            _SEV_ORDER.get(r.severity, 5),
-            0 if r.status == Status.FAIL else 1,
-        ))
-        top = issues[:_TOP_ISSUES_COUNT]
-
-        if not top:
+    def _print_top_findings(
+        self, console, report: AuditReport, status: Status
+    ) -> None:
+        """Print a prioritised FAIL or WARN block (severity-sorted, capped)."""
+        g = _glyphs(console)
+        rows = sorted(
+            (r for r in report.results if r.status == status),
+            key=lambda r: _SEV_ORDER.get(r.severity, 5),
+        )[:_TOP_N]
+        if not rows:
             return
 
-        lines: list[str] = []
-        for i, result in enumerate(top, 1):
-            sc  = _STATUS_COLOR[result.status]
-            svc = _SEVERITY_COLOR.get(result.severity, "white")
-
-            lines.append(
-                f"  [bold]{i}.[/bold]  "
-                f"[{sc}]{result.status.value}[/{sc}]"
-                f" / [{svc}]{result.severity.value}[/{svc}]"
-                f"   [bold]{result.check_name}[/bold]"
+        if status == Status.FAIL:
+            head_glyph, head_text, accent, row_glyph = (
+                g["flag"], "TOP FAILURES", _RED, g["fail"]
             )
-            for rline in textwrap.wrap(result.remediation, _REM_WRAP_WIDTH):
-                lines.append(f"       [italic dim]{rline}[/italic dim]")
+        else:
+            head_glyph, head_text, accent, row_glyph = (
+                g["warn"], "TOP WARNINGS", _AMBER, g["warn"]
+            )
 
-            if i < len(top):
-                lines.append("")
+        prefix = f"{head_glyph} " if head_glyph else ""
+        console.print(_text("  ", (f"{prefix}{head_text}", f"bold {accent}")))
 
-        flag = _u(console, "⚑  ", "")
-        console.print(Panel(
-            "\n".join(lines),
-            title=f"[bold red]{flag}Top Issues[/bold red]",
-            border_style="red",
-            padding=(1, 1),
-        ))
+        for r in rows:
+            sev  = _SEVERITY_ABBR.get(r.severity, "?").ljust(_SEV_WIDTH)
+            desc = _truncate(r.check_name, _DESC_WIDTH).ljust(_DESC_WIDTH)
+            line = _text(
+                "  ",
+                (row_glyph + " ", accent),
+                (sev + " ", _SEVERITY_HEX.get(r.severity, _TEXT)),
+                (desc, _TEXT),
+            )
+            if r.cis_reference:
+                line.append(" " + r.cis_reference, style=_FAINT)
+            console.print(line)
         console.print()
+
+    def _print_category_detail(self, console, report: AuditReport) -> None:
+        """Verbose view: every check, grouped by category, in the rail language."""
+        g = _glyphs(console)
+        glyph_for = {
+            Status.PASS:  g["pass"],  Status.FAIL: g["fail"], Status.WARN: g["warn"],
+            Status.INFO:  g["info"],  Status.ERROR: g["error"],
+        }
+        cat_scores = calculate_category_scores(report.results)
+
+        for category in sorted({r.category for r in report.results}):
+            results   = [r for r in report.results if r.category == category]
+            cat_score = cat_scores.get(category, 100)
+            letter, _ = score_grade(cat_score)
+            gc        = _grade_hex(cat_score)
+
+            badge = f"{cat_score}/100  {letter}"
+            pad   = max(2, _PANEL_WIDTH - len(category) - len(badge))
+            self._rail(console, _text(
+                (category, f"bold {_GREEN}"),
+                (" " * pad, None),
+                (badge, gc),
+            ))
+
+            for r in results:
+                sc = _STATUS_HEX[r.status]
+                # CRITICAL failures get the critical-pink glyph.
+                glyph_color = (
+                    _CRIT if (r.status == Status.FAIL
+                              and r.severity == Severity.CRITICAL)
+                    else sc
+                )
+                line = _text(
+                    "  ",
+                    (glyph_for[r.status] + " ", glyph_color),
+                    (r.check_name, sc),
+                )
+                if r.cis_reference:
+                    line.append("  " + r.cis_reference, style=_FAINT)
+                console.print(line)
+
+                sev_c = _SEVERITY_HEX.get(r.severity, _TEXT)
+                console.print(_text(
+                    "       ", ("severity  ", _MUTED), (r.severity.value, sev_c),
+                ))
+                if r.details:
+                    for i, ln in enumerate(textwrap.wrap(r.details, _REM_WRAP_WIDTH)):
+                        label = "details   " if i == 0 else "          "
+                        console.print(_text("       ", (label, _MUTED), (ln, _TEXT)))
+                if r.remediation:
+                    for i, ln in enumerate(textwrap.wrap(r.remediation, _REM_WRAP_WIDTH)):
+                        label = "fix       " if i == 0 else "          "
+                        console.print(_text("       ", (label, _MUTED), (ln, _TEXT)))
+                console.print()
+            console.print()
 
     def _print_footer(
         self,
@@ -691,40 +729,47 @@ class Reporter:
         html_path: str | None,
         json_path: str | None,
     ) -> None:
-        """Print the scan summary footer."""
-        if _console_is_unicode(console):
-            from rich.rule import Rule
-            console.print(Rule(style="dim"))
-        else:
-            console.print("[dim]" + "-" * 79 + "[/dim]")
-        console.print(
-            f"  [dim]Scan completed in[/dim] [bold]{report.scan_duration:.1f}s[/bold]"
-        )
+        """Print the single-arrow summary footer (plus any caveats, muted)."""
+        g = _glyphs(console)
+        issues = report.fail_count + report.warn_count
+        plural = "s" if issues != 1 else ""
+
         if html_path:
-            console.print(
-                f"  [dim]HTML report saved to:[/dim] [bold cyan]{html_path}[/bold cyan]"
-            )
+            tail = (f" {g['sep']} open to triage all {issues} issue{plural}"
+                    if issues else f" {g['sep']} clean — no issues to triage")
+            console.print(_text(
+                "  ",
+                (f"{g['arrow']} {html_path} written", _GREEN),
+                (tail, _MUTED),
+            ))
+        elif issues:
+            console.print(_text(
+                "  ",
+                (f"{g['arrow']} {issues} issue{plural} to triage", _AMBER),
+                (f" {g['sep']} run with --html report.html for the full report", _MUTED),
+            ))
+        else:
+            console.print(_text("  ", (f"{g['arrow']} clean — no issues found", _GREEN)))
+
         if json_path:
-            console.print(
-                f"  [dim]JSON report saved to:[/dim] [bold cyan]{json_path}[/bold cyan]"
-            )
-        error_count = report.error_count
-        if error_count:
-            console.print(
-                f"  [yellow]![/yellow]  [yellow bold]{error_count} check(s) could not "
-                f"complete.[/yellow bold]  "
-                "[dim]Run as Administrator for full results.[/dim]"
-            )
+            console.print(_text("  ", (f"{g['sep']} {json_path} written", _MUTED)))
+        if report.error_count:
+            n = report.error_count
+            console.print(_text(
+                "  ",
+                (f"{n} check{'s' if n != 1 else ''} could not complete", _AMBER),
+                (" — run as Administrator for full results", _MUTED),
+            ))
         if not report.is_admin:
-            console.print(
-                "  [dim]Note:[/dim] Some checks were skipped — "
-                "[bold]run as Administrator[/bold] for complete results."
-            )
+            console.print(_text(
+                "  ",
+                ("note: some checks skipped — run as Administrator for complete results",
+                 _MUTED),
+            ))
         if not self.verbose:
-            console.print(
-                "  [dim]Tip:[/dim] Run with [bold]--verbose[/bold] "
-                "for full details and remediation steps"
-            )
+            console.print(_text(
+                "  ", ("run with --verbose for per-check detail", _MUTED),
+            ))
         console.print()
 
     # ── Plain-text fallback ───────────────────────────────────────────────────

--- a/src/apotrope/reporter.py
+++ b/src/apotrope/reporter.py
@@ -125,8 +125,24 @@ _HTML_SEVERITY: dict[Severity, str] = {
     Severity.INFO:     _MUTED,
 }
 
-# CIS Benchmark edition the cis_map IDs are verified against (see cis_map.py).
-_CIS_VERSION = "v5.0.0"
+def _cis_version_for(report: AuditReport) -> str:
+    """CIS Benchmark edition to display for *report*.
+
+    Prefers the value the scanner stamped on the report (authoritative — it's
+    derived from the same Win10/Win11 detection used to pick the CIS IDs). Falls
+    back to parsing the build number out of os_version for reports constructed
+    directly (API/tests) without a cis_version.
+    """
+    import re
+
+    from apotrope import cis_map
+
+    if report.cis_version:
+        return report.cis_version
+    m = re.search(r"(\d{3,})\s*$", (report.os_version or "").strip())
+    build = int(m.group(1)) if m else 0
+    # Match scanner.run's test, but treat an unparseable build as current (Win11).
+    return cis_map.benchmark_version(is_win10=bool(build) and build < 22000)
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -572,7 +588,7 @@ class Reporter:
             "category_bars":      category_bars,
             "n_cats":             len(category_data),
             "top_issues":         top_issues,
-            "cis_version":        _CIS_VERSION,
+            "cis_version":        _cis_version_for(report),
         }
 
     def _build_executive_summary(self, report: AuditReport) -> str:

--- a/src/apotrope/scanner.py
+++ b/src/apotrope/scanner.py
@@ -105,6 +105,9 @@ class Scanner:
         is_win10 = build < 22000
         self._apply_cis_references(results, is_win10=is_win10)
 
+        from apotrope import cis_map
+        cis_version = cis_map.benchmark_version(is_win10=is_win10)
+
         # Apply profile transforms (disabled checks, severity overrides)
         if self.profile:
             results = self._apply_profile(results)
@@ -127,6 +130,7 @@ class Scanner:
             results=results,
             score=score,
             is_admin=self.is_admin,
+            cis_version=cis_version,
         )
         log.info(
             "Scan complete: %d results, score=%d, duration=%.2fs",

--- a/src/apotrope/templates/report.html.j2
+++ b/src/apotrope/templates/report.html.j2
@@ -1,599 +1,625 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Apotrope Security Audit &mdash; {{ report.hostname }}</title>
-  <style>
-    /* ── Reset ─────────────────────────────────────────────────── */
-    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Apotrope — Security Posture Report · {{ hostname }}</title>
+<style>{% raw %}
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
-    /* ── Base ──────────────────────────────────────────────────── */
-    body {
-      /* Segoe UI leads: this is a Windows tool, viewed by Windows users.
-         Segoe UI is the native Windows UI font — professional, readable at density. */
-      font-family: "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto,
-                   "Helvetica Neue", Arial, sans-serif;
-      background: #f1f5f9;
-      color: #1e293b;
-      font-size: 14px;
-      line-height: 1.6;
-      -webkit-print-color-adjust: exact;
-      print-color-adjust: exact;
-    }
+  :root {
+    /* near-black, faint blue-green */
+    --void:      #03060a;
+    --bg:        #05090c;
+    --panel:     #080d11;
+    --panel-2:   #0b1218;
+    --line:      rgba(0, 255, 102, 0.10);
+    --line-soft: rgba(120, 200, 170, 0.07);
 
-    /* ── Page wrapper ──────────────────────────────────────────── */
-    .page {
-      max-width: 1100px;
-      margin: 1.5rem auto;
-      background: #ffffff;
-      border-radius: 6px;
-      box-shadow: 0 2px 12px rgba(0,0,0,.10);
-      overflow: hidden;
-    }
+    /* status / semantic */
+    --green:  #2bff88;   /* PASS / good     */
+    --cyan:   #44e0e6;   /* INFO            */
+    --amber:  #ffb23d;   /* WARN / fair     */
+    --red:    #ff5147;   /* FAIL            */
+    --crit:   #ff2d6b;   /* CRITICAL        */
+    --orange: #ff7a18;   /* decorative glow */
 
-    /* ── Report header ─────────────────────────────────────────── */
-    .report-header {
-      background: linear-gradient(135deg, #1e3a5f 0%, #1d4ed8 100%);
-      color: #ffffff;
-      padding: 2rem 2.5rem;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      gap: 2rem;
-    }
-    .header-brand {
-      font-size: .8rem;
-      font-weight: 700;
-      letter-spacing: .12em;
-      text-transform: uppercase;
-      opacity: .75;
-      margin-bottom: .35rem;
-    }
-    .header-title {
-      font-size: 1.55rem;
-      font-weight: 700;
-      margin-bottom: .75rem;
-    }
-    .header-meta {
-      display: flex;
-      flex-wrap: wrap;
-      gap: .5rem 1.5rem;
-      font-size: .8rem;
-      opacity: .85;
-    }
-    .header-meta span::before { margin-right: .3em; }
+    --text:   #c4d6cd;
+    --bright: #e8fff2;
+    --muted:  #5d776c;
+    --faint:  #2f4138;
 
-    /* ── Score gauge (CSS conic-gradient) ──────────────────────── */
-    .gauge-wrap { text-align: center; flex-shrink: 0; }
-    .gauge {
-      width: 160px;
-      height: 160px;
-      border-radius: 50%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      margin: 0 auto .4rem;
-      position: relative;
-    }
-    /* Grade colour sets --gauge-color via class */
-    .gauge-A { background: conic-gradient(#059669 {{ report.score | int }}%, #e2f8ef {{ report.score | int }}%); }
-    .gauge-B { background: conic-gradient(#16a34a {{ report.score | int }}%, #e2f5e6 {{ report.score | int }}%); }
-    .gauge-C { background: conic-gradient(#ca8a04 {{ report.score | int }}%, #fef9e7 {{ report.score | int }}%); }
-    .gauge-D { background: conic-gradient(#ea580c {{ report.score | int }}%, #fff4ec {{ report.score | int }}%); }
-    .gauge-F { background: conic-gradient(#dc2626 {{ report.score | int }}%, #fff0f0 {{ report.score | int }}%); }
-    .gauge-inner {
-      width: 126px;
-      height: 126px;
-      border-radius: 50%;
-      background: #fff;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      line-height: 1;
-    }
-    .gauge-num  { font-size: 2.2rem; font-weight: 800; color: #1e293b; }
-    .gauge-denom { font-size: .75rem; color: #64748b; }
-    .gauge-letter { font-size: 1.2rem; font-weight: 700; margin-top: .15rem; }
-    .gauge-A .gauge-letter { color: #059669; }
-    .gauge-B .gauge-letter { color: #16a34a; }
-    .gauge-C .gauge-letter { color: #ca8a04; }
-    .gauge-D .gauge-letter { color: #ea580c; }
-    .gauge-F .gauge-letter { color: #dc2626; }
-    .gauge-label {
-      font-size: .8rem;
-      font-weight: 600;
-      color: rgba(255,255,255,.85);
-      letter-spacing: .04em;
-    }
+    /* accent (tweakable) — defaults to terminal green */
+    --accent: #2bff88;
+    --accent-dim: rgba(43, 255, 136, 0.14);
 
-    /* ── Stats bar ─────────────────────────────────────────────── */
-    .stats-bar {
-      display: flex;
-      border-bottom: 1px solid #e2e8f0;
-    }
-    .stat-box {
-      flex: 1;
-      padding: .9rem 1rem;
-      text-align: center;
-      border-right: 1px solid #e2e8f0;
-    }
-    .stat-box:last-child { border-right: none; }
-    .stat-num { font-size: 1.6rem; font-weight: 800; line-height: 1; }
-    .stat-lbl { font-size: .7rem; text-transform: uppercase; letter-spacing: .08em; color: #64748b; margin-top: .15rem; }
-    .stat-total .stat-num { color: #1d4ed8; }
-    .stat-pass  .stat-num { color: #059669; }
-    .stat-fail  .stat-num { color: #dc2626; }
-    .stat-warn  .stat-num { color: #d97706; }
-    .stat-error .stat-num { color: #7c3aed; }
+    /* offline font stacks — no Google Fonts, no embedding required */
+    --mono: "IBM Plex Mono","Cascadia Code","Consolas",ui-monospace,monospace;
+    --sans: "IBM Plex Sans",system-ui,-apple-system,"Segoe UI",sans-serif;
 
-    /* ── Section ───────────────────────────────────────────────── */
-    section { padding: 1.75rem 2.5rem; border-bottom: 1px solid #e2e8f0; }
-    section:last-of-type { border-bottom: none; }
-    .section-title {
-      font-size: .7rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: .1em;
-      color: #64748b;
-      margin-bottom: 1rem;
-      padding-bottom: .5rem;
-      border-bottom: 1px solid #e2e8f0;
-    }
+    --r: 3px;
+    --gap: 22px;
+    --pad: 22px;
+    --maxw: 1180px;
 
-    /* ── Executive summary ─────────────────────────────────────── */
-    .exec-summary { color: #374151; max-width: 80ch; margin-bottom: 1.25rem; }
+    --glitch: 1;       /* 0..1 scanline/glow intensity */
+    --row-pad: 13px;   /* density */
+    --fs: 15px;
+  }
 
-    /* ── Callout ───────────────────────────────────────────────── */
-    .callout {
-      border-radius: 5px;
-      padding: 1rem 1.25rem;
-      margin-bottom: .75rem;
-    }
-    .callout-alert {
-      background: #fef2f2;
-      border: 1px solid #fca5a5;
-      border-left: 4px solid #dc2626;
-    }
-    .callout-title {
-      font-size: .8rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: .06em;
-      color: #991b1b;
-      margin-bottom: .6rem;
-    }
-    .callout ul { list-style: none; display: flex; flex-direction: column; gap: .4rem; }
-    .callout li { display: flex; align-items: flex-start; gap: .5rem; flex-wrap: wrap; font-size: .85rem; color: #374151; }
-    .callout li .rem-text { color: #6b7280; margin-left: .25rem; }
+  html { scroll-behavior: smooth; }
 
-    /* ── Badges ────────────────────────────────────────────────── */
-    .badge {
-      display: inline-block;
-      padding: .12rem .45rem;
-      border-radius: 3px;
-      font-size: .7rem;
-      font-weight: 700;
-      white-space: nowrap;
-      vertical-align: middle;
-    }
-    .badge-PASS  { background: #dcfce7; color: #15803d; }
-    .badge-FAIL  { background: #fee2e2; color: #b91c1c; }
-    .badge-WARN  { background: #fef3c7; color: #b45309; }
-    .badge-INFO  { background: #dbeafe; color: #1d4ed8; }
-    .badge-ERROR { background: #f3e8ff; color: #6d28d9; }
+  body {
+    background:
+      radial-gradient(1200px 700px at 78% -8%, rgba(255, 122, 24, 0.07), transparent 60%),
+      radial-gradient(900px 600px at -5% 4%, rgba(43, 255, 136, 0.05), transparent 55%),
+      var(--bg);
+    color: var(--text);
+    font-family: var(--mono);
+    font-size: var(--fs);
+    line-height: 1.55;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+  }
 
-    .sev {
-      display: inline-block;
-      padding: .1rem .4rem;
-      border-radius: 3px;
-      font-size: .7rem;
-      font-weight: 600;
-      white-space: nowrap;
-      vertical-align: middle;
-    }
-    .sev-CRITICAL { background: #fef2f2; color: #991b1b; border: 1px solid #fca5a5; }
-    .sev-HIGH     { background: #fff7ed; color: #9a3412; border: 1px solid #fdba74; }
-    .sev-MEDIUM   { background: #fefce8; color: #854d0e; border: 1px solid #fde047; }
-    .sev-LOW      { background: #eff6ff; color: #1e40af; border: 1px solid #93c5fd; }
-    .sev-INFO     { background: #f8fafc; color: #475569; border: 1px solid #cbd5e1; }
+  /* ── CRT / scanline overlay ────────────────────────────────────────────── */
+  .crt-overlay {
+    pointer-events: none;
+    position: fixed; inset: 0; z-index: 9000;
+    background: repeating-linear-gradient(
+      to bottom,
+      rgba(0,0,0,0) 0px,
+      rgba(0,0,0,0) 2px,
+      rgba(0, 30, 18, calc(0.16 * var(--glitch))) 3px,
+      rgba(0, 30, 18, calc(0.16 * var(--glitch))) 3px
+    );
+    mix-blend-mode: multiply;
+    opacity: var(--glitch);
+  }
+  .crt-vignette {
+    pointer-events: none;
+    position: fixed; inset: 0; z-index: 9001;
+    box-shadow: inset 0 0 240px 40px rgba(0,0,0,0.9);
+    opacity: calc(0.7 * var(--glitch));
+  }
+  .crt-flicker {
+    pointer-events: none;
+    position: fixed; inset: 0; z-index: 8999;
+    background: rgba(43,255,136,0.012);
+    animation: flicker 7s infinite steps(60);
+    opacity: var(--glitch);
+  }
+  @keyframes flicker {
+    0%,100%{opacity:calc(0.5*var(--glitch));} 3%{opacity:calc(0.2*var(--glitch));}
+    6%{opacity:calc(0.6*var(--glitch));} 9%{opacity:calc(0.3*var(--glitch));}
+    50%{opacity:calc(0.55*var(--glitch));} 53%{opacity:calc(0.25*var(--glitch));}
+  }
+  @media (prefers-reduced-motion: reduce) { .crt-flicker { animation: none; } }
 
-    /* ── Category section ──────────────────────────────────────── */
-    .cat-block { margin-bottom: 1.5rem; border: 1px solid #e2e8f0; border-radius: 6px; overflow: hidden; }
-    .cat-block:last-child { margin-bottom: 0; }
-    .cat-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: .65rem 1rem;
-      background: #f8fafc;
-      border-bottom: 1px solid #e2e8f0;
-      cursor: pointer;
-      user-select: none;
-      list-style: none;
-    }
-    .cat-header::-webkit-details-marker { display: none; }
-    .cat-name { font-weight: 600; font-size: .9rem; color: #1e293b; }
-    .cat-meta { display: flex; align-items: center; gap: .75rem; font-size: .8rem; color: #64748b; }
-    .cat-score { font-weight: 700; }
-    .cat-score-A { color: #059669; }
-    .cat-score-B { color: #16a34a; }
-    .cat-score-C { color: #ca8a04; }
-    .cat-score-D { color: #ea580c; }
-    .cat-score-F { color: #dc2626; }
-    .cat-chevron { font-size: .65rem; color: #94a3b8; }
-    details.cat-block[open] .cat-chevron::after { content: "▲"; }
-    details.cat-block:not([open]) .cat-chevron::after { content: "▼"; }
+  /* faint binary rain behind everything */
+  .bin-rain {
+    pointer-events: none;
+    position: fixed; inset: 0; z-index: 0;
+    overflow: hidden;
+    opacity: calc(0.5 * var(--glitch));
+  }
 
-    /* ── Category table ────────────────────────────────────────── */
-    .cat-table { width: 100%; border-collapse: collapse; }
-    .cat-table thead th {
-      background: #f8fafc;
-      font-size: .7rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: .06em;
-      color: #64748b;
-      padding: .55rem .75rem;
-      text-align: left;
-      border-bottom: 1px solid #e2e8f0;
-    }
-    .cat-table tbody td {
-      padding: .6rem .75rem;
-      border-bottom: 1px solid #f1f5f9;
-      vertical-align: top;
-      font-size: .85rem;
-    }
-    .cat-table tbody tr:last-child td { border-bottom: none; }
-    .row-FAIL { background: #fff8f8; }
-    .row-WARN { background: #fffdf0; }
-    .row-INFO { background: #f8fbff; }
-    .row-ERROR { background: #fdf8ff; }
+  /* ── Layout ─────────────────────────────────────────────────────────────── */
+  .wrap { position: relative; z-index: 1; max-width: var(--maxw); margin: 0 auto; padding: 0 24px 120px; }
 
-    .check-name { font-weight: 500; }
-    .check-desc { font-size: .78rem; color: #64748b; margin-top: .15rem; }
-    .details-text { font-size: .8rem; color: #374151; white-space: pre-wrap; word-break: break-word; }
+  ::selection { background: var(--accent); color: #00120a; }
 
-    details.row-detail summary {
-      list-style: none;
-      cursor: pointer;
-      font-size: .78rem;
-      color: #2563eb;
-    }
-    details.row-detail summary::-webkit-details-marker { display: none; }
-    details.row-detail[open] .rem-block { margin-top: .4rem; }
-    .rem-block {
-      font-size: .78rem;
-      color: #374151;
-      background: #f8fafc;
-      border-left: 3px solid #93c5fd;
-      padding: .4rem .6rem;
-      margin-top: .4rem;
-      border-radius: 0 3px 3px 0;
-    }
+  a { color: var(--accent); text-decoration: none; }
 
-    /* ── Detailed findings cards ───────────────────────────────── */
-    .finding {
-      border: 1px solid #e2e8f0;
-      border-radius: 6px;
-      margin-bottom: 1rem;
-      overflow: hidden;
-    }
-    .finding:last-child { margin-bottom: 0; }
-    .finding-FAIL { border-color: #fca5a5; }
-    .finding-WARN { border-color: #fde68a; }
+  /* ── Scrollbar ──────────────────────────────────────────────────────────── */
+  ::-webkit-scrollbar { width: 11px; height: 11px; }
+  ::-webkit-scrollbar-track { background: var(--void); }
+  ::-webkit-scrollbar-thumb { background: #16241d; border: 2px solid var(--void); border-radius: 6px; }
+  ::-webkit-scrollbar-thumb:hover { background: #1d3329; }
 
-    .finding-header {
-      display: flex;
-      align-items: center;
-      flex-wrap: wrap;
-      gap: .5rem;
-      padding: .7rem 1rem;
-      background: #f8fafc;
-      border-bottom: 1px solid #e2e8f0;
-    }
-    .finding-FAIL .finding-header { background: #fff5f5; border-bottom-color: #fecaca; }
-    .finding-WARN .finding-header { background: #fffbeb; border-bottom-color: #fde68a; }
-    .finding-title { font-weight: 600; font-size: .9rem; color: #1e293b; margin-left: .25rem; flex: 1; }
-    .finding-cat   { font-size: .75rem; color: #94a3b8; margin-left: auto; }
-    .cis-badge { display: inline-block; font-size: .65rem; font-weight: 700; letter-spacing: .04em;
-                 background: #eff6ff; color: #1d4ed8; border: 1px solid #bfdbfe;
-                 border-radius: 3px; padding: .1rem .35rem; margin-left: .4rem; vertical-align: middle; }
+  /* ── Panel primitive ────────────────────────────────────────────────────── */
+  .panel {
+    background:
+      linear-gradient(180deg, rgba(43,255,136,0.018), transparent 120px),
+      var(--panel);
+    border: 1px solid var(--line);
+    border-radius: var(--r);
+    position: relative;
+  }
+  .panel::before {
+    /* corner ticks */
+    content: "";
+    position: absolute; top: -1px; left: -1px;
+    width: 12px; height: 12px;
+    border-top: 1px solid var(--accent); border-left: 1px solid var(--accent);
+    opacity: 0.55;
+  }
+  .panel::after {
+    content: "";
+    position: absolute; bottom: -1px; right: -1px;
+    width: 12px; height: 12px;
+    border-bottom: 1px solid var(--accent); border-right: 1px solid var(--accent);
+    opacity: 0.55;
+  }
 
-    .finding-body { padding: 1rem; display: grid; grid-template-columns: 1fr 1fr; gap: .75rem 1.5rem; }
-    .finding-field dt { font-size: .7rem; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; color: #64748b; margin-bottom: .25rem; }
-    .finding-field dd { font-size: .85rem; color: #374151; white-space: pre-wrap; word-break: break-word; }
-    .finding-field.full-width { grid-column: 1 / -1; }
+  .mono { font-family: var(--mono); }
+  .sans { font-family: var(--sans); }
 
-    /* ── Appendix table ────────────────────────────────────────── */
-    .app-table { width: 100%; border-collapse: collapse; }
-    .app-table thead th {
-      background: #f8fafc;
-      font-size: .7rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: .06em;
-      color: #64748b;
-      padding: .5rem .75rem;
-      text-align: left;
-      border-bottom: 2px solid #e2e8f0;
-    }
-    .app-table tbody td {
-      padding: .5rem .75rem;
-      border-bottom: 1px solid #f1f5f9;
-      vertical-align: top;
-      font-size: .82rem;
-    }
-    .app-table tbody tr:last-child td { border-bottom: none; }
+  .label {
+    font-size: 10.5px; letter-spacing: 0.22em; text-transform: uppercase;
+    color: var(--muted); font-weight: 500;
+  }
+  .kicker {
+    font-size: 11px; letter-spacing: 0.3em; text-transform: uppercase;
+    color: var(--accent); font-weight: 600;
+  }
 
-    /* ── Footer ────────────────────────────────────────────────── */
-    .report-footer {
-      padding: 1rem 2.5rem;
-      background: #f8fafc;
-      border-top: 1px solid #e2e8f0;
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
-      gap: 2rem;
-      flex-wrap: wrap;
-    }
-    .footer-brand { font-size: .78rem; color: #475569; }
-    .footer-brand strong { color: #1e293b; }
-    .footer-disclaimer {
-      font-size: .72rem;
-      color: #94a3b8;
-      max-width: 60ch;
-      font-style: italic;
-    }
+  /* blinking cursor */
+  .cursor { display:inline-block; width:9px; height:1.05em; background: var(--accent);
+            vertical-align: -2px; margin-left: 3px; animation: blink 1.05s steps(2) infinite; }
+  @keyframes blink { 0%,50%{opacity:1;} 51%,100%{opacity:0;} }
 
-    /* ── Print ─────────────────────────────────────────────────── */
-    @media print {
-      @page { size: A4; margin: 15mm 12mm; }
-      body { background: white; font-size: 10pt; }
-      .page { box-shadow: none; border-radius: 0; margin: 0; max-width: 100%; }
-      .report-header { background: #1d4ed8 !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-      section { break-inside: avoid; }
-      .finding { break-inside: avoid; page-break-inside: avoid; }
-      .cat-block { break-inside: avoid; }
-      details.cat-block { display: block; }
-      details.cat-block summary { display: flex; }
-      details.row-detail { display: block; }
-      details.row-detail summary { display: none; }
-      details.row-detail .rem-block { display: block; }
-    }
+  /* focus rings */
+  button, input, select { font-family: inherit; color: inherit; }
+  button { cursor: pointer; background: none; border: none; }
+  input:focus-visible, button:focus-visible { outline: 1px solid var(--accent); outline-offset: 2px; }
 
-    @media (max-width: 700px) {
-      .report-header { flex-direction: column; }
-      .stats-bar { flex-wrap: wrap; }
-      .stat-box { min-width: 50%; }
-      .finding-body { grid-template-columns: 1fr; }
-    }
-  </style>
+  /* ── Header ─────────────────────────────────────────────────────────────── */
+  .topbar { display:flex; align-items:center; justify-content:space-between; gap:24px;
+            padding:20px 0 18px; border-bottom:1px solid var(--line); flex-wrap:wrap; }
+  .brand { display:flex; align-items:center; gap:13px; }
+  .brand .diamond { color:var(--accent); font-size:22px; filter:drop-shadow(0 0 7px var(--accent)); }
+  .brand .name { font-size:19px; font-weight:700; letter-spacing:0.42em; color:var(--bright);
+                 text-transform:uppercase; }
+  .brand .ver { font-size:10.5px; color:var(--muted); letter-spacing:0.12em; align-self:flex-end; padding-bottom:3px; }
+  .topbar-meta { display:flex; gap:26px; flex-wrap:wrap; align-items:center; }
+  .meta-item { display:flex; flex-direction:column; gap:2px; }
+  .meta-item .v { color:var(--text); font-size:13px; }
+  .meta-item .v b { color:var(--bright); font-weight:600; }
+  .ro-tag { display:inline-flex; align-items:center; gap:7px; font-size:10px; letter-spacing:0.18em;
+            text-transform:uppercase; color:var(--cyan); border:1px solid rgba(68,224,230,0.3);
+            background:rgba(68,224,230,0.06); padding:5px 10px; border-radius:2px; white-space:nowrap; }
+  .ro-tag .dot { width:6px; height:6px; border-radius:50%; background:var(--cyan); box-shadow:0 0 7px var(--cyan); }
+
+  /* hero grid */
+  .hero { display:grid; grid-template-columns: 320px 1fr; gap:var(--gap); margin-top:var(--gap); align-items:start; }
+  @media (max-width: 880px){ .hero { grid-template-columns: 1fr; } }
+
+  .gauge-panel { padding:26px 20px 22px; display:flex; flex-direction:column; align-items:center; gap:6px; }
+  .gauge-wrap { position:relative; width:230px; height:230px; }
+  .gauge-center { position:absolute; inset:0; display:flex; flex-direction:column; align-items:center; justify-content:center; }
+  .gauge-score { font-size:64px; font-weight:700; line-height:0.9; letter-spacing:-0.02em; }
+  .gauge-of { font-size:12px; color:var(--muted); letter-spacing:0.18em; margin-top:4px; }
+  .gauge-grade { margin-top:9px; display:flex; align-items:center; gap:8px; }
+  .grade-chip { font-size:15px; font-weight:700; padding:2px 10px; border-radius:2px; letter-spacing:0.05em; }
+  .grade-label { font-size:11px; letter-spacing:0.24em; text-transform:uppercase; color:var(--muted); }
+  .gauge-cat { font-size:10.5px; color:var(--faint); letter-spacing:0.2em; text-transform:uppercase; margin-top:6px; }
+
+  /* right column */
+  .hero-right { display:flex; flex-direction:column; gap:var(--gap); }
+  .summary-panel { padding:18px 20px 20px; flex:1; }
+  .summary-head { display:flex; align-items:center; justify-content:space-between; margin-bottom:12px; }
+  .summary-body { font-size:13.5px; line-height:1.72; color:var(--text); }
+  .summary-body .hl-crit { color:var(--crit); font-weight:600; }
+  .summary-body .hl-high { color:var(--red); font-weight:600; }
+  .summary-body .hl-ok { color:var(--green); font-weight:600; }
+
+  .stat-strip { display:grid; grid-template-columns: 1.1fr 1fr; gap:var(--gap); }
+  @media (max-width: 560px){ .stat-strip { grid-template-columns:1fr; } }
+  .donut-panel, .bars-panel { padding:16px 18px 18px; }
+  .panel-h { display:flex; align-items:center; justify-content:space-between; margin-bottom:12px; }
+
+  /* count pills */
+  .pills { display:flex; gap:8px; flex-wrap:wrap; }
+  .pill { display:inline-flex; align-items:center; gap:7px; font-size:12px; font-weight:500;
+          padding:5px 11px; border-radius:2px; border:1px solid transparent; letter-spacing:0.02em; }
+  .pill .n { font-weight:700; font-variant-numeric: tabular-nums; }
+  .pill-pass { color:var(--green); border-color:rgba(43,255,136,0.28); background:rgba(43,255,136,0.06); }
+  .pill-fail { color:var(--red);   border-color:rgba(255,81,71,0.3);  background:rgba(255,81,71,0.07); }
+  .pill-warn { color:var(--amber); border-color:rgba(255,178,61,0.3); background:rgba(255,178,61,0.06); }
+  .pill-info { color:var(--cyan);  border-color:rgba(68,224,230,0.28);background:rgba(68,224,230,0.05); }
+
+  /* donut */
+  .donut-row { display:flex; align-items:center; gap:18px; }
+  .donut-legend { display:flex; flex-direction:column; gap:7px; flex:1; }
+  .leg { display:flex; align-items:center; gap:9px; font-size:12px; }
+  .leg .sw { width:9px; height:9px; border-radius:1px; flex-shrink:0; }
+  .leg .lk { color:var(--muted); flex:1; letter-spacing:0.08em; }
+  .leg .lv { color:var(--bright); font-weight:600; font-variant-numeric:tabular-nums; }
+
+  /* category bars */
+  .cbar { display:grid; grid-template-columns: 116px 1fr 42px; align-items:center; gap:11px;
+          padding:6px 0; cursor:pointer; border:none; width:100%; text-align:left; }
+  .cbar:hover .cbar-name { color:var(--bright); }
+  .cbar:hover .cbar-track { box-shadow: inset 0 0 0 1px var(--line); }
+  .cbar-name { font-size:11.5px; color:var(--text); letter-spacing:0.04em; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .cbar-track { height:13px; background:#0a130d; border:1px solid rgba(43,255,136,0.12); border-radius:2px; overflow:hidden; position:relative; }
+  .cbar-fill { height:100%; border-radius:0; transition:width .6s cubic-bezier(.2,.7,.2,1); }
+  /* HP-bar segmentation: 20 cells, score maps to filled cells */
+  .cbar-track::after { content:""; position:absolute; inset:0; pointer-events:none; z-index:2;
+     background: repeating-linear-gradient(90deg, transparent 0 calc(5% - 2px), var(--panel) calc(5% - 2px) 5%); }
+  .cbar-val { font-size:11.5px; text-align:right; font-variant-numeric:tabular-nums; font-weight:600; }
+  .cbar.flagged .cbar-name::before { content:"› "; color:var(--accent); }
+
+  /* toolbar */
+  .toolbar { display:flex; align-items:center; gap:14px; flex-wrap:wrap; margin:var(--gap) 0 14px;
+             padding:13px 16px; }
+  .filters { display:flex; gap:7px; flex-wrap:wrap; }
+  .fchip { display:inline-flex; align-items:center; gap:8px; font-size:11.5px; letter-spacing:0.08em;
+           padding:6px 12px; border:1px solid var(--line); border-radius:2px; color:var(--muted);
+           text-transform:uppercase; transition:all .15s; }
+  .fchip:hover { color:var(--text); border-color:rgba(120,200,170,0.25); }
+  .fchip[data-on="true"] { color:var(--void); font-weight:700; }
+  .fchip .fn { font-variant-numeric:tabular-nums; font-weight:700; opacity:0.9; }
+  .fchip.f-all[data-on="true"]  { background:var(--accent); border-color:var(--accent); }
+  .fchip.f-fail[data-on="true"] { background:var(--red);   border-color:var(--red); }
+  .fchip.f-warn[data-on="true"] { background:var(--amber); border-color:var(--amber); }
+  .fchip.f-pass[data-on="true"] { background:var(--green); border-color:var(--green); }
+  .fchip.f-info[data-on="true"] { background:var(--cyan);  border-color:var(--cyan); }
+
+  .search { display:flex; align-items:center; gap:8px; border:1px solid var(--line); border-radius:2px;
+            padding:6px 11px; min-width:210px; flex:1; max-width:340px; }
+  .search:focus-within { border-color:var(--accent); }
+  .search input { background:none; border:none; outline:none; width:100%; font-size:13px; color:var(--bright); }
+  .search input::placeholder { color:var(--faint); }
+  .search .pr { color:var(--accent); font-size:13px; }
+  .tool-right { display:flex; align-items:center; gap:14px; margin-left:auto; }
+  .linkbtn { font-size:11px; letter-spacing:0.1em; text-transform:uppercase; color:var(--muted); border-bottom:1px dashed transparent; }
+  .linkbtn:hover { color:var(--accent); border-bottom-color:var(--accent); }
+  .showing { font-size:11px; color:var(--faint); letter-spacing:0.06em; white-space:nowrap; }
+
+  /* top issues */
+  .top-issues { margin:var(--gap) 0; padding:18px 20px 20px; border-color:rgba(255,81,71,0.22)!important; }
+  .top-issues::before, .top-issues::after { border-color:var(--red)!important; }
+  .ti-head { display:flex; align-items:center; gap:10px; margin-bottom:14px; }
+  .ti-flag { color:var(--red); font-size:14px; letter-spacing:0.2em; text-transform:uppercase; font-weight:700; }
+  .ti-list { display:flex; flex-direction:column; gap:10px; }
+  .ti-item { display:grid; grid-template-columns: 26px 1fr; gap:12px; padding:11px 13px;
+             background:rgba(255,81,71,0.035); border:1px solid rgba(255,81,71,0.14); border-radius:2px; }
+  .ti-num { font-size:13px; font-weight:700; color:var(--red); }
+  .ti-name { font-size:13.5px; color:var(--bright); font-weight:600; margin-bottom:3px; }
+  .ti-tags { display:flex; gap:8px; align-items:center; margin-bottom:6px; flex-wrap:wrap; }
+  .ti-fix { font-size:12px; color:var(--muted); line-height:1.6; }
+  .ti-fix b { color:var(--text); font-weight:500; }
+
+  /* category section */
+  .cat-section { margin-top:var(--gap); }
+  .cat-bar { display:flex; align-items:center; gap:14px; padding:11px 16px;
+             border:1px solid var(--line); border-top-left-radius:var(--r); border-top-right-radius:var(--r);
+             background:var(--panel-2); position:sticky; top:0; z-index:5; }
+  .cat-name { font-size:13.5px; font-weight:600; letter-spacing:0.08em; color:var(--bright); text-transform:uppercase; }
+  .cat-meta { display:flex; align-items:center; gap:10px; margin-left:auto; }
+  .cat-score { font-size:12px; font-weight:700; font-variant-numeric:tabular-nums; }
+  .cat-tally { display:flex; gap:9px; font-size:11px; }
+  .cat-tally span { font-variant-numeric:tabular-nums; }
+
+  /* finding rows */
+  .findings { border:1px solid var(--line); border-top:none;
+              border-bottom-left-radius:var(--r); border-bottom-right-radius:var(--r); overflow:hidden; }
+  .frow { border-top:1px solid var(--line-soft); }
+  .frow:first-child { border-top:none; }
+  .fhead { display:grid; grid-template-columns: 30px 86px 1fr auto; align-items:center; gap:13px;
+           padding:var(--row-pad) 16px; width:100%; text-align:left; transition:background .12s; }
+  .fhead:hover { background:rgba(43,255,136,0.025); }
+  .fhead.is-open { background:rgba(43,255,136,0.03); }
+  .ficon { font-size:14px; text-align:center; font-weight:700; }
+  .fsev { font-size:10px; letter-spacing:0.1em; font-weight:600; text-transform:uppercase;
+          padding:3px 7px; border-radius:2px; text-align:center; white-space:nowrap; }
+  .fname { font-size:13.5px; color:var(--text); }
+  .fname .fcat { color:var(--faint); font-size:11px; margin-right:8px; letter-spacing:0.06em; }
+  .fname .fsnip { color:var(--muted); font-size:12px; margin-top:2px; }
+  .fname b { color:var(--bright); font-weight:500; }
+  .fright { display:flex; align-items:center; gap:12px; }
+  .chev { color:var(--muted); font-size:11px; transition:transform .2s; }
+  .fhead.is-open .chev { transform:rotate(90deg); color:var(--accent); }
+
+  .fbody { padding:2px 16px 18px 59px; display:grid; gap:13px;
+           border-top:1px solid var(--line-soft); background:rgba(0,0,0,0.18); }
+  .fbody .fld { display:grid; grid-template-columns: 82px 1fr; gap:14px; align-items:start; }
+  .fbody .fld .k { font-size:10.5px; letter-spacing:0.14em; text-transform:uppercase; color:var(--faint); padding-top:2px; }
+  .fbody .fld .vv { font-size:13px; color:var(--text); line-height:1.65; }
+  .code { font-size:12.5px; background:#02060a; border:1px solid var(--line); border-left:2px solid var(--accent);
+          border-radius:2px; padding:11px 13px; color:var(--green); white-space:pre-wrap; word-break:break-word;
+          position:relative; }
+  .code .copy { position:absolute; top:7px; right:8px; font-size:9.5px; letter-spacing:0.1em; text-transform:uppercase;
+                color:var(--muted); border:1px solid var(--line); padding:3px 7px; border-radius:2px; background:var(--void); }
+  .code .copy:hover { color:var(--accent); border-color:var(--accent); }
+  .cis { display:inline-flex; align-items:center; gap:6px; font-size:11px; letter-spacing:0.06em;
+         color:var(--cyan); border:1px solid rgba(68,224,230,0.28); background:rgba(68,224,230,0.05);
+         padding:3px 9px; border-radius:2px; }
+
+  .empty { padding:46px 20px; text-align:center; color:var(--faint); font-size:13px; letter-spacing:0.08em; }
+
+  /* footer */
+  .foot { margin-top:46px; padding-top:22px; border-top:1px solid var(--line);
+          display:flex; justify-content:space-between; align-items:center; gap:20px; flex-wrap:wrap;
+          font-size:11.5px; color:var(--muted); letter-spacing:0.05em; }
+  .foot .auth { color:var(--faint); }
+  .foot a { color:var(--muted); border-bottom:1px dashed transparent; }
+  .foot a:hover { color:var(--accent); border-bottom-color:var(--accent); }
+
+  /* fade-in */
+  .rise { animation: rise .5s cubic-bezier(.2,.7,.2,1) both; }
+  @keyframes rise { from { transform: translateY(10px); } to { transform:none; } }
+  @media (prefers-reduced-motion: reduce){ .rise { animation:none; } }
+
+  /* ── Print: drop the CRT atmosphere, expand every finding, ink-friendly ─── */
+  @media print {
+    .crt-overlay, .crt-vignette, .crt-flicker, .bin-rain { display:none !important; }
+    html, body { background:#fff !important; color:#111 !important; }
+    .wrap { padding-bottom:0; }
+    .panel { background:#fff !important; border-color:#bbb !important; }
+    .panel::before, .panel::after { display:none; }
+    .toolbar, .tool-right, .search, .filters { display:none !important; }
+    .cat-bar { position:static; background:#f2f2f2 !important; }
+    .cat-name, .brand .name, .ti-name, .fname b, .meta-item .v b { color:#111 !important; }
+    .fbody[hidden] { display:grid !important; }   /* show all details on paper */
+    .code { background:#f6f6f6 !important; color:#111 !important; }
+  }
+{% endraw %}</style>
 </head>
 <body>
-<div class="page">
+  <div class="bin-rain" id="binRain"></div>
+  <div class="crt-flicker"></div>
 
-  {# ── HEADER ──────────────────────────────────────────────────── #}
-  <header class="report-header">
-    <div class="header-left">
-      <div class="header-brand">Apotrope Security Audit Report</div>
-      <div class="header-title">{{ report.hostname }}</div>
-      <div class="header-meta">
-        <span>OS: {{ report.os_version }}</span>
-        <span>Scanned: {{ generated_at }}</span>
-        <span>Duration: {{ "%.1f"|format(report.scan_duration) }}s</span>
+  <div class="wrap">
+
+    <!-- ── Header ──────────────────────────────────────────────────────── -->
+    <div class="topbar">
+      <div class="brand">
+        <span class="diamond">◈</span>
+        <span class="name">APOTROPE</span>
+        <span class="ver">v{{ version }}</span>
+      </div>
+      <div class="topbar-meta">
+        <div class="meta-item"><span class="label">Host</span><span class="v"><b>{{ hostname }}</b></span></div>
+        <div class="meta-item"><span class="label">System</span><span class="v">{{ os_version }}</span></div>
+        <div class="meta-item"><span class="label">Scan</span><span class="v">{{ scan_timestamp }} <span style="color:var(--faint)">· {{ scan_duration }}s</span></span></div>
+        <span class="ro-tag"><span class="dot"></span>Read-only audit</span>
       </div>
     </div>
-    <div class="gauge-wrap">
-      <div class="gauge gauge-{{ score_grade }}">
-        <div class="gauge-inner">
-          <span class="gauge-num">{{ report.score }}</span>
-          <span class="gauge-denom">/100</span>
-          <span class="gauge-letter">{{ score_grade }}</span>
+
+    <!-- ── Hero: score gauge + executive summary + stat strip ──────────── -->
+    <div class="hero">
+      <div class="gauge-panel panel rise">
+        <div class="kicker" style="align-self:flex-start">Security Score</div>
+        <div class="gauge-wrap">
+          <svg width="230" height="230" viewBox="0 0 230 230" style="position:absolute;inset:0">
+            <defs><filter id="gl"><feGaussianBlur stdDeviation="3.2" result="b"/>
+              <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter></defs>
+            {% for t in gauge_ticks %}<line x1="{{ t.x1 }}" y1="{{ t.y1 }}" x2="{{ t.x2 }}" y2="{{ t.y2 }}" stroke="{{ t.color }}" stroke-width="2" opacity="{{ t.opacity }}"/>{% endfor %}
+            <circle cx="115" cy="115" r="96" fill="none" stroke="#0c1610" stroke-width="9"/>
+            <circle cx="115" cy="115" r="96" fill="none" stroke="{{ band_color }}" stroke-width="9"
+              stroke-linecap="round" stroke-dasharray="603.2" stroke-dashoffset="{{ gauge_dashoffset }}"
+              transform="rotate(-90 115 115)" filter="url(#gl)"/>
+          </svg>
+          <div class="gauge-center">
+            <div class="gauge-score" style="color:{{ band_color }};text-shadow:0 0 22px {{ band_color }}">{{ score }}</div>
+            <div class="gauge-of">/ 100</div>
+            <div class="gauge-grade">
+              <span class="grade-chip" style="color:var(--void);background:{{ band_color }}">{{ grade_letter }}</span>
+              <span class="grade-label">{{ grade_label }}</span>
+            </div>
+          </div>
+        </div>
+        <div class="gauge-cat">{{ total_checks }} checks evaluated</div>
+      </div>
+
+      <div class="hero-right">
+        <div class="summary-panel panel rise">
+          <div class="summary-head">
+            <span class="kicker">Executive Summary</span>
+            <div class="pills">
+              <span class="pill pill-pass"><span class="n">{{ pass_count }}</span> passed</span>
+              <span class="pill pill-fail"><span class="n">{{ fail_count }}</span> failed</span>
+              <span class="pill pill-warn"><span class="n">{{ warn_count }}</span> warnings</span>
+              <span class="pill pill-info"><span class="n">{{ info_count }}</span> info</span>
+            </div>
+          </div>
+          <div class="summary-body">{{ exec_summary_html }}</div>
+        </div>
+
+        <div class="stat-strip">
+          <div class="donut-panel panel rise">
+            <div class="panel-h"><span class="label">Result Distribution</span><span class="label">{{ total_checks }}</span></div>
+            <div class="donut-row">
+              <svg width="128" height="128" viewBox="0 0 128 128">
+                <circle cx="64" cy="64" r="52" fill="none" stroke="#0c1610" stroke-width="13"/>
+                {% for d in donut %}<circle cx="64" cy="64" r="52" fill="none" stroke="{{ d.color }}" stroke-width="13"
+                  stroke-dasharray="{{ d.dash }} {{ d.gap }}" stroke-dashoffset="{{ d.offset }}"
+                  transform="rotate(-90 64 64)"/>{% endfor %}
+                <text x="64" y="60" text-anchor="middle" fill="var(--red)" font-size="22" font-weight="700">{{ donut_center }}</text>
+                <text x="64" y="77" text-anchor="middle" fill="var(--muted)" font-size="8.5" letter-spacing="1.4">FAILED</text>
+              </svg>
+              <div class="donut-legend">
+                <div class="leg"><span class="sw" style="background:var(--green)"></span><span class="lk">PASS</span><span class="lv">{{ pass_count }}</span></div>
+                <div class="leg"><span class="sw" style="background:var(--red)"></span><span class="lk">FAIL</span><span class="lv">{{ fail_count }}</span></div>
+                <div class="leg"><span class="sw" style="background:var(--amber)"></span><span class="lk">WARN</span><span class="lv">{{ warn_count }}</span></div>
+                <div class="leg"><span class="sw" style="background:var(--cyan)"></span><span class="lk">INFO</span><span class="lv">{{ info_count }}</span></div>
+              </div>
+            </div>
+          </div>
+
+          <div class="bars-panel panel rise">
+            <div class="panel-h"><span class="label">Category Scores</span><span class="label">{{ n_cats }} areas</span></div>
+            {% for c in category_bars %}
+            <button class="cbar{% if c.score < 80 %} flagged{% endif %}" onclick="apoJump('{{ c.slug }}')">
+              <span class="cbar-name">{{ c.name }}</span>
+              <span class="cbar-track"><span class="cbar-fill" style="width:{{ c.score }}%;background:{{ c.band }};box-shadow:0 0 8px {{ c.band }}"></span></span>
+              <span class="cbar-val" style="color:{{ c.band }}">{{ c.score }}</span>
+            </button>
+            {% endfor %}
+          </div>
         </div>
       </div>
-      <div class="gauge-label">{{ score_label }}</div>
     </div>
-  </header>
 
-  {# ── STATS BAR ────────────────────────────────────────────────── #}
-  <div class="stats-bar">
-    <div class="stat-box stat-total">
-      <div class="stat-num">{{ report.results | length }}</div>
-      <div class="stat-lbl">Total Checks</div>
-    </div>
-    <div class="stat-box stat-pass">
-      <div class="stat-num">{{ report.pass_count }}</div>
-      <div class="stat-lbl">Passed</div>
-    </div>
-    <div class="stat-box stat-fail">
-      <div class="stat-num">{{ report.fail_count }}</div>
-      <div class="stat-lbl">Failed</div>
-    </div>
-    <div class="stat-box stat-warn">
-      <div class="stat-num">{{ report.warn_count }}</div>
-      <div class="stat-lbl">Warnings</div>
-    </div>
-    {% if report.error_count %}
-    <div class="stat-box stat-error">
-      <div class="stat-num">{{ report.error_count }}</div>
-      <div class="stat-lbl">Errors</div>
-    </div>
-    {% endif %}
-  </div>
-
-  {# ── EXECUTIVE SUMMARY ────────────────────────────────────────── #}
-  <section>
-    <h2 class="section-title">Executive Summary</h2>
-    <p class="exec-summary">{{ executive_summary }}</p>
-
-    {% if top_findings %}
-    <div class="callout callout-alert">
-      <div class="callout-title">Critical &amp; High Priority Findings</div>
-      <ul>
-        {% for f in top_findings %}
-        <li>
-          <span class="badge badge-{{ f.status.value }}">{{ f.status.value }}</span>
-          <span class="sev sev-{{ f.severity.value }}">{{ f.severity.value }}</span>
-          <strong>{{ f.check_name }}</strong>
-          {% if f.remediation %}
-          <span class="rem-text">&mdash; {{ f.remediation }}</span>
-          {% endif %}
-        </li>
+    {% if top_issues %}
+    <!-- ── Top issues ──────────────────────────────────────────────────── -->
+    <div class="top-issues panel">
+      <div class="ti-head">
+        <span class="ti-flag">⚑ Top Issues</span>
+        <span class="label">Prioritized remediation · {{ top_issues|length }}</span>
+      </div>
+      <div class="ti-list">
+        {% for r in top_issues %}
+        <div class="ti-item">
+          <span class="ti-num">{{ r.num }}</span>
+          <div>
+            <div class="ti-tags">
+              <span class="fsev" style="color:{{ r.sev_color }};border:1px solid {{ r.sev_color }};background:transparent">{{ r.severity }}</span>
+              <span style="font-size:11px;color:{{ r.status_color }};letter-spacing:0.1em">{{ r.status }}</span>
+              <button class="linkbtn" onclick="apoJump('{{ r.category_slug }}')">{{ r.category }} ↗</button>
+            </div>
+            <div class="ti-name">{{ r.check_name }}</div>
+            <div class="ti-fix"><b>Fix:</b> {{ r.remediation }}</div>
+          </div>
+        </div>
         {% endfor %}
-      </ul>
+      </div>
     </div>
     {% endif %}
-  </section>
 
-  {# ── CATEGORY BREAKDOWN ───────────────────────────────────────── #}
-  <section>
-    <h2 class="section-title">Category Breakdown</h2>
+    <!-- ── Toolbar ─────────────────────────────────────────────────────── -->
+    <div class="toolbar panel">
+      <div class="filters">
+        <button class="fchip f-all"  data-on="true"  data-k="ALL">ALL <span class="fn">{{ total_checks }}</span></button>
+        <button class="fchip f-fail" data-on="false" data-k="FAIL">FAIL <span class="fn">{{ fail_count }}</span></button>
+        <button class="fchip f-warn" data-on="false" data-k="WARN">WARN <span class="fn">{{ warn_count }}</span></button>
+        <button class="fchip f-pass" data-on="false" data-k="PASS">PASS <span class="fn">{{ pass_count }}</span></button>
+        <button class="fchip f-info" data-on="false" data-k="INFO">INFO <span class="fn">{{ info_count }}</span></button>
+      </div>
+      <div class="search"><span class="pr">›</span><input id="apoSearch" placeholder="filter findings…" spellcheck="false"/></div>
+      <div class="tool-right">
+        <button class="linkbtn" id="apoExpand">expand all</button>
+        <button class="linkbtn" id="apoCollapse">collapse</button>
+        <span class="showing" id="apoShowing">{{ total_checks }} / {{ total_checks }} shown</span>
+      </div>
+    </div>
+
+    <!-- ── Category sections ───────────────────────────────────────────── -->
     {% for cat in category_data %}
-    <details class="cat-block"{% if cat.fail_count or cat.warn_count or cat.error_count %} open{% endif %}>
-      <summary class="cat-header">
+    <div class="cat-section" id="cat-{{ cat.slug }}">
+      <div class="cat-bar">
         <span class="cat-name">{{ cat.name }}</span>
         <span class="cat-meta">
-          {% if cat.fail_count %}<span class="badge badge-FAIL">{{ cat.fail_count }} failed</span>{% endif %}
-          {% if cat.warn_count %}<span class="badge badge-WARN">{{ cat.warn_count }} warn</span>{% endif %}
-          <span class="cat-score cat-score-{{ cat.grade }}">{{ cat.score }}/100 &nbsp;{{ cat.grade }}</span>
-          <span class="cat-chevron"></span>
+          <span class="cat-tally">
+            {% if cat.fail %}<span style="color:var(--red)">✗{{ cat.fail }}</span>{% endif %}
+            {% if cat.warn %}<span style="color:var(--amber)">!{{ cat.warn }}</span>{% endif %}
+            {% if cat.pass %}<span style="color:var(--green)">✓{{ cat.pass }}</span>{% endif %}
+            {% if cat.info %}<span style="color:var(--cyan)">i{{ cat.info }}</span>{% endif %}
+          </span>
+          <span class="cat-score" style="color:{{ cat.band }}">{{ cat.score }}/100 {{ cat.grade_letter }}</span>
         </span>
-      </summary>
-      <table class="cat-table">
-        <thead>
-          <tr>
-            <th style="width:6%">Status</th>
-            <th style="width:8%">Severity</th>
-            <th style="width:28%">Check</th>
-            <th>Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for r in cat.results %}
-          <tr class="row-{{ r.status.value }}">
-            <td><span class="badge badge-{{ r.status.value }}">{{ r.status.value }}</span></td>
-            <td><span class="sev sev-{{ r.severity.value }}">{{ r.severity.value }}</span></td>
-            <td>
-              <div class="check-name">{{ r.check_name }}</div>
-              <div class="check-desc">{{ r.description }}</div>
-            </td>
-            <td>
-              <div class="details-text">{{ r.details }}</div>
-              {% if r.remediation %}
-              <details class="row-detail">
-                <summary>&#9656; Remediation</summary>
-                <div class="rem-block">{{ r.remediation }}</div>
-              </details>
-              {% endif %}
-            </td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </details>
-    {% endfor %}
-  </section>
-
-  {# ── DETAILED FINDINGS ────────────────────────────────────────── #}
-  {% if fail_warn_results %}
-  <section>
-    <h2 class="section-title">Detailed Findings</h2>
-    {% for r in fail_warn_results %}
-    <div class="finding finding-{{ r.status.value }}">
-      <div class="finding-header">
-        <span class="badge badge-{{ r.status.value }}">{{ r.status.value }}</span>
-        <span class="sev sev-{{ r.severity.value }}">{{ r.severity.value }}</span>
-        <span class="finding-title">{{ r.check_name }}{% if r.cis_reference %}<span class="cis-badge" title="CIS Benchmark reference">{{ r.cis_reference }}</span>{% endif %}</span>
-        <span class="finding-cat">{{ r.category }}</span>
       </div>
-      <div class="finding-body">
-        <div class="finding-field">
-          <dt>Description</dt>
-          <dd>{{ r.description }}</dd>
+      <div class="findings">
+        {% for f in cat.findings %}
+        <div class="frow" data-status="{{ f.status }}" data-text="{{ f.check_name|lower }} {{ f.category|lower }} {{ f.details|lower }} {{ f.cis|lower }}">
+          <button class="fhead">
+            <span class="ficon" style="color:{{ f.status_color }}">{{ f.status_glyph }}</span>
+            <span class="fsev" style="color:{{ f.sev_color }};border:1px solid {{ f.sev_color }};background:transparent">{{ f.severity }}</span>
+            <span class="fname">
+              <b>{{ f.check_name }}</b>
+              {% if f.snippet %}<div class="fsnip">{{ f.snippet }}</div>{% endif %}
+            </span>
+            <span class="fright">
+              {% if f.cis %}<span class="cis">{{ f.cis }}</span>{% endif %}
+              <span class="chev">▶</span>
+            </span>
+          </button>
+          <div class="fbody" hidden>
+            <div class="fld"><span class="k">Checks</span><span class="vv">{{ f.description }}</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">{{ f.details }}</span></div>
+            {% if f.remediation %}
+            <div class="fld"><span class="k">Remediation</span>
+              <div class="code">{{ f.remediation }}<button class="copy">copy</button></div></div>
+            {% endif %}
+            {% if f.cis %}<div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">{{ f.cis }}</span></span></div>{% endif %}
+          </div>
         </div>
-        <div class="finding-field">
-          <dt>Finding</dt>
-          <dd>{{ r.details }}</dd>
-        </div>
-        {% if r.remediation %}
-        <div class="finding-field full-width">
-          <dt>Remediation</dt>
-          <dd>{{ r.remediation }}</dd>
-        </div>
-        {% endif %}
+        {% endfor %}
       </div>
     </div>
     {% endfor %}
-  </section>
-  {% endif %}
 
-  {# ── APPENDIX A — SYSTEM INVENTORY ───────────────────────────── #}
-  {% if info_results %}
-  <section>
-    <h2 class="section-title">Appendix A &mdash; System Inventory</h2>
-    <table class="app-table">
-      <thead>
-        <tr>
-          <th>Category</th>
-          <th>Item</th>
-          <th>Details</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for r in info_results | sort(attribute='category') %}
-        <tr>
-          <td>{{ r.category }}</td>
-          <td>{{ r.check_name }}</td>
-          <td style="white-space: pre-wrap; word-break: break-word;">{{ r.details }}</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </section>
-  {% endif %}
-
-  {# ── APPENDIX B — FULL CHECK LIST ─────────────────────────────── #}
-  <section>
-    <h2 class="section-title">Appendix B &mdash; Full Check List</h2>
-    <table class="app-table">
-      <thead>
-        <tr>
-          <th style="width:5%">Status</th>
-          <th style="width:8%">Severity</th>
-          <th style="width:16%">Category</th>
-          <th>Check Name</th>
-          <th style="width:10%">CIS Ref</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for r in report.results | sort(attribute='category') %}
-        <tr>
-          <td><span class="badge badge-{{ r.status.value }}">{{ r.status.value }}</span></td>
-          <td><span class="sev sev-{{ r.severity.value }}">{{ r.severity.value }}</span></td>
-          <td>{{ r.category }}</td>
-          <td>{{ r.check_name }}</td>
-          <td>{% if r.cis_reference %}<span class="cis-badge">{{ r.cis_reference }}</span>{% endif %}</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </section>
-
-  {# ── FOOTER ───────────────────────────────────────────────────── #}
-  <footer class="report-footer">
-    <div class="footer-brand">
-      Generated by <strong>Apotrope v{{ version }}</strong>
-      on {{ generated_at }}
+    <!-- ── Footer ──────────────────────────────────────────────────────── -->
+    <div class="foot">
+      <span class="auth">For authorized security assessment use only · <strong style="color:var(--green);font-weight:600;text-shadow:0 0 9px rgba(43,255,136,0.45)">No data left this machine</strong> · CIS Benchmark {{ cis_version }}</span>
+      <span>apotrope.sh · <a href="https://github.com/hexorcist404/apotrope">github.com/hexorcist404/apotrope</a> · MIT</span>
     </div>
-    <div class="footer-disclaimer">
-      This report is for informational purposes only. It does not constitute
-      a complete security assessment. Review all findings with a qualified
-      security professional before taking remediation actions.
-    </div>
-  </footer>
 
-</div>
+  </div>
+
+  <div class="crt-overlay"></div>
+  <div class="crt-vignette"></div>
+
+  <script>{% raw %}
+(function(){
+  var rows = [].slice.call(document.querySelectorAll('.frow'));
+  var chips = [].slice.call(document.querySelectorAll('.fchip'));
+  var search = document.getElementById('apoSearch');
+  var showing = document.getElementById('apoShowing');
+  var active = 'ALL';
+
+  function apply(){
+    var q = (search.value||'').trim().toLowerCase();
+    var shown = 0;
+    rows.forEach(function(row){
+      var okStatus = active === 'ALL' || row.dataset.status === active;
+      var okText = !q || (row.dataset.text||'').indexOf(q) > -1;
+      var vis = okStatus && okText;
+      row.style.display = vis ? '' : 'none';
+      if (vis) shown++;
+    });
+    document.querySelectorAll('.cat-section').forEach(function(sec){
+      var any = [].some.call(sec.querySelectorAll('.frow'), function(r){ return r.style.display !== 'none'; });
+      sec.style.display = any ? '' : 'none';
+    });
+    showing.textContent = shown + ' / ' + rows.length + ' shown';
+  }
+
+  chips.forEach(function(chip){
+    chip.addEventListener('click', function(){
+      active = chip.dataset.k;
+      chips.forEach(function(c){ c.dataset.on = String(c === chip); });
+      apply();
+    });
+  });
+  search.addEventListener('input', apply);
+
+  rows.forEach(function(row){
+    var head = row.querySelector('.fhead'), body = row.querySelector('.fbody');
+    head.addEventListener('click', function(e){
+      if (e.target.closest('.copy')) return;
+      var open = body.hasAttribute('hidden');
+      if (open){ body.removeAttribute('hidden'); head.classList.add('is-open'); }
+      else { body.setAttribute('hidden',''); head.classList.remove('is-open'); }
+    });
+  });
+  document.getElementById('apoExpand').addEventListener('click', function(){
+    rows.forEach(function(r){ if (r.style.display==='none') return;
+      r.querySelector('.fbody').removeAttribute('hidden'); r.querySelector('.fhead').classList.add('is-open'); });
+  });
+  document.getElementById('apoCollapse').addEventListener('click', function(){
+    rows.forEach(function(r){ r.querySelector('.fbody').setAttribute('hidden',''); r.querySelector('.fhead').classList.remove('is-open'); });
+  });
+
+  document.querySelectorAll('.code .copy').forEach(function(btn){
+    btn.addEventListener('click', function(e){
+      e.stopPropagation();
+      var code = btn.parentNode.textContent.replace(/copy$/, '').trim();
+      if (navigator.clipboard) navigator.clipboard.writeText(code);
+      var t = btn.textContent; btn.textContent = 'copied'; setTimeout(function(){ btn.textContent = t; }, 1300);
+    });
+  });
+
+  window.apoJump = function(slug){
+    var el = document.getElementById('cat-' + slug);
+    if (!el) return;
+    window.scrollTo({ top: el.getBoundingClientRect().top + window.scrollY - 12, behavior: 'smooth' });
+  };
+})();
+{% endraw %}</script>
 </body>
 </html>

--- a/tests/test_cis_version.py
+++ b/tests/test_cis_version.py
@@ -1,0 +1,135 @@
+"""Tests for CIS Benchmark edition auto-detection (Win10 v4.0.0 / Win11 v5.0.0).
+
+Covers the three layers:
+  - cis_map.benchmark_version  — the OS-family → edition mapping (source of truth)
+  - Scanner.run                — stamps the right edition from build detection
+  - Reporter HTML footer       — displays the edition the scan actually used
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch
+
+from apotrope import cis_map
+from apotrope.models import AuditReport, CheckResult, Severity, Status
+from apotrope.reporter import Reporter
+from apotrope.scanner import Scanner
+
+
+# ---------------------------------------------------------------------------
+# cis_map.benchmark_version — the mapping
+# ---------------------------------------------------------------------------
+
+class TestBenchmarkVersion:
+    def test_win11_is_v5(self):
+        assert cis_map.benchmark_version(is_win10=False) == "v5.0.0"
+
+    def test_win10_is_v4(self):
+        assert cis_map.benchmark_version(is_win10=True) == "v4.0.0"
+
+    def test_default_is_win11(self):
+        assert cis_map.benchmark_version() == "v5.0.0"
+
+    def test_constants_match(self):
+        assert cis_map.CIS_VERSION_WIN11 == "v5.0.0"
+        assert cis_map.CIS_VERSION_WIN10 == "v4.0.0"
+
+
+# ---------------------------------------------------------------------------
+# cis_map.lookup — per-check IDs still switch by OS family
+# ---------------------------------------------------------------------------
+
+class TestLookupOsAware:
+    def test_win11_uses_base_id(self):
+        # Win11 v5.0.0 base map ID for PowerShell script-block logging.
+        assert cis_map.lookup("PowerShell Script Block Logging") == "CIS 18.10.88.1"
+
+    def test_win10_substitutes_override(self):
+        # Win10 v4.0.0 renumbers section 88 → 87, so the ID must differ.
+        win10 = cis_map.lookup("PowerShell Script Block Logging", is_win10=True)
+        win11 = cis_map.lookup("PowerShell Script Block Logging", is_win10=False)
+        assert win10 == "CIS 18.10.87.1"
+        assert win10 != win11
+
+
+# ---------------------------------------------------------------------------
+# Scanner stamps cis_version from the same build detection it uses for IDs
+# ---------------------------------------------------------------------------
+
+def _fake_module() -> ModuleType:
+    mod = ModuleType("fake")
+    mod.CATEGORY = "Test"
+    mod.run = lambda: [CheckResult("Test", "x", Status.PASS, Severity.LOW, "d", "ok")]
+    return mod
+
+
+def _run_with_build(build_version: str) -> AuditReport:
+    scanner = Scanner()
+    with patch("apotrope.scanner.platform.version", return_value=build_version), \
+         patch.object(scanner, "_discover_modules", return_value=[_fake_module()]):
+        return scanner.run()
+
+
+class TestScannerStampsVersion:
+    def test_win11_build_stamps_v5(self):
+        report = _run_with_build("10.0.22631")  # Win11
+        assert report.cis_version == "v5.0.0"
+
+    def test_win10_build_stamps_v4(self):
+        report = _run_with_build("10.0.19045")  # Win10 22H2
+        assert report.cis_version == "v4.0.0"
+
+    def test_boundary_22000_is_win11(self):
+        report = _run_with_build("10.0.22000")  # first Win11 build
+        assert report.cis_version == "v5.0.0"
+
+
+# ---------------------------------------------------------------------------
+# Reporter HTML footer shows the detected edition
+# ---------------------------------------------------------------------------
+
+def _render(report: AuditReport) -> str:
+    with tempfile.NamedTemporaryFile(suffix=".html", delete=False) as f:
+        path = f.name
+    try:
+        Reporter().generate_html_report(report, path)
+        return Path(path).read_text(encoding="utf-8")
+    finally:
+        os.unlink(path)
+
+
+def _report(cis_version: str = "", os_version: str = "Windows 11 Pro 10.0.22631") -> AuditReport:
+    return AuditReport(
+        hostname="PC",
+        os_version=os_version,
+        scan_timestamp=datetime(2026, 6, 6, tzinfo=timezone.utc),
+        scan_duration=1.0,
+        results=[CheckResult("Firewall", "FW", Status.PASS, Severity.LOW, "d", "ok")],
+        score=100,
+        cis_version=cis_version,
+    )
+
+
+class TestReporterFooterVersion:
+    def test_uses_stamped_version_win10(self):
+        html = _render(_report(cis_version="v4.0.0"))
+        assert "CIS Benchmark v4.0.0" in html
+        assert "v5.0.0" not in html
+
+    def test_uses_stamped_version_win11(self):
+        html = _render(_report(cis_version="v5.0.0"))
+        assert "CIS Benchmark v5.0.0" in html
+
+    def test_fallback_parses_win10_build(self):
+        # No stamped version → infer from the build in os_version.
+        html = _render(_report(cis_version="", os_version="Windows 10 Pro 10.0.19045"))
+        assert "CIS Benchmark v4.0.0" in html
+
+    def test_fallback_parses_win11_build(self):
+        html = _render(_report(cis_version="", os_version="Windows 11 Pro 10.0.26100"))
+        assert "CIS Benchmark v5.0.0" in html

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -92,18 +92,28 @@ class TestGenerateHtmlReport:
         html = self._generate(_make_report())
         assert "1" in html   # 1 PASS, 1 FAIL, 1 WARN, 1 INFO
 
-    def test_category_breakdown_present(self):
+    def test_category_scores_present(self):
         html = self._generate(_make_report())
-        assert "Category Breakdown" in html
+        assert "Category Scores" in html
         assert "Firewall" in html
 
-    def test_detailed_findings_present(self):
+    def test_findings_rendered_server_side(self):
+        """Findings must be in the static HTML (readable with JS disabled)."""
         html = self._generate(_make_report())
-        assert "Detailed Findings" in html
+        assert 'class="findings"' in html
+        assert 'class="frow"' in html
+        # the FAIL finding's status is baked into a filterable data attribute
+        assert 'data-status="FAIL"' in html
 
-    def test_appendix_present(self):
+    def test_filter_toolbar_present(self):
         html = self._generate(_make_report())
-        assert "Appendix" in html
+        assert 'id="apoSearch"' in html
+        assert 'data-k="FAIL"' in html
+
+    def test_info_findings_rendered(self):
+        html = self._generate(_make_report())
+        assert 'data-status="INFO"' in html
+        assert "OS Version" in html  # the INFO check name
 
     def test_no_external_dependencies(self):
         html = self._generate(_make_report())
@@ -124,17 +134,10 @@ class TestGenerateHtmlReport:
         assert "Executive Summary" in html
         assert "TEST-PC" in html  # hostname in summary
 
-    def test_top_findings_callout_present_when_critical(self):
+    def test_top_issues_callout_present_when_critical(self):
         html = self._generate(_make_report())
-        assert "Critical" in html or "High Priority" in html
-
-    def test_info_appendix_present(self):
-        html = self._generate(_make_report())
-        assert "Appendix A" in html
-
-    def test_full_checklist_present(self):
-        html = self._generate(_make_report())
-        assert "Appendix B" in html
+        assert "Top Issues" in html
+        assert "CRITICAL" in html
 
     def test_html_special_chars_escaped(self):
         """Regression: autoescape=True must escape user-controlled fields.


### PR DESCRIPTION
Unifies the three surfaces — terminal output, the `--html` report, and the marketing site — into one CRT/terminal look (shared palette, `◈` brandmark, score rail, prioritised findings).

## What's in here

**1. Terminal output** (`753cce3`)
- Truecolor palette + green `▌` rail replacing Rich boxes; concise default view (banner → inline scan bar → score block → TOP FAILURES → TOP WARNINGS → footer). Full per-category detail moves to `--verbose`.
- ASCII + `NO_COLOR`/non-tty fallbacks handled via Rich.

**2. HTML report** (`c7015ad`)
- Single self-contained file: inline CSS + one inline JS, **zero network at load**. Findings render server-side (readable/searchable/printable with JS off). Score gauge, donut, category bars, Top Issues, filter/search toolbar, expandable rows.
- All scan-derived text HTML-escaped; offline system-font stack (no linked fonts); `@media print` block.

**3. CIS version fix** (`e00b2b1`)
- Footer now shows the OS-correct CIS edition (Win11 v5.0.0 / Win10 v4.0.0), stamped on the report from the same `is_win10` detection used to pick the IDs. New `test_cis_version.py`.

**4. Marketing site** (`939efaf`)
- `docs/index.html` + `docs/site.js` rebuilt in the CRT aesthetic (animated terminal demo mirrors the real CLI). Adds `docs/.nojekyll` and a synthetic sample `docs/report.html` for the teaser link.

**5. README** (`ce5ab72`) — Edited copy.

## Verification
- **560 tests pass**, ruff clean.
- Terminal: both truecolor and ASCII paths rendered and checked.
- Report + site: rendered in headless Chromium — no console errors; filtering/expand/copy work; report link resolves.
- Tool confirmed fully offline (terminal + report); site intentionally uses the Google Fonts CDN (public page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)