### PR TITLE
feat: copy-paste-ready remediation commands (command field)

### DIFF
--- a/src/apotrope/checks/accounts.py
+++ b/src/apotrope/checks/accounts.py
@@ -39,6 +39,7 @@ _PS_COMPLEXITY = (
 _ADMIN_WARN_THRESHOLD = 2
 _MIN_PW_FAIL = 8
 _MIN_PW_WARN = 12
+_MIN_PW_TARGET = 14  # CIS 1.1.4 recommended length — the value remediation sets
 
 
 def run() -> list[CheckResult]:
@@ -217,8 +218,8 @@ def _check_password_policy() -> list[CheckResult]:
             severity=Severity.HIGH,
             description=f"Minimum password length must be ≥{_MIN_PW_FAIL} (WARN if <{_MIN_PW_WARN}).",
             details=f"Minimum password length: {min_len} characters.",
-            remediation="Require a minimum password length of 14 characters.",
-            command="net accounts /minpwlen:14",
+            remediation=f"Require a minimum password length of {_MIN_PW_TARGET} characters.",
+            command=f"net accounts /minpwlen:{_MIN_PW_TARGET}",
         ))
     elif min_len < _MIN_PW_WARN:
         results.append(CheckResult(
@@ -227,9 +228,9 @@ def _check_password_policy() -> list[CheckResult]:
             status=Status.WARN,
             severity=Severity.MEDIUM,
             description=f"Minimum password length must be ≥{_MIN_PW_FAIL} (WARN if <{_MIN_PW_WARN}).",
-            details=f"Minimum password length: {min_len} characters (recommended: {_MIN_PW_WARN}+).",
-            remediation="Require a minimum password length of 14 characters.",
-            command="net accounts /minpwlen:14",
+            details=f"Minimum password length: {min_len} characters (recommended: {_MIN_PW_TARGET}+).",
+            remediation=f"Require a minimum password length of {_MIN_PW_TARGET} characters.",
+            command=f"net accounts /minpwlen:{_MIN_PW_TARGET}",
         ))
     else:
         results.append(CheckResult(

--- a/src/apotrope/checks/accounts.py
+++ b/src/apotrope/checks/accounts.py
@@ -84,7 +84,11 @@ def _check_guest_account() -> list[CheckResult]:
         details=f"Built-in Guest account is {'enabled' if enabled else 'disabled'}.",
         remediation=(
             "" if not enabled else
-            "Disable the Guest account: Disable-LocalUser -Name 'Guest'"
+            "Disable the built-in Guest account."
+        ),
+        command=(
+            "" if not enabled else
+            "Disable-LocalUser -Name 'Guest'"
         ),
     )]
 
@@ -118,22 +122,25 @@ def _check_builtin_admin() -> list[CheckResult]:
         status, sev = Status.FAIL, Severity.MEDIUM
         details = "Built-in Administrator account is enabled with the default name."
         remediation = (
-            "Rename and/or disable the built-in Administrator account. "
-            "Rename: Rename-LocalUser -Name 'Administrator' -NewName '<new_name>'. "
-            "Disable: Disable-LocalUser -Name 'Administrator'"
+            "Rename the built-in Administrator account and disable it if it is not in active use."
+        )
+        command = (
+            "Rename-LocalUser -Name 'Administrator' -NewName '<new_name>'\n"
+            "Disable-LocalUser -Name 'Administrator'"
         )
     elif enabled:
         status, sev = Status.WARN, Severity.LOW
         details = f"Built-in Administrator account is enabled (renamed to '{name}')."
         remediation = (
-            "Consider disabling the built-in Administrator account if it is not in active use: "
-            f"Disable-LocalUser -Name '{name}'"
+            "Consider disabling the built-in Administrator account if it is not in active use."
         )
+        command = f"Disable-LocalUser -Name '{name}'"
     else:
         status, sev = Status.PASS, Severity.MEDIUM
         rename_note = f" (renamed to '{name}')" if not is_default_name else ""
         details = f"Built-in Administrator account is disabled{rename_note}."
         remediation = ""
+        command = ""
 
     return [CheckResult(
         category=CATEGORY,
@@ -143,6 +150,7 @@ def _check_builtin_admin() -> list[CheckResult]:
         description="Checks if the built-in Administrator account is enabled and not renamed.",
         details=details,
         remediation=remediation,
+        command=command,
     )]
 
 
@@ -168,9 +176,16 @@ def _check_admin_count() -> list[CheckResult]:
         details=f"{count} administrator(s): {', '.join(names) if names else 'none'}",
         remediation=(
             "" if not over_threshold else
-            f"Review and reduce the {count} local administrator accounts. "
-            "Remove unnecessary members: "
-            "Remove-LocalGroupMember -Group 'Administrators' -Member '<username>'"
+            "Review who holds local admin rights and remove standing admin from service "
+            "and helpdesk accounts; use just-in-time elevation (LAPS / PIM) instead."
+        ),
+        command=(
+            "" if not over_threshold else
+            "# List current local administrators\n"
+            "Get-LocalGroupMember -Group 'Administrators'\n"
+            "\n"
+            "# Remove a standing admin (replace with the account to remove)\n"
+            "Remove-LocalGroupMember -Group 'Administrators' -Member 'CORP\\svc_backup'"
         ),
     )]
 
@@ -202,7 +217,8 @@ def _check_password_policy() -> list[CheckResult]:
             severity=Severity.HIGH,
             description=f"Minimum password length must be ≥{_MIN_PW_FAIL} (WARN if <{_MIN_PW_WARN}).",
             details=f"Minimum password length: {min_len} characters.",
-            remediation=f"Increase minimum password length: net accounts /minpwlen:{_MIN_PW_WARN}",
+            remediation="Require a minimum password length of 14 characters.",
+            command="net accounts /minpwlen:14",
         ))
     elif min_len < _MIN_PW_WARN:
         results.append(CheckResult(
@@ -212,7 +228,8 @@ def _check_password_policy() -> list[CheckResult]:
             severity=Severity.MEDIUM,
             description=f"Minimum password length must be ≥{_MIN_PW_FAIL} (WARN if <{_MIN_PW_WARN}).",
             details=f"Minimum password length: {min_len} characters (recommended: {_MIN_PW_WARN}+).",
-            remediation=f"Increase minimum password length: net accounts /minpwlen:{_MIN_PW_WARN}",
+            remediation="Require a minimum password length of 14 characters.",
+            command="net accounts /minpwlen:14",
         ))
     else:
         results.append(CheckResult(
@@ -242,7 +259,11 @@ def _check_password_policy() -> list[CheckResult]:
         ),
         remediation=(
             "" if not lockout_disabled else
-            "Enable account lockout: net accounts /lockoutthreshold:5 /lockoutduration:30"
+            "Enable account lockout so accounts are locked after repeated failed logins."
+        ),
+        command=(
+            "" if not lockout_disabled else
+            "net accounts /lockoutthreshold:5 /lockoutduration:30"
         ),
     ))
 
@@ -274,9 +295,16 @@ def _check_password_policy() -> list[CheckResult]:
             details=f"Password complexity requirement: {'enabled' if enabled else 'disabled'}.",
             remediation=(
                 "" if enabled else
-                "Enable password complexity: "
-                "secpol.msc → Account Policies → Password Policy → "
-                "Password must meet complexity requirements → Enabled"
+                "Enable the password complexity requirement so passwords must mix "
+                "character types."
+            ),
+            command=(
+                "" if enabled else
+                "# Set via Local Security Policy: secpol.msc -> Account Policies ->\n"
+                "# Password Policy -> Password must meet complexity requirements -> Enabled.\n"
+                "# Verify the current setting:\n"
+                "secedit /export /cfg \"$env:TEMP\\secpol.cfg\" | Out-Null; "
+                "Select-String -Path \"$env:TEMP\\secpol.cfg\" -Pattern 'PasswordComplexity'"
             ),
         ))
 

--- a/src/apotrope/checks/antivirus.py
+++ b/src/apotrope/checks/antivirus.py
@@ -79,9 +79,11 @@ def _check_defender() -> list[CheckResult]:
         ),
         remediation=(
             "" if rtp_enabled else
-            "Enable real-time protection: "
-            "Set-MpPreference -DisableRealtimeMonitoring $false. "
-            "Or: Windows Security → Virus & threat protection → Real-time protection: On"
+            "Turn Microsoft Defender real-time protection back on immediately."
+        ),
+        command=(
+            "" if rtp_enabled else
+            "Set-MpPreference -DisableRealtimeMonitoring $false"
         ),
     ))
 
@@ -99,8 +101,11 @@ def _check_defender() -> list[CheckResult]:
         details=f"Antivirus signature age: {sig_age} day(s).",
         remediation=(
             "" if sig_ok else
-            "Update Defender signatures immediately: Update-MpSignature. "
-            "Or: Windows Security → Virus & threat protection → Check for updates"
+            "Update Defender's antivirus definitions now."
+        ),
+        command=(
+            "" if sig_ok else
+            "Update-MpSignature"
         ),
     ))
 
@@ -117,9 +122,13 @@ def _check_defender() -> list[CheckResult]:
         details=f"IsTamperProtected: {tamper}",
         remediation=(
             "" if tamper else
-            "Enable Tamper Protection: "
-            "Windows Security → Virus & threat protection → "
-            "Manage settings → Tamper Protection: On"
+            "Enable Tamper Protection so Defender settings can't be changed by malware or scripts."
+        ),
+        command=(
+            "" if tamper else
+            "# Enable in Windows Security -> Virus & threat protection ->\n"
+            "# Manage settings -> Tamper Protection: On. Verify the current state:\n"
+            "(Get-MpComputerStatus).IsTamperProtected"
         ),
     ))
 

--- a/src/apotrope/checks/encryption.py
+++ b/src/apotrope/checks/encryption.py
@@ -65,11 +65,10 @@ def run() -> list[CheckResult]:
                 "BitLocker may be unavailable, or elevated privileges are required."
             ),
             remediation=(
-                "Run Apotrope as Administrator to retrieve BitLocker status. "
-                "To enable BitLocker on the OS drive: "
-                "Enable-BitLocker -MountPoint 'C:' "
-                "-EncryptionMethod XtsAes256 -RecoveryPasswordProtector"
+                "Run Apotrope as Administrator to retrieve BitLocker status, then "
+                "encrypt the system drive with BitLocker using the TPM protector."
             ),
+            command="Enable-BitLocker -MountPoint 'C:' -EncryptionMethod XtsAes256 -UsedSpaceOnly -TpmProtector",
         )]
 
     results: list[CheckResult] = []
@@ -119,8 +118,10 @@ def _check_volume(vol: dict) -> list[CheckResult]:
             f"Encrypted: {pct}% | Protection: Off"
         ),
         remediation=(
-            f"Enable BitLocker on drive {mount}: "
+            f"Encrypt drive {mount} with BitLocker using the TPM protector."
+        ),
+        command=(
             f"Enable-BitLocker -MountPoint '{mount}' "
-            f"-EncryptionMethod XtsAes256 -RecoveryPasswordProtector"
+            f"-EncryptionMethod XtsAes256 -UsedSpaceOnly -TpmProtector"
         ),
     )]

--- a/src/apotrope/checks/firewall.py
+++ b/src/apotrope/checks/firewall.py
@@ -83,7 +83,10 @@ def run() -> list[CheckResult]:
             details=f"Profile: {name} | Enabled: {enabled}",
             remediation=(
                 "" if enabled else
-                f"Enable the {name} firewall profile: "
+                f"Turn the {name}-profile firewall back on."
+            ),
+            command=(
+                "" if enabled else
                 f"Set-NetFirewallProfile -Profile {name} -Enabled True"
             ),
         ))
@@ -110,7 +113,10 @@ def run() -> list[CheckResult]:
             ),
             remediation=(
                 "" if not inbound_explicit_allow else
-                f"Set default inbound to Block for the {name} profile: "
+                f"Set the {name} firewall profile to block inbound connections by default."
+            ),
+            command=(
+                "" if not inbound_explicit_allow else
                 f"Set-NetFirewallProfile -Profile {name} -DefaultInboundAction Block"
             ),
         ))

--- a/src/apotrope/checks/misc.py
+++ b/src/apotrope/checks/misc.py
@@ -98,10 +98,14 @@ def _check_autoplay() -> list[CheckResult]:
                 "AutoPlay can be abused to auto-execute malicious content from USB drives."
             ),
             remediation=(
-                "Disable AutoPlay via Group Policy: Computer Configuration → Administrative "
-                "Templates → Windows Components → AutoPlay Policies → Turn off AutoPlay → Enabled. "
-                "Or via registry: Set-ItemProperty -Path "
-                f"'{_AUTOPLAY_KEY}' -Name NoDriveTypeAutoRun -Value 255 -Type DWord -Force"
+                "Disable AutoPlay for all drive types so removable media cannot "
+                "auto-execute content. This can also be set via Group Policy: Computer "
+                "Configuration → Administrative Templates → Windows Components → AutoPlay "
+                "Policies → Turn off AutoPlay → Enabled."
+            ),
+            command=(
+                f"Set-ItemProperty -Path '{_AUTOPLAY_KEY}' "
+                "-Name NoDriveTypeAutoRun -Value 255 -Type DWord -Force"
             ),
         )]
 
@@ -137,7 +141,10 @@ def _check_autoplay() -> list[CheckResult]:
                 "Some drive types may still trigger AutoPlay."
             ),
             remediation=(
-                "Set NoDriveTypeAutoRun to 255 to disable AutoPlay for all drive types: "
+                "Disable AutoPlay for all drive types so the remaining drive types "
+                "can no longer auto-execute content."
+            ),
+            command=(
                 f"Set-ItemProperty -Path '{_AUTOPLAY_KEY}' "
                 "-Name NoDriveTypeAutoRun -Value 255 -Type DWord -Force"
             ),
@@ -150,7 +157,8 @@ def _check_autoplay() -> list[CheckResult]:
         severity=Severity.MEDIUM,
         description="Checks whether AutoPlay is disabled for all drive types.",
         details=f"AutoPlay may be enabled (NoDriveTypeAutoRun = {val}).",
-        remediation=(
+        remediation="Disable AutoPlay for all drive types so removable media cannot auto-execute content.",
+        command=(
             f"Set-ItemProperty -Path '{_AUTOPLAY_KEY}' "
             "-Name NoDriveTypeAutoRun -Value 255 -Type DWord -Force"
         ),
@@ -191,9 +199,15 @@ def _check_winrm() -> list[CheckResult]:
         ),
         remediation=(
             "" if not running else
-            "If remote management is not required, stop and disable WinRM: "
-            "Stop-Service WinRM; Set-Service WinRM -StartupType Disabled. "
-            "If required, restrict access: "
+            "If remote management is not required, stop and disable WinRM. If it is "
+            "required, restrict access and disable Basic authentication."
+        ),
+        command=(
+            "" if not running else
+            "# If remote management is not required, stop and disable WinRM:\n"
+            "Stop-Service WinRM\n"
+            "Set-Service WinRM -StartupType Disabled\n"
+            "# If WinRM is required, disable Basic authentication instead:\n"
             "Set-Item WSMan:\\localhost\\Service\\Auth\\Basic -Value $false"
         ),
     )]
@@ -249,7 +263,10 @@ def _check_spectre() -> list[CheckResult]:
                 "This improves CPU performance but removes Spectre/Meltdown protections."
             ),
             remediation=(
-                "Re-enable mitigations by removing the override registry keys: "
+                "Re-enable Spectre/Meltdown mitigations by removing the override "
+                "registry keys that disable them."
+            ),
+            command=(
                 f"Remove-ItemProperty -Path '{_SPECTRE_KEY}' "
                 "-Name FeatureSettingsOverride,FeatureSettingsOverrideMask -ErrorAction SilentlyContinue"
             ),
@@ -316,10 +333,12 @@ def _check_audit_policy() -> list[CheckResult]:
                 "Security-relevant events may not be recorded."
             ),
             remediation=(
-                "Enable audit logging for key subcategories via Group Policy or auditpol: "
-                "auditpol /set /subcategory:'Logon' /success:enable /failure:enable. "
-                "Review: secpol.msc → Advanced Audit Policy Configuration."
+                "Enable audit logging for the key subcategories that currently have "
+                "auditing disabled so security-relevant events are recorded. This can "
+                "also be configured via Group Policy (secpol.msc → Advanced Audit Policy "
+                "Configuration)."
             ),
+            command="auditpol /set /subcategory:'Logon' /success:enable /failure:enable",
         )]
 
     checked = ", ".join(audit_map.keys()) if audit_map else "none found"

--- a/src/apotrope/checks/network.py
+++ b/src/apotrope/checks/network.py
@@ -96,6 +96,21 @@ def _check_listening_ports() -> list[CheckResult]:
     for port, hits in sorted(risky_hits.items()):
         service, status, severity, reason = _RISKY_PORTS[port]
         addr_list = ", ".join(f"{a} ({p})" for a, p in hits)
+        if port == 23:
+            # Telnet — catalog entry: stop/disable the service outright.
+            remediation = "Stop and disable the Telnet service (it sends credentials in cleartext)."
+            command = (
+                "Stop-Service -Name 'TlntSvr' -Force\n"
+                "Set-Service -Name 'TlntSvr' -StartupType Disabled\n"
+                "Disable-WindowsOptionalFeature -Online -FeatureName TelnetServer -NoRestart"
+            )
+        else:
+            remediation = (
+                f"Stop the service behind port {port} ({service}) and block the port in Windows Firewall."
+            )
+            command = (
+                f"New-NetFirewallRule -Direction Inbound -LocalPort {port} -Protocol TCP -Action Block"
+            )
         results.append(CheckResult(
             category=CATEGORY,
             check_name=f"Listening Port — {port}/{service}",
@@ -103,11 +118,8 @@ def _check_listening_ports() -> list[CheckResult]:
             severity=severity,
             description=f"Checks whether port {port} ({service}) is listening. {reason}",
             details=f"Port {port} ({service}) is listening on: {addr_list}",
-            remediation=(
-                f"Disable or firewall port {port} ({service}). "
-                f"Stop the associated service and block the port in Windows Firewall: "
-                f"New-NetFirewallRule -Direction Inbound -LocalPort {port} -Protocol TCP -Action Block"
-            ),
+            remediation=remediation,
+            command=command,
         ))
 
     # Summary INFO result for all listeners
@@ -149,13 +161,11 @@ def _check_llmnr() -> list[CheckResult]:
                 "Attackers on the local network can use tools like Responder "
                 "to capture NTLMv2 hashes via LLMNR poisoning."
             ),
-            remediation=(
-                "Disable LLMNR via Group Policy: "
-                "Computer Configuration → Administrative Templates → Network → "
-                "DNS Client → Turn off multicast name resolution → Enabled. "
-                "Or via registry: "
-                "New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\DNSClient' "
-                "-Name 'EnableMulticast' -Value 0 -PropertyType DWORD -Force"
+            remediation="Disable LLMNR to block Responder-style name-resolution poisoning.",
+            command=(
+                "$key = 'HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\DNSClient'\n"
+                "New-Item -Path $key -Force | Out-Null\n"
+                "Set-ItemProperty -Path $key -Name 'EnableMulticast' -Value 0"
             ),
         )]
 
@@ -207,11 +217,8 @@ def _check_netbios() -> list[CheckResult]:
             f"NetBIOS over TCP/IP is explicitly enabled on {enabled_count} adapter(s). "
             f"NetBIOS exposes the host to name-spoofing and enumeration."
         )
-        remediation = (
-            "Disable NetBIOS on all adapters: "
-            "Network Connections → Adapter → Properties → TCP/IPv4 → Advanced → WINS → "
-            "Disable NetBIOS over TCP/IP. "
-            "Or via WMI: "
+        remediation = "Disable NetBIOS over TCP/IP on all IP-enabled adapters."
+        command = (
             "(Get-CimInstance Win32_NetworkAdapterConfiguration -Filter 'IPEnabled=True')"
             ".SetTcpipNetbios(2)"
         )
@@ -221,14 +228,16 @@ def _check_netbios() -> list[CheckResult]:
             f"{dhcp_count} adapter(s) inherit NetBIOS setting from DHCP. "
             "If the DHCP server does not explicitly disable NetBIOS, it may be active."
         )
-        remediation = (
-            "Explicitly disable NetBIOS on all adapters rather than relying on DHCP. "
-            "Set TcpipNetbiosOptions to 2 on each adapter."
+        remediation = "Explicitly disable NetBIOS on all adapters rather than relying on DHCP."
+        command = (
+            "(Get-CimInstance Win32_NetworkAdapterConfiguration -Filter 'IPEnabled=True')"
+            ".SetTcpipNetbios(2)"
         )
     else:
         status, severity = Status.PASS, Severity.LOW
         details = f"NetBIOS over TCP/IP is explicitly disabled on all {disabled_count} adapter(s)."
         remediation = ""
+        command = ""
 
     return [CheckResult(
         category=CATEGORY,
@@ -238,6 +247,7 @@ def _check_netbios() -> list[CheckResult]:
         description="Checks whether NetBIOS over TCP/IP is disabled on all network adapters.",
         details=details,
         remediation=remediation,
+        command=command,
     )]
 
 

--- a/src/apotrope/checks/os_info.py
+++ b/src/apotrope/checks/os_info.py
@@ -154,8 +154,15 @@ def _check_os_build() -> list[CheckResult]:
                     f"This build no longer receives security updates."
                 ),
                 remediation=(
-                    "Upgrade to a supported Windows release. "
-                    "See: https://learn.microsoft.com/en-us/windows/release-health/"
+                    "Upgrade to a supported build (Windows 10 22H2) or Windows 11 — "
+                    "the upgrade itself has no single command. Confirm the current "
+                    "build first, then run Windows Update or the Installation Assistant."
+                ),
+                command=(
+                    "# There is no in-place command for the upgrade — use Windows Update or the\n"
+                    "# Windows Installation Assistant. Confirm the current build first:\n"
+                    "[System.Environment]::OSVersion.Version\n"
+                    "(Get-ItemProperty 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion').DisplayVersion"
                 ),
             )
         else:
@@ -185,8 +192,12 @@ def _check_os_build() -> list[CheckResult]:
                 "Verify this is a current supported release."
             ),
             remediation=(
-                "Check the Microsoft support lifecycle page: "
-                "https://learn.microsoft.com/en-us/windows/release-health/"
+                "Confirm the current build and verify it is a supported release on the "
+                "Microsoft support lifecycle page."
+            ),
+            command=(
+                "[System.Environment]::OSVersion.Version\n"
+                "(Get-ItemProperty 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion').DisplayVersion"
             ),
         )
 
@@ -209,10 +220,8 @@ def _check_uptime() -> list[CheckResult]:
             severity=Severity.MEDIUM,
             description=f"Warns when uptime exceeds {_UPTIME_WARN_DAYS} days (suggests pending patch reboots).",
             details=f"System has been running for {days} days without a reboot.",
-            remediation=(
-                "Reboot the system to apply pending patches. "
-                "Review Windows Update history for updates that require a restart."
-            ),
+            remediation="Schedule a reboot to apply deferred updates.",
+            command="Restart-Computer",
         )]
 
     return [CheckResult(
@@ -267,8 +276,13 @@ def _check_secure_boot() -> list[CheckResult]:
             description="Checks whether UEFI Secure Boot is enabled.",
             details="Secure Boot is not supported or the system is running in legacy BIOS mode.",
             remediation=(
-                "Enable UEFI mode in firmware settings if the hardware supports it. "
-                "Secure Boot requires UEFI firmware."
+                "Secure Boot requires UEFI firmware — enable UEFI mode in firmware "
+                "settings if the hardware supports it, then confirm the state from Windows."
+            ),
+            command=(
+                "# Secure Boot is a UEFI/firmware setting — reboot into firmware setup to enable it.\n"
+                "# Verify Secure Boot state (returns True once enabled in UEFI):\n"
+                "Confirm-SecureBootUEFI"
             ),
         )]
 
@@ -282,8 +296,15 @@ def _check_secure_boot() -> list[CheckResult]:
         details=f"Secure Boot is {'enabled' if enabled else 'disabled'}.",
         remediation=(
             "" if enabled else
-            "Enable Secure Boot in UEFI/BIOS firmware settings. "
-            "Note: may require reinstalling Windows in UEFI mode if currently using legacy BIOS."
+            "Secure Boot is a UEFI/firmware setting — reboot into firmware setup to "
+            "enable it, then confirm the state from Windows afterwards. May require "
+            "reinstalling Windows in UEFI mode if currently using legacy BIOS."
+        ),
+        command=(
+            "" if enabled else
+            "# Secure Boot is a UEFI/firmware setting — reboot into firmware setup to enable it.\n"
+            "# Verify Secure Boot state (returns True once enabled in UEFI):\n"
+            "Confirm-SecureBootUEFI"
         ),
     )]
 
@@ -312,8 +333,10 @@ def _check_tpm() -> list[CheckResult]:
             details="No TPM chip detected.",
             remediation=(
                 "A TPM 2.0 chip is required for BitLocker and is mandatory for Windows 11. "
-                "Enable TPM in UEFI/BIOS settings if available."
+                "Enable the TPM in UEFI/BIOS firmware settings if the hardware supports it, "
+                "then confirm it is detected from Windows."
             ),
+            command="Get-Tpm",
         )]
 
     return [CheckResult(
@@ -325,8 +348,12 @@ def _check_tpm() -> list[CheckResult]:
         details=f"TPM present. Ready: {ready}. Firmware version: {version}.",
         remediation=(
             "" if ready else
-            "Check TPM status in tpm.msc or Device Manager. "
-            "Clear and re-initialize the TPM if it reports errors."
+            "Initialize the TPM and take ownership so it is ready for use."
+        ),
+        command=(
+            "" if ready else
+            "Get-Tpm\n"
+            "Initialize-Tpm -AllowClear -AllowPhysicalPresence"
         ),
     )]
 

--- a/src/apotrope/checks/powershell.py
+++ b/src/apotrope/checks/powershell.py
@@ -80,8 +80,11 @@ def _check_execution_policy() -> list[CheckResult]:
         ),
         remediation=(
             "" if not risky else
-            f"Set a more restrictive policy: Set-ExecutionPolicy RemoteSigned -Scope LocalMachine. "
-            f"Current policy '{output}' allows unsigned scripts to run freely."
+            "Tighten the execution policy from Unrestricted to RemoteSigned (or AllSigned)."
+        ),
+        command=(
+            "" if not risky else
+            "Set-ExecutionPolicy -Scope LocalMachine -ExecutionPolicy RemoteSigned -Force"
         ),
     )]
 
@@ -108,10 +111,14 @@ def _check_script_block_logging() -> list[CheckResult]:
         ),
         remediation=(
             "" if enabled else
-            "Enable via Group Policy: Computer Configuration → Administrative Templates → "
-            "Windows Components → Windows PowerShell → Turn on PowerShell Script Block Logging. "
-            "Or via registry: Set-ItemProperty -Path "
-            f"'{_SBL_KEY}' -Name EnableScriptBlockLogging -Value 1 -Type DWord -Force"
+            "Enable PowerShell Script Block Logging so malicious or obfuscated scripts "
+            "are recorded in the event log."
+        ),
+        command=(
+            "" if enabled else
+            f"$key = '{_SBL_KEY}'\n"
+            "New-Item -Path $key -Force | Out-Null\n"
+            "Set-ItemProperty -Path $key -Name 'EnableScriptBlockLogging' -Value 1"
         ),
     )]
 
@@ -138,10 +145,14 @@ def _check_module_logging() -> list[CheckResult]:
         ),
         remediation=(
             "" if enabled else
-            "Enable via Group Policy: Computer Configuration → Administrative Templates → "
-            "Windows Components → Windows PowerShell → Turn on Module Logging. "
-            "Or via registry: Set-ItemProperty -Path "
-            f"'{_ML_KEY}' -Name EnableModuleLogging -Value 1 -Type DWord -Force"
+            "Enable PowerShell Module Logging so module pipeline execution is recorded "
+            "in the event log."
+        ),
+        command=(
+            "" if enabled else
+            f"$key = '{_ML_KEY}'\n"
+            "New-Item -Path $key -Force | Out-Null\n"
+            "Set-ItemProperty -Path $key -Name 'EnableModuleLogging' -Value 1"
         ),
     )]
 
@@ -187,9 +198,10 @@ def _check_psv2() -> list[CheckResult]:
                 "PowerShell v2 is installed. Attackers can invoke 'powershell -Version 2' "
                 "to bypass Script Block Logging and other v5+ security controls."
             ),
-            remediation=(
-                "Remove PowerShell v2: "
-                "Disable-WindowsOptionalFeature -Online -FeatureName MicrosoftWindowsPowerShellV2Root"
+            remediation="Remove the legacy PowerShell v2 engine (a downgrade-attack vector).",
+            command=(
+                "Disable-WindowsOptionalFeature -Online "
+                "-FeatureName MicrosoftWindowsPowerShellV2Root -NoRestart"
             ),
         )]
 

--- a/src/apotrope/checks/rdp.py
+++ b/src/apotrope/checks/rdp.py
@@ -93,11 +93,15 @@ def _check_rdp_enabled(data: dict) -> tuple[list[CheckResult], bool]:
                 "Ensure access is restricted by firewall and NLA is required."
             ),
             remediation=(
-                "If RDP is not required, disable it: "
+                "If RDP isn't needed, disable it. If it is required, keep NLA required "
+                "and restrict access by firewall scope or a VPN / RD gateway."
+            ),
+            command=(
+                "# Disable Remote Desktop (skip this if RDP is intentionally in use)\n"
                 "Set-ItemProperty -Path "
-                "'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server' "
-                "-Name fDenyTSConnections -Value 1. "
-                "If RDP is required, restrict access via Windows Firewall."
+                "'HKLM:\\System\\CurrentControlSet\\Control\\Terminal Server' "
+                "-Name 'fDenyTSConnections' -Value 1\n"
+                "Disable-NetFirewallRule -DisplayGroup 'Remote Desktop'"
             ),
         )
     else:
@@ -126,11 +130,11 @@ def _check_rdp_nla(data: dict) -> list[CheckResult]:
             severity=Severity.HIGH,
             description="Checks whether NLA is required for RDP connections.",
             details="Could not determine NLA setting (UserAuthentication key not found).",
-            remediation=(
-                "Enable NLA: "
+            remediation="Require Network Level Authentication for RDP.",
+            command=(
                 "Set-ItemProperty -Path "
-                "'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp' "
-                "-Name UserAuthentication -Value 1"
+                "'HKLM:\\System\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp' "
+                "-Name 'UserAuthentication' -Value 1"
             ),
         )]
 
@@ -150,12 +154,13 @@ def _check_rdp_nla(data: dict) -> list[CheckResult]:
         ),
         remediation=(
             "" if nla_required else
-            "Enable NLA: "
+            "Require Network Level Authentication for RDP."
+        ),
+        command=(
+            "" if nla_required else
             "Set-ItemProperty -Path "
-            "'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp' "
-            "-Name UserAuthentication -Value 1. "
-            "Or: System Properties → Remote → "
-            "'Allow connections only from computers running Remote Desktop with NLA'"
+            "'HKLM:\\System\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp' "
+            "-Name 'UserAuthentication' -Value 1"
         ),
     )]
 

--- a/src/apotrope/checks/services.py
+++ b/src/apotrope/checks/services.py
@@ -34,35 +34,39 @@ _PS_UNQUOTED = (
     "| ConvertTo-Json -Compress"
 )
 
-# Known-risky service names → (status, severity, details, remediation)
-_RISKY: dict[str, tuple[Status, Severity, str, str]] = {
+# Known-risky service names → (status, severity, details, remediation, command)
+_RISKY: dict[str, tuple[Status, Severity, str, str, str]] = {
     "RemoteRegistry": (
         Status.WARN,
         Severity.HIGH,
         "Remote Registry service is running — allows remote modification of the registry.",
-        "Stop and disable Remote Registry: "
-        "Stop-Service RemoteRegistry; Set-Service RemoteRegistry -StartupType Disabled",
+        "Stop and disable the Remote Registry service.",
+        "Stop-Service -Name 'RemoteRegistry' -Force\n"
+        "Set-Service -Name 'RemoteRegistry' -StartupType Disabled",
     ),
     "TlntSvr": (
         Status.FAIL,
         Severity.CRITICAL,
         "Telnet Server is running — all traffic (including credentials) is sent in cleartext.",
-        "Disable Telnet Server immediately: "
-        "Stop-Service TlntSvr; Set-Service TlntSvr -StartupType Disabled",
+        "Stop and disable the Telnet Server service immediately.",
+        "Stop-Service -Name 'TlntSvr' -Force\n"
+        "Set-Service -Name 'TlntSvr' -StartupType Disabled",
     ),
     "Telnet": (
         Status.FAIL,
         Severity.CRITICAL,
         "Telnet service is running — cleartext credential exposure.",
-        "Disable Telnet: Stop-Service Telnet; Set-Service Telnet -StartupType Disabled",
+        "Stop and disable the Telnet service immediately.",
+        "Stop-Service -Name 'Telnet' -Force\n"
+        "Set-Service -Name 'Telnet' -StartupType Disabled",
     ),
     "SNMP": (
         Status.WARN,
         Severity.MEDIUM,
         "SNMP service is running. SNMPv1/v2 uses weak community-string authentication.",
-        "Disable SNMP if not required: "
-        "Stop-Service SNMP; Set-Service SNMP -StartupType Disabled. "
-        "If required, restrict access and use SNMPv3.",
+        "Disable SNMP if it is not required; if it is, restrict access and use SNMPv3.",
+        "Stop-Service -Name 'SNMP' -Force\n"
+        "Set-Service -Name 'SNMP' -StartupType Disabled",
     ),
 }
 
@@ -90,7 +94,7 @@ def _check_risky_services() -> list[CheckResult]:
     running_names = {str(s.get("Name", "")).lower(): str(s.get("Name", "")) for s in services}
 
     results: list[CheckResult] = []
-    for svc_name, (status, severity, details, remediation) in _RISKY.items():
+    for svc_name, (status, severity, details, remediation, command) in _RISKY.items():
         if svc_name.lower() in running_names:
             display = running_names[svc_name.lower()]
             results.append(CheckResult(
@@ -101,6 +105,7 @@ def _check_risky_services() -> list[CheckResult]:
                 description=f"Checks whether the {display} service is running.",
                 details=details,
                 remediation=remediation,
+                command=command,
             ))
 
     if not results:
@@ -162,9 +167,16 @@ def _check_unquoted_paths() -> list[CheckResult]:
             "executable that Windows resolves before the intended binary."
         ),
         remediation=(
-            "Quote the PathName of each affected service in the registry: "
-            "HKLM:\\SYSTEM\\CurrentControlSet\\Services\\<ServiceName>\\ImagePath. "
-            "Wrap the executable path in double quotes, preserving any arguments."
+            "Wrap the executable path of each affected service in double quotes "
+            "(preserving any arguments) so Windows resolves the intended binary."
+        ),
+        command=(
+            "# Review the unquoted ImagePath, then re-set it wrapped in quotes\n"
+            "Get-ItemProperty -Path "
+            "'HKLM:\\SYSTEM\\CurrentControlSet\\Services\\<ServiceName>' -Name ImagePath\n"
+            "Set-ItemProperty -Path "
+            "'HKLM:\\SYSTEM\\CurrentControlSet\\Services\\<ServiceName>' "
+            "-Name ImagePath -Value '\"C:\\Path With Spaces\\service.exe\"'"
         ),
     )]
 

--- a/src/apotrope/checks/smb.py
+++ b/src/apotrope/checks/smb.py
@@ -67,10 +67,8 @@ def _check_smb1(data: dict) -> list[CheckResult]:
             severity=Severity.CRITICAL,
             description="Checks that SMBv1 is disabled (mitigates EternalBlue/WannaCry).",
             details="Could not determine SMBv1 status from Get-SmbServerConfiguration.",
-            remediation=(
-                "Verify SMBv1 status manually: Get-SmbServerConfiguration | Select EnableSMB1Protocol. "
-                "To disable: Set-SmbServerConfiguration -EnableSMB1Protocol $false -Force"
-            ),
+            remediation="Remove the legacy SMBv1 protocol, then reboot.",
+            command="Disable-WindowsOptionalFeature -Online -FeatureName SMB1Protocol -NoRestart",
         )]
 
     enabled = bool(raw)
@@ -83,10 +81,11 @@ def _check_smb1(data: dict) -> list[CheckResult]:
         details=f"SMBv1 protocol is {'enabled' if enabled else 'disabled'}.",
         remediation=(
             "" if not enabled else
-            "Disable SMBv1 immediately: "
-            "Set-SmbServerConfiguration -EnableSMB1Protocol $false -Force. "
-            "Also disable via Windows Features: "
-            "Disable-WindowsOptionalFeature -Online -FeatureName SMB1Protocol"
+            "Remove the legacy SMBv1 protocol, then reboot."
+        ),
+        command=(
+            "" if not enabled else
+            "Disable-WindowsOptionalFeature -Online -FeatureName SMB1Protocol -NoRestart"
         ),
     )]
 
@@ -104,31 +103,43 @@ def _check_smb_signing(data: dict) -> list[CheckResult]:
             severity=Severity.HIGH,
             description="Checks that SMB message signing is required (mitigates relay attacks).",
             details="Could not determine SMB signing configuration.",
-            remediation="Check manually: Get-SmbServerConfiguration | Select RequireSecuritySignature",
+            remediation=(
+                "Require SMB message signing on both the client and server side so "
+                "sessions can't be relayed or tampered with."
+            ),
+            command=(
+                "Set-SmbClientConfiguration -RequireSecuritySignature $true -Force\n"
+                "Set-SmbServerConfiguration -RequireSecuritySignature $true -Force"
+            ),
         )]
 
     required_bool = bool(required)
     enabled_bool = bool(enabled) if enabled is not None else False
 
+    _signing_command = (
+        "Set-SmbClientConfiguration -RequireSecuritySignature $true -Force\n"
+        "Set-SmbServerConfiguration -RequireSecuritySignature $true -Force"
+    )
+    _signing_remediation = (
+        "Require SMB message signing on both the client and server side so "
+        "sessions can't be relayed or tampered with."
+    )
+
     if required_bool:
         details = "SMB signing is required on this server."
         status = Status.PASS
         remediation = ""
+        command = ""
     elif enabled_bool:
         details = "SMB signing is enabled but not required — clients may negotiate unsigned connections."
         status = Status.WARN
-        remediation = (
-            "Require SMB signing to prevent relay attacks: "
-            "Set-SmbServerConfiguration -RequireSecuritySignature $true -Force"
-        )
+        remediation = _signing_remediation
+        command = _signing_command
     else:
         details = "SMB signing is neither required nor enabled."
         status = Status.FAIL
-        remediation = (
-            "Enable and require SMB signing: "
-            "Set-SmbServerConfiguration -EnableSecuritySignature $true "
-            "-RequireSecuritySignature $true -Force"
-        )
+        remediation = _signing_remediation
+        command = _signing_command
 
     return [CheckResult(
         category=CATEGORY,
@@ -138,6 +149,7 @@ def _check_smb_signing(data: dict) -> list[CheckResult]:
         description="Checks that SMB message signing is required (mitigates NTLM relay attacks).",
         details=details,
         remediation=remediation,
+        command=command,
     )]
 
 

--- a/src/apotrope/checks/uac.py
+++ b/src/apotrope/checks/uac.py
@@ -89,11 +89,10 @@ def _check_uac_enabled(data: dict) -> list[CheckResult]:
             severity=Severity.CRITICAL,
             description="Checks whether User Account Control (UAC) is enabled.",
             details="Could not read UAC EnableLUA registry value.",
-            remediation=(
-                "Verify UAC status: "
-                f"Get-ItemProperty '{_REG_KEY}' | Select EnableLUA. "
-                "Enable UAC: Set-ItemProperty -Path "
-                f"'{_REG_KEY}' -Name EnableLUA -Value 1"
+            remediation="Verify UAC status manually, then re-enable User Account Control if it is off.",
+            command=(
+                f"Get-ItemProperty '{_REG_KEY}' | Select EnableLUA\n"
+                f"Set-ItemProperty -Path '{_REG_KEY}' -Name EnableLUA -Value 1"
             ),
         )]
 
@@ -107,11 +106,12 @@ def _check_uac_enabled(data: dict) -> list[CheckResult]:
         details=f"UAC (EnableLUA) is {'enabled' if enabled else 'disabled'}.",
         remediation=(
             "" if enabled else
-            "Enable UAC immediately: "
-            "Set-ItemProperty -Path "
-            f"'{_REG_KEY}' "
-            "-Name EnableLUA -Value 1. "
-            "A reboot is required for the change to take effect."
+            "Re-enable User Account Control, then reboot for it to take effect."
+        ),
+        command=(
+            "" if enabled else
+            f"Set-ItemProperty -Path '{_REG_KEY}' -Name 'EnableLUA' -Value 1\n"
+            "Restart-Computer"
         ),
     )]
 
@@ -148,11 +148,12 @@ def _check_admin_behavior(data: dict) -> list[CheckResult]:
                 "Administrators are elevated silently without any confirmation prompt."
             ),
             remediation=(
-                "Set admin UAC to at least require consent: "
-                "Set-ItemProperty -Path "
-                f"'{_REG_KEY}' "
-                "-Name ConsentPromptBehaviorAdmin -Value 2. "
-                "Recommended value: 2 (prompt for consent on secure desktop)"
+                "Require administrators to confirm elevation by prompting for consent "
+                "on the secure desktop instead of elevating silently."
+            ),
+            command=(
+                f"Set-ItemProperty -Path '{_REG_KEY}' "
+                "-Name ConsentPromptBehaviorAdmin -Value 2"
             ),
         )]
 
@@ -197,10 +198,11 @@ def _check_secure_desktop(data: dict) -> list[CheckResult]:
         ),
         remediation=(
             "" if on_secure else
-            "Enable secure desktop for UAC prompts: "
-            "Set-ItemProperty -Path "
-            f"'{_REG_KEY}' "
-            "-Name PromptOnSecureDesktop -Value 1"
+            "Show UAC prompts on the isolated secure desktop."
+        ),
+        command=(
+            "" if on_secure else
+            f"Set-ItemProperty -Path '{_REG_KEY}' -Name 'PromptOnSecureDesktop' -Value 1"
         ),
     )]
 

--- a/src/apotrope/checks/updates.py
+++ b/src/apotrope/checks/updates.py
@@ -87,8 +87,15 @@ def _check_last_update() -> list[CheckResult]:
             description="Checks when the most recent Windows Update was installed.",
             details="No hotfixes with a valid install date were found in the hotfix log.",
             remediation=(
-                "Run Windows Update manually: "
-                "Settings → Windows Update → Check for updates."
+                "Install all pending quality and security updates. "
+                "Schedule a maintenance window if reboots are deferred."
+            ),
+            command=(
+                "# Install the PSWindowsUpdate helper module (first time only)\n"
+                "Install-Module PSWindowsUpdate -Force -Scope CurrentUser\n"
+                "\n"
+                "# Download and install everything available, rebooting if required\n"
+                "Install-WindowsUpdate -AcceptAll -AutoReboot"
             ),
         )]
 
@@ -113,8 +120,15 @@ def _check_last_update() -> list[CheckResult]:
                 f"System is {age_days - _FAIL_DAYS} days past the {_FAIL_DAYS}-day threshold."
             ),
             remediation=(
-                "Install all pending Windows Updates immediately. "
-                "Open: Start-Process ms-settings:windowsupdate"
+                "Install all pending quality and security updates. "
+                "Schedule a maintenance window if reboots are deferred."
+            ),
+            command=(
+                "# Install the PSWindowsUpdate helper module (first time only)\n"
+                "Install-Module PSWindowsUpdate -Force -Scope CurrentUser\n"
+                "\n"
+                "# Download and install everything available, rebooting if required\n"
+                "Install-WindowsUpdate -AcceptAll -AutoReboot"
             ),
         )]
 
@@ -130,8 +144,15 @@ def _check_last_update() -> list[CheckResult]:
                 f"({last_update.strftime('%Y-%m-%d')})."
             ),
             remediation=(
-                "Check for and install pending Windows Updates: "
-                "Start-Process ms-settings:windowsupdate"
+                "Install all pending quality and security updates. "
+                "Schedule a maintenance window if reboots are deferred."
+            ),
+            command=(
+                "# Install the PSWindowsUpdate helper module (first time only)\n"
+                "Install-Module PSWindowsUpdate -Force -Scope CurrentUser\n"
+                "\n"
+                "# Download and install everything available, rebooting if required\n"
+                "Install-WindowsUpdate -AcceptAll -AutoReboot"
             ),
         )]
 
@@ -177,8 +198,12 @@ def _check_wu_service() -> list[CheckResult]:
         details=f"Windows Update service status: {output}.",
         remediation=(
             "" if running else
-            "Start the Windows Update service: Start-Service -Name wuauserv. "
-            "If disabled, change startup type: "
+            "Start the Windows Update service, and set it to start automatically "
+            "if it has been disabled."
+        ),
+        command=(
+            "" if running else
+            "Start-Service -Name wuauserv\n"
             "Set-Service -Name wuauserv -StartupType Automatic"
         ),
     )]
@@ -239,10 +264,10 @@ def _check_pending_updates() -> list[CheckResult]:
         description="Counts Windows Updates that are available but not yet installed.",
         details=f"{count} pending Windows Update(s) are available but not installed.",
         remediation=(
-            f"Install {count} pending update(s): "
-            "Settings → Windows Update → Install now, or: "
-            "Install-WindowsUpdate -AcceptAll (requires PSWindowsUpdate module)"
+            f"Install the {count} pending update(s) now (requires the "
+            "PSWindowsUpdate module)."
         ),
+        command="Install-WindowsUpdate -AcceptAll",
     )]
 
 

--- a/src/apotrope/cli.py
+++ b/src/apotrope/cli.py
@@ -34,6 +34,7 @@ def build_parser() -> argparse.ArgumentParser:
             "  apotrope --category firewall,encryption  Specific categories only\n"
             "  apotrope --dry-run                   List checks without running\n"
             "  apotrope --verbose                   Show details for every check\n"
+            "  apotrope --fix                       Print paste-ready PowerShell fixes\n"
             "\n"
             "NOTICE: Apotrope is a READ-ONLY tool for AUTHORISED auditing only.\n"
             "It makes no changes to the system.  Do not run on systems you do\n"
@@ -89,6 +90,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Show detailed output for every check",
     )
     parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Print copy-paste-ready PowerShell remediation for each failing/warning check",
+    )
+    parser.add_argument(
         "--no-color",
         action="store_true",
         help="Disable Rich color formatting",
@@ -127,7 +133,7 @@ def main() -> None:
 
     admin    = is_admin()
     scanner  = Scanner(categories=categories, is_admin=admin, profile=profile)
-    reporter = Reporter(verbose=args.verbose, no_color=args.no_color)
+    reporter = Reporter(verbose=args.verbose, no_color=args.no_color, fix=args.fix)
 
     # --dry-run: list modules and exit without scanning
     if args.dry_run:

--- a/src/apotrope/compare.py
+++ b/src/apotrope/compare.py
@@ -165,6 +165,7 @@ def load_baseline(path: str) -> AuditReport:
                 description=r.get("description", ""),
                 details=r.get("details", ""),
                 remediation=r.get("remediation", ""),
+                command=r.get("command", ""),
                 check_duration=float(r.get("check_duration", 0.0)),
                 cis_reference=r.get("cis_reference", ""),
             )

--- a/src/apotrope/models.py
+++ b/src/apotrope/models.py
@@ -38,7 +38,11 @@ class CheckResult:
         severity:    Risk level if the check fails (CRITICAL/HIGH/MEDIUM/LOW/INFO).
         description: What this check verifies.
         details:     What was actually found on the system.
-        remediation: Actionable fix guidance; empty string when status is PASS.
+        remediation: Plain-English fix guidance (the *what & why*); no command
+                     text. Empty string when status is PASS/INFO.
+        command:     Verbatim, ready-to-paste PowerShell a user can run in an
+                     elevated prompt. May be multi-line (one statement per line);
+                     empty string when there is nothing to run (PASS/INFO).
     """
 
     category: str
@@ -48,6 +52,7 @@ class CheckResult:
     description: str
     details: str
     remediation: str = ""
+    command: str = ""            # ready-to-paste PowerShell; "" when PASS/INFO
     check_duration: float = 0.0  # seconds the parent module took to run
     cis_reference: str = ""      # CIS Benchmark control ID, e.g. "CIS 9.1.1"
 

--- a/src/apotrope/reporter.py
+++ b/src/apotrope/reporter.py
@@ -203,11 +203,16 @@ class Reporter:
     Args:
         verbose:  Show details and remediation for every check result.
         no_color: Disable Rich color markup (produces plain, no-ANSI output).
+        fix:      Print a copy-paste-ready "TOP FIXES" block with the exact
+                  PowerShell command for each failing/warning check.
     """
 
-    def __init__(self, verbose: bool = False, no_color: bool = False) -> None:
+    def __init__(
+        self, verbose: bool = False, no_color: bool = False, fix: bool = False
+    ) -> None:
         self.verbose = verbose
         self.no_color = no_color
+        self.fix = fix
 
     # ── Public API ────────────────────────────────────────────────────────────
 
@@ -297,6 +302,9 @@ class Reporter:
             # Default view stays concise: prioritised failures, then warnings.
             self._print_top_findings(console, report, Status.FAIL)
             self._print_top_findings(console, report, Status.WARN)
+            # --fix: append a copy-paste-ready block of exact PowerShell commands.
+            if self.fix:
+                self._print_top_fixes(console, report)
         self._print_footer(console, report, html_path, json_path)
 
     def generate_html_report(self, report: AuditReport, path: str) -> None:
@@ -467,6 +475,7 @@ class Reporter:
                 "description":  r.description,
                 "details":      r.details,
                 "remediation":  r.remediation,
+                "command":      r.command,
                 "cis":          r.cis_reference,
                 "snippet":      snippet,
             }
@@ -892,6 +901,59 @@ class Reporter:
             console.print(line)
         console.print()
 
+    def _fix_candidates(self, report: AuditReport) -> list[CheckResult]:
+        """FAIL/WARN findings that carry a command, ordered for the fixes block.
+
+        Severity-sorted (CRITICAL→LOW), FAIL before WARN — same priority the
+        HTML top-issues panel uses.
+        """
+        rows = [
+            r for r in report.results
+            if r.status in (Status.FAIL, Status.WARN) and r.command
+        ]
+        rows.sort(key=lambda r: (
+            _SEV_ORDER.get(r.severity, 5),
+            0 if r.status == Status.FAIL else 1,
+        ))
+        return rows
+
+    def _print_top_fixes(self, console, report: AuditReport) -> None:
+        """Print copy-paste-ready PowerShell for the top failing/warning checks.
+
+        Each finding gets a header line (glyph/severity/name/CIS) followed by its
+        exact command on indented bare lines — no glyph, rail, or prompt — so a
+        user can select and paste straight into an elevated PowerShell.
+        """
+        rows = self._fix_candidates(report)[:_TOP_N]
+        if not rows:
+            return
+
+        g = _glyphs(console)
+        flag = f"{g['flag']} " if g["flag"] else ""
+        console.print(_text(
+            "  ",
+            (f"{flag}TOP FIXES", f"bold {_RED}"),
+            ("   copy-paste into an elevated PowerShell", _MUTED),
+        ))
+        console.print()
+
+        for r in rows:
+            sev  = _SEVERITY_ABBR.get(r.severity, "?").ljust(_SEV_WIDTH)
+            desc = _truncate(r.check_name, _DESC_WIDTH).ljust(_DESC_WIDTH)
+            line = _text(
+                "  ",
+                (g["fail"] + " ", _RED),
+                (sev + " ", _SEVERITY_HEX.get(r.severity, _TEXT)),
+                (desc, _TEXT),
+            )
+            if r.cis_reference:
+                line.append(" " + r.cis_reference, style=_FAINT)
+            console.print(line)
+            # Bare command lines — nothing but the command, indented 6 spaces.
+            for cmd_line in r.command.split("\n"):
+                console.print(_text("      ", (cmd_line, _GREEN)))
+            console.print()
+
     def _print_category_detail(self, console, report: AuditReport) -> None:
         """Verbose view: every check, grouped by category, in the rail language."""
         g = _glyphs(console)
@@ -944,6 +1006,11 @@ class Reporter:
                     for i, ln in enumerate(textwrap.wrap(r.remediation, _REM_WRAP_WIDTH)):
                         label = "fix       " if i == 0 else "          "
                         console.print(_text("       ", (label, _MUTED), (ln, _TEXT)))
+                if r.command:
+                    # Verbatim (un-wrapped) so each line stays copy-paste-valid.
+                    for i, ln in enumerate(r.command.split("\n")):
+                        label = "run       " if i == 0 else "          "
+                        console.print(_text("       ", (label, _MUTED), (ln, _GREEN)))
                 console.print()
             console.print()
 
@@ -991,9 +1058,24 @@ class Reporter:
                 ("note: some checks skipped — run as Administrator for complete results",
                  _MUTED),
             ))
-        if not self.verbose:
+        if self.fix and not self.verbose:
+            total_fixes = len(self._fix_candidates(report))
+            shown = min(total_fixes, _TOP_N)
+            if total_fixes > shown:
+                console.print(_text(
+                    "  ",
+                    (f"{shown} of {total_fixes} fixes shown", _MUTED),
+                    (" — run --verbose for every fix", _MUTED),
+                ))
+            else:
+                console.print(_text(
+                    "  ", ("run with --verbose for per-check detail", _MUTED),
+                ))
+        elif not self.verbose:
             console.print(_text(
-                "  ", ("run with --verbose for per-check detail", _MUTED),
+                "  ",
+                ("run with --verbose for per-check detail "
+                 f"{g['sep']} --fix for paste-ready commands", _MUTED),
             ))
         console.print()
 
@@ -1015,7 +1097,10 @@ class Reporter:
         for r in report.results:
             icon = _STATUS_ICON.get(r.status, "?")
             print(f"[{icon}] [{r.severity.value:8}] {r.category}: {r.check_name}")
-            if self.verbose and r.details:
+            if (self.verbose or self.fix) and r.details:
                 print(f"       {r.details}")
-            if self.verbose and r.remediation:
+            if (self.verbose or self.fix) and r.remediation:
                 print(f"       Fix: {r.remediation}")
+            if (self.verbose or self.fix) and r.command:
+                for ln in r.command.split("\n"):
+                    print(f"       {ln}")

--- a/src/apotrope/templates/report.html.j2
+++ b/src/apotrope/templates/report.html.j2
@@ -526,7 +526,7 @@
       </div>
       <div class="findings">
         {% for f in cat.findings %}
-        <div class="frow" data-status="{{ f.status }}" data-text="{{ f.check_name|lower }} {{ f.category|lower }} {{ f.details|lower }} {{ f.cis|lower }}">
+        <div class="frow" data-status="{{ f.status }}" data-text="{{ f.check_name|lower }} {{ f.category|lower }} {{ f.details|lower }} {{ f.cis|lower }} {{ f.command|lower }}">
           <button class="fhead">
             <span class="ficon" style="color:{{ f.status_color }}">{{ f.status_glyph }}</span>
             <span class="fsev" style="color:{{ f.sev_color }};border:1px solid {{ f.sev_color }};background:transparent">{{ f.severity }}</span>

--- a/src/apotrope/templates/report.html.j2
+++ b/src/apotrope/templates/report.html.j2
@@ -319,12 +319,20 @@
   .fbody .fld { display:grid; grid-template-columns: 82px 1fr; gap:14px; align-items:start; }
   .fbody .fld .k { font-size:10.5px; letter-spacing:0.14em; text-transform:uppercase; color:var(--faint); padding-top:2px; }
   .fbody .fld .vv { font-size:13px; color:var(--text); line-height:1.65; }
-  .code { font-size:12.5px; background:#02060a; border:1px solid var(--line); border-left:2px solid var(--accent);
-          border-radius:2px; padding:11px 13px; color:var(--green); white-space:pre-wrap; word-break:break-word;
-          position:relative; }
-  .code .copy { position:absolute; top:7px; right:8px; font-size:9.5px; letter-spacing:0.1em; text-transform:uppercase;
-                color:var(--muted); border:1px solid var(--line); padding:3px 7px; border-radius:2px; background:var(--void); }
+  .rem { display:grid; gap:11px; }
+  .rem-note { font-size:13px; color:var(--text); line-height:1.65; }
+  .code { font-size:12.5px; background:#02060a; border:1px solid var(--line);
+          border-left:2px solid var(--accent); border-radius:2px; overflow:hidden; }
+  .code-bar { display:flex; align-items:center; justify-content:space-between; gap:12px;
+              padding:6px 8px 6px 11px; background:rgba(43,255,136,0.05);
+              border-bottom:1px solid var(--line); }
+  .code-tag { font-size:9.5px; letter-spacing:0.14em; text-transform:uppercase; color:var(--muted); }
+  .code .copy { font-size:9.5px; letter-spacing:0.1em; text-transform:uppercase; flex-shrink:0;
+                color:var(--muted); border:1px solid var(--line); padding:3px 9px; border-radius:2px;
+                background:var(--void); cursor:pointer; }
   .code .copy:hover { color:var(--accent); border-color:var(--accent); }
+  .code-cmd { font-family:"IBM Plex Mono","Cascadia Code","Consolas",monospace; font-size:12.5px;
+              color:var(--green); white-space:pre-wrap; word-break:break-word; padding:11px 13px; margin:0; }
   .cis { display:inline-flex; align-items:center; gap:6px; font-size:11px; letter-spacing:0.06em;
          color:var(--cyan); border:1px solid rgba(68,224,230,0.28); background:rgba(68,224,230,0.05);
          padding:3px 9px; border-radius:2px; }
@@ -355,7 +363,10 @@
     .cat-bar { position:static; background:#f2f2f2 !important; }
     .cat-name, .brand .name, .ti-name, .fname b, .meta-item .v b { color:#111 !important; }
     .fbody[hidden] { display:grid !important; }   /* show all details on paper */
-    .code { background:#f6f6f6 !important; color:#111 !important; }
+    .code { background:#f6f6f6 !important; }
+    .code-bar { background:#ececec !important; border-bottom-color:#ccc !important; }
+    .code-tag { color:#444 !important; }
+    .code-cmd { color:#111 !important; }
   }
 {% endraw %}</style>
 </head>
@@ -531,9 +542,20 @@
           <div class="fbody" hidden>
             <div class="fld"><span class="k">Checks</span><span class="vv">{{ f.description }}</span></div>
             <div class="fld"><span class="k">Found</span><span class="vv">{{ f.details }}</span></div>
-            {% if f.remediation %}
+            {% if f.remediation or f.command %}
             <div class="fld"><span class="k">Remediation</span>
-              <div class="code">{{ f.remediation }}<button class="copy">copy</button></div></div>
+              <div class="rem">
+                {% if f.remediation %}<div class="rem-note">{{ f.remediation }}</div>{% endif %}
+                {% if f.command %}
+                <div class="code">
+                  <div class="code-bar">
+                    <span class="code-tag">▷ Windows PowerShell · run as Administrator</span>
+                    <button class="copy" type="button">copy</button>
+                  </div>
+                  <pre class="code-cmd">{{ f.command }}</pre>
+                </div>
+                {% endif %}
+              </div></div>
             {% endif %}
             {% if f.cis %}<div class="fld"><span class="k">Mapping</span><span class="vv"><span class="cis">{{ f.cis }}</span></span></div>{% endif %}
           </div>
@@ -608,7 +630,9 @@
   document.querySelectorAll('.code .copy').forEach(function(btn){
     btn.addEventListener('click', function(e){
       e.stopPropagation();
-      var code = btn.parentNode.textContent.replace(/copy$/, '').trim();
+      // Copy ONLY the command text, not the label bar or button.
+      var pre = btn.closest('.code').querySelector('.code-cmd');
+      var code = pre ? pre.textContent.replace(/\s+$/, '') : '';
       if (navigator.clipboard) navigator.clipboard.writeText(code);
       var t = btn.textContent; btn.textContent = 'copied'; setTimeout(function(){ btn.textContent = t; }, 1300);
     });

--- a/tests/test_checks/test_accounts.py
+++ b/tests/test_checks/test_accounts.py
@@ -29,7 +29,7 @@ class TestCheckGuestAccount:
         r = results[0]
         assert r.status == Status.FAIL
         assert "enabled" in r.details.lower()
-        assert "Disable-LocalUser" in r.remediation
+        assert "Disable-LocalUser" in r.command
 
     def test_guest_not_found_is_info(self):
         with patch("apotrope.checks.accounts.run_powershell", return_value=""):
@@ -232,7 +232,7 @@ class TestCheckPasswordPolicy:
         results = self._run(self._NET_NO_LOCKOUT, "1")
         r = next(r for r in results if "Lockout" in r.check_name)
         assert r.status == Status.WARN
-        assert "net accounts" in r.remediation
+        assert "net accounts" in r.command
 
     def test_complexity_disabled_is_fail(self):
         results = self._run(self._NET_GOOD, "0")

--- a/tests/test_checks/test_antivirus.py
+++ b/tests/test_checks/test_antivirus.py
@@ -60,7 +60,7 @@ class TestCheckDefender:
         sig = next(r for r in results if "Signature" in r.check_name)
         assert sig.status == Status.WARN
         assert sig.severity == Severity.HIGH
-        assert "Update-MpSignature" in sig.remediation
+        assert "Update-MpSignature" in sig.command
 
     def test_signatures_at_threshold_returns_warn(self):
         with patch("apotrope.checks.antivirus.run_powershell_json",

--- a/tests/test_checks/test_encryption.py
+++ b/tests/test_checks/test_encryption.py
@@ -80,7 +80,7 @@ class TestEncryptionRunOsDrive:
         assert results[0].status == Status.FAIL
         assert results[0].severity == Severity.HIGH
         assert results[0].remediation != ""
-        assert "Enable-BitLocker" in results[0].remediation
+        assert "Enable-BitLocker" in results[0].command
 
     def test_unencrypted_os_drive_remediation_includes_mount_point(self):
         with patch("apotrope.checks.encryption.run_powershell_json",

--- a/tests/test_checks/test_firewall.py
+++ b/tests/test_checks/test_firewall.py
@@ -113,7 +113,7 @@ class TestFirewallRunFailures:
         enabled_check = next(r for r in results if "Enabled" in r.check_name)
         assert enabled_check.status == Status.FAIL
         assert enabled_check.severity == Severity.HIGH
-        assert "Set-NetFirewallProfile" in enabled_check.remediation
+        assert "Set-NetFirewallProfile" in enabled_check.command
 
     def test_explicit_allow_inbound_returns_warn(self):
         profiles = [_PROFILE_ALLOW_INBOUND]
@@ -122,7 +122,7 @@ class TestFirewallRunFailures:
         inbound_check = next(r for r in results if "Inbound" in r.check_name)
         assert inbound_check.status == Status.WARN
         assert inbound_check.severity == Severity.MEDIUM
-        assert "Set-NetFirewallProfile" in inbound_check.remediation
+        assert "Set-NetFirewallProfile" in inbound_check.command
 
     def test_not_configured_inbound_is_not_a_warn(self):
         """NotConfigured inherits Block from system policy — not a finding."""

--- a/tests/test_checks/test_misc.py
+++ b/tests/test_checks/test_misc.py
@@ -38,7 +38,7 @@ class TestCheckAutoplay:
 
     def test_warn_has_remediation(self):
         r = self._run("NOTSET")[0]
-        assert "NoDriveTypeAutoRun" in r.remediation
+        assert "NoDriveTypeAutoRun" in r.command
 
     def test_error_returns_error(self):
         with patch("apotrope.checks.misc.run_powershell",
@@ -111,7 +111,7 @@ class TestCheckSpectre:
 
     def test_disabled_has_remediation(self):
         r = self._run({"Override": 3, "Mask": 3})[0]
-        assert "FeatureSettingsOverride" in r.remediation
+        assert "FeatureSettingsOverride" in r.command
 
     def test_error_returns_error(self):
         with patch("apotrope.checks.misc.run_powershell_json",
@@ -155,7 +155,7 @@ class TestCheckAuditPolicy:
 
     def test_warn_has_remediation(self):
         r = self._run([self._entry("Logon", "No Auditing")])[0]
-        assert "auditpol" in r.remediation
+        assert "auditpol" in r.command
 
     def test_error_returns_error(self):
         with patch("apotrope.checks.misc.run_powershell_json",

--- a/tests/test_checks/test_powershell.py
+++ b/tests/test_checks/test_powershell.py
@@ -83,7 +83,7 @@ class TestCheckScriptBlockLogging:
 
     def test_warn_has_remediation(self):
         r = self._run("NOTSET")[0]
-        assert "EnableScriptBlockLogging" in r.remediation
+        assert "EnableScriptBlockLogging" in r.command
 
     def test_error_returns_error(self):
         with patch("apotrope.checks.powershell.run_powershell",
@@ -115,7 +115,7 @@ class TestCheckModuleLogging:
 
     def test_warn_has_remediation(self):
         r = self._run("0")[0]
-        assert "EnableModuleLogging" in r.remediation
+        assert "EnableModuleLogging" in r.command
 
 
 # ---------------------------------------------------------------------------
@@ -180,7 +180,7 @@ class TestCheckPsv2:
 
     def test_warn_has_remediation(self):
         r = self._run("Enabled")[0]
-        assert "Disable-WindowsOptionalFeature" in r.remediation
+        assert "Disable-WindowsOptionalFeature" in r.command
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_checks/test_rdp.py
+++ b/tests/test_checks/test_rdp.py
@@ -41,7 +41,7 @@ class TestCheckRdpEnabled:
 
     def test_rdp_enabled_has_remediation(self):
         results, _ = rdp._check_rdp_enabled(_data(deny=0))
-        assert "fDenyTSConnections" in results[0].remediation
+        assert "fDenyTSConnections" in results[0].command
 
     def test_key_absent_treated_as_disabled(self):
         results, enabled = rdp._check_rdp_enabled({})
@@ -72,11 +72,11 @@ class TestCheckRdpNla:
     def test_nla_absent_is_warn(self):
         r = rdp._check_rdp_nla({})[0]
         assert r.status == Status.WARN
-        assert "UserAuthentication" in r.remediation
+        assert "UserAuthentication" in r.command
 
     def test_nla_fail_includes_remediation(self):
         r = rdp._check_rdp_nla(_data(nla=0))[0]
-        assert "UserAuthentication" in r.remediation
+        assert "UserAuthentication" in r.command
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_checks/test_services.py
+++ b/tests/test_checks/test_services.py
@@ -103,7 +103,7 @@ class TestCheckUnquotedPaths:
 
     def test_fail_has_remediation(self):
         r = self._run([_unquoted("MySvc", "C:\\My Path\\svc.exe")])[0]
-        assert "ImagePath" in r.remediation
+        assert "ImagePath" in r.command
 
     def test_multiple_unquoted_paths_counted(self):
         items = [

--- a/tests/test_checks/test_smb.py
+++ b/tests/test_checks/test_smb.py
@@ -45,7 +45,9 @@ class TestCheckSmb1:
 
     def test_smb1_enabled_has_remediation(self):
         r = self._run(_data(smb1=True))[0]
-        assert "Set-SmbServerConfiguration" in r.remediation
+        assert r.remediation and "Set-" not in r.remediation
+        assert "Disable-WindowsOptionalFeature" in r.command
+        assert "SMB1Protocol" in r.command
 
     def test_null_value_is_warn(self):
         r = smb._check_smb1({"EnableSMB1Protocol": None})[0]
@@ -78,10 +80,11 @@ class TestCheckSmbSigning:
         assert r.status == Status.FAIL
         assert r.severity == Severity.HIGH
 
-    def test_fail_has_both_commands_in_remediation(self):
+    def test_fail_has_both_commands_in_command(self):
         r = self._run(_data(require_signing=False, enable_signing=False))[0]
-        assert "EnableSecuritySignature" in r.remediation
-        assert "RequireSecuritySignature" in r.remediation
+        assert "Set-SmbClientConfiguration" in r.command
+        assert "Set-SmbServerConfiguration" in r.command
+        assert "RequireSecuritySignature" in r.command
 
     def test_null_required_is_warn(self):
         r = smb._check_smb_signing({"RequireSecuritySignature": None})[0]

--- a/tests/test_checks/test_uac.py
+++ b/tests/test_checks/test_uac.py
@@ -39,7 +39,7 @@ class TestCheckUacEnabled:
         r = uac._check_uac_enabled(_data(lua=0))[0]
         assert r.status == Status.FAIL
         assert r.severity == Severity.CRITICAL
-        assert "EnableLUA" in r.remediation
+        assert "EnableLUA" in r.command
 
     def test_uac_absent_is_warn(self):
         r = uac._check_uac_enabled({})[0]
@@ -76,7 +76,7 @@ class TestCheckAdminBehavior:
 
     def test_warn_has_remediation(self):
         r = uac._check_admin_behavior(_data(admin_behavior=0))[0]
-        assert "ConsentPromptBehaviorAdmin" in r.remediation
+        assert "ConsentPromptBehaviorAdmin" in r.command
 
     def test_level_description_in_details(self):
         r = uac._check_admin_behavior(_data(admin_behavior=2))[0]
@@ -104,7 +104,7 @@ class TestCheckSecureDesktop:
 
     def test_off_has_remediation(self):
         r = uac._check_secure_desktop(_data(secure_desktop=0))[0]
-        assert "PromptOnSecureDesktop" in r.remediation
+        assert "PromptOnSecureDesktop" in r.command
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -217,7 +217,7 @@ class TestMain:
             importlib.reload(cli_mod)
             cli_mod.main()
 
-        MockReporter.assert_called_once_with(verbose=True, no_color=False)
+        MockReporter.assert_called_once_with(verbose=True, no_color=False, fix=False)
 
     def test_exit_1_when_score_below_70(self):
         """Score 69 → exit 1."""


### PR DESCRIPTION
## Copy-paste-ready remediation commands

Every failing/warning check now hands the user a **ready-to-paste PowerShell command** instead of burying it inside a sentence. The change is structural: `CheckResult.remediation` is split into plain-English prose (`remediation`) plus a new verbatim PowerShell field (`command`), surfaced across all three output surfaces.

### What changed
- **`models.py`** — new `command: str = ""` field on `CheckResult` (after `remediation`). JSON output picks it up automatically via `dataclasses.asdict`.
- **14 check modules** (`checks/*.py`) — every FAIL/WARN branch now sets a clean one-sentence `remediation` plus a verbatim `command`. Multi-step fixes use real newlines; firmware/manual cases (Secure Boot, OS upgrade) use a `#`-commented note plus a verification cmdlet so the block still pastes harmlessly. PASS/INFO/ERROR branches stay `command=""`.
- **HTML report** (`reporter.py` + `report.html.j2`) — the Remediation row renders the prose note, then a labeled code block (`▷ Windows PowerShell · run as Administrator`, green left rail, COPY button). Copy now grabs **only** the command text (`.code-cmd`). Print styles and CSS updated to match.
- **Terminal** (`cli.py` + `reporter.py`) — new `--fix` flag prints a `TOP FIXES` block with bare, paste-valid command lines (no glyph/rail/prompt). `--verbose` prints every command verbatim under its finding; the footer hint is `--fix`-aware. `--no-color` keeps commands verbatim.
- **JSON** — each finding now serializes a `command` key for SIEM/pipeline use.

### Verification
- **560/560 tests pass.** Tests that asserted command text inside `remediation` were moved to assert against `command`.
- Live audit confirms all FAIL/WARN findings produce a non-empty `command`, and every result carries a `command` key in JSON.
- HTML render verified against the design reference (prose note + labeled PowerShell block; PASS findings show no block).

Implements the `design_handoff_copy_paste_remediation` spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
