### PR TITLE
test: cover Rich terminal rendering paths in reporter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,5 +30,7 @@ jobs:
       - name: Install package and dev dependencies
         run: pip install -e ".[dev]"
 
-      - name: Run tests
-        run: pytest tests/ -q --tb=short
+      - name: Run tests with coverage
+        # Branch coverage is enabled in pyproject.toml ([tool.coverage.run]).
+        # The threshold can only ratchet up — raise it as coverage improves.
+        run: pytest tests/ -q --tb=short --cov --cov-report=term-missing --cov-fail-under=95

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,11 @@ addopts = "-v"
 
 [tool.coverage.run]
 source = ["src/apotrope"]
+branch = true
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+]

--- a/tests/test_checks/test_accounts.py
+++ b/tests/test_checks/test_accounts.py
@@ -274,3 +274,36 @@ class TestRun:
             results = accounts.run()
         assert all(isinstance(r, CheckResult) for r in results)
         assert len(results) >= 6
+
+
+# ---------------------------------------------------------------------------
+# Password policy parse fallback and complexity error path
+# ---------------------------------------------------------------------------
+
+class TestPasswordPolicyFallbacks:
+    _NET_BAD_LEN = (
+        "Minimum password length: None\n"
+        "Lockout threshold: 5\n"
+        "Lockout duration (minutes): 30\n"
+    )
+
+    def test_non_numeric_min_length_treated_as_zero(self):
+        with patch("apotrope.checks.accounts.run_powershell",
+                   side_effect=[self._NET_BAD_LEN, "1"]):
+            results = accounts._check_password_policy()
+        length = next(r for r in results if "Length" in r.check_name)
+        assert length.status == Status.FAIL
+        assert "0" in length.details
+
+    def test_complexity_query_error_appends_error_result(self):
+        net_good = (
+            "Minimum password length: 14\n"
+            "Lockout threshold: 5\n"
+            "Lockout duration (minutes): 30\n"
+        )
+        with patch("apotrope.checks.accounts.run_powershell",
+                   side_effect=[net_good, ApotropeError("secedit denied")]):
+            results = accounts._check_password_policy()
+        complexity = next(r for r in results if "Complexity" in r.check_name)
+        assert complexity.status == Status.ERROR
+        assert "secedit denied" in complexity.details

--- a/tests/test_checks/test_firewall.py
+++ b/tests/test_checks/test_firewall.py
@@ -167,3 +167,15 @@ class TestFirewallRunErrors:
                    side_effect=ApotropeError("access denied")):
             results = firewall.run()
         assert "access denied" in results[0].details
+
+
+# ---------------------------------------------------------------------------
+# _parse_action fallback for unparseable values
+# ---------------------------------------------------------------------------
+
+class TestParseActionFallback:
+    def test_unintable_object_returns_unknown(self):
+        assert firewall._parse_action([1, 2]) == "Unknown([1, 2])"
+
+    def test_unintable_object_does_not_raise(self):
+        assert firewall._parse_action(object()).startswith("Unknown(")

--- a/tests/test_checks/test_misc.py
+++ b/tests/test_checks/test_misc.py
@@ -240,3 +240,43 @@ class TestRun:
         ):
             results = misc.run()
         assert all(r.category == "Hardening" for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Parse fallbacks and list-shaped JSON payloads
+# ---------------------------------------------------------------------------
+
+class TestAutoplayParseFallback:
+    def test_non_numeric_registry_value_not_treated_as_disabled(self):
+        with patch("apotrope.checks.misc.run_powershell",
+                   return_value="garbage"):
+            r = misc._check_autoplay()[0]
+        assert r.status != Status.PASS
+        assert r.status != Status.ERROR
+
+
+class TestSpectreParseFallback:
+    def test_non_numeric_override_not_flagged_as_disabled(self):
+        payload = {"Override": "garbage", "Mask": "junk"}
+        with patch("apotrope.checks.misc.run_powershell_json",
+                   return_value=payload):
+            r = misc._check_spectre()[0]
+        assert r.status != Status.ERROR
+        assert r.status != Status.FAIL
+
+
+class TestScreenLockPayloadShapes:
+    def test_json_as_list_unwrapped(self):
+        payload = [{"Active": "1", "Secure": "1", "Timeout": "600"}]
+        with patch("apotrope.checks.misc.run_powershell_json",
+                   return_value=payload):
+            r = misc._check_screen_lock()[0]
+        assert r.status == Status.PASS
+
+    def test_non_numeric_timeout_warns_as_unset(self):
+        payload = {"Active": "1", "Secure": "1", "Timeout": "garbage"}
+        with patch("apotrope.checks.misc.run_powershell_json",
+                   return_value=payload):
+            r = misc._check_screen_lock()[0]
+        assert r.status == Status.WARN
+        assert "0 or unset" in r.details

--- a/tests/test_checks/test_network.py
+++ b/tests/test_checks/test_network.py
@@ -193,3 +193,16 @@ class TestRun:
             results = network.run()
         assert all(isinstance(r, CheckResult) for r in results)
         assert len(results) >= 4
+
+
+# ---------------------------------------------------------------------------
+# _check_ipv6 error fallback
+# ---------------------------------------------------------------------------
+
+class TestIpv6ErrorFallback:
+    def test_powershell_error_reports_inactive(self):
+        with patch("apotrope.checks.network.run_powershell",
+                   side_effect=ApotropeError("denied")):
+            r = network._check_ipv6()[0]
+        assert r.status == Status.INFO
+        assert "not active" in r.details

--- a/tests/test_checks/test_os_info.py
+++ b/tests/test_checks/test_os_info.py
@@ -287,3 +287,51 @@ class TestOsInfoRun:
             results = os_info.run()
         assert len(results) > 0
         assert all(r.status == Status.ERROR for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Parse fallbacks and list-shaped JSON payloads
+# ---------------------------------------------------------------------------
+
+class TestBuildParseFallback:
+    def test_non_numeric_build_does_not_crash(self):
+        data = _os_json(build="garbage")
+        with patch("apotrope.checks.os_info.run_powershell_json",
+                   return_value=data), \
+             patch("apotrope.checks.os_info._now",
+                   return_value=datetime(2026, 1, 1, tzinfo=timezone.utc)):
+            results = os_info._check_os_build()
+        assert results
+        assert all(r.status != Status.ERROR for r in results)
+        version = next(r for r in results if r.check_name == "OS Version")
+        assert version.status == Status.INFO
+
+
+class TestListShapedPayloads:
+    def test_domain_json_as_list_unwrapped(self):
+        with patch("apotrope.checks.os_info.run_powershell_json",
+                   return_value=[_domain_json(part_of_domain=True, domain="CORP")]):
+            results = os_info._check_domain()
+        assert results[0].status != Status.ERROR
+        assert "CORP" in results[0].details
+
+    def test_domain_empty_list_treated_as_unknown(self):
+        with patch("apotrope.checks.os_info.run_powershell_json",
+                   return_value=[]):
+            results = os_info._check_domain()
+        assert results[0].status != Status.ERROR
+        assert "UNKNOWN" in results[0].details
+
+    def test_tpm_json_as_list_unwrapped(self):
+        payload = [{"TpmPresent": True, "TpmReady": True,
+                    "ManufacturerVersion": "7.2"}]
+        with patch("apotrope.checks.os_info.run_powershell_json",
+                   return_value=payload):
+            results = os_info._check_tpm()
+        assert results[0].status != Status.ERROR
+        assert "TPM" in results[0].check_name
+
+
+class TestNowHelper:
+    def test_now_returns_utc_aware_datetime(self):
+        assert os_info._now().tzinfo is timezone.utc

--- a/tests/test_checks/test_powershell.py
+++ b/tests/test_checks/test_powershell.py
@@ -206,3 +206,29 @@ class TestRun:
         with patch("apotrope.checks.powershell.run_powershell", side_effect=side_effects):
             results = powershell.run()
         assert all(r.category == "PowerShell" for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Error handling for the remaining sub-checks
+# ---------------------------------------------------------------------------
+
+class TestSubCheckErrorPaths:
+    def _error_run(self, fn):
+        with patch("apotrope.checks.powershell.run_powershell",
+                   side_effect=ApotropeError("access denied")):
+            return fn()[0]
+
+    def test_module_logging_error(self):
+        r = self._error_run(powershell._check_module_logging)
+        assert r.status == Status.ERROR
+        assert "access denied" in r.details
+
+    def test_constrained_language_error(self):
+        r = self._error_run(powershell._check_constrained_language)
+        assert r.status == Status.ERROR
+        assert "access denied" in r.details
+
+    def test_psv2_error(self):
+        r = self._error_run(powershell._check_psv2)
+        assert r.status == Status.ERROR
+        assert "access denied" in r.details

--- a/tests/test_checks/test_updates.py
+++ b/tests/test_checks/test_updates.py
@@ -193,3 +193,39 @@ class TestUpdatesRun:
         assert results[0].status == Status.ERROR
         assert results[1].status == Status.PASS   # Running
         assert results[2].status == Status.PASS   # 0 pending
+
+
+# ---------------------------------------------------------------------------
+# configure() — profile threshold overrides
+# ---------------------------------------------------------------------------
+
+class TestConfigure:
+    def setup_method(self):
+        self._orig = (updates._WARN_DAYS, updates._FAIL_DAYS)
+
+    def teardown_method(self):
+        updates._WARN_DAYS, updates._FAIL_DAYS = self._orig
+
+    def test_thresholds_override_module_defaults(self):
+        updates.configure({"max_update_age_warn": 45, "max_update_age_fail": 90})
+        assert updates._WARN_DAYS == 45
+        assert updates._FAIL_DAYS == 90
+
+    def test_partial_thresholds_only_change_named_key(self):
+        updates.configure({"max_update_age_warn": 10})
+        assert updates._WARN_DAYS == 10
+        assert updates._FAIL_DAYS == self._orig[1]
+
+    def test_unknown_keys_ignored(self):
+        updates.configure({"unrelated_threshold": 5})
+        assert (updates._WARN_DAYS, updates._FAIL_DAYS) == self._orig
+
+    def test_values_coerced_to_int(self):
+        updates.configure({"max_update_age_warn": "45"})
+        assert updates._WARN_DAYS == 45
+
+
+class TestNowHelper:
+    def test_now_returns_utc_aware_datetime(self):
+        now = updates._now()
+        assert now.tzinfo is timezone.utc

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -280,3 +280,161 @@ class TestMain:
         mock_scanner.run_with_progress = MagicMock()
         # run_with_progress should NOT have been called on the reporter
         # (checking via scanner.dry_run was called is sufficient)
+
+
+# ---------------------------------------------------------------------------
+# main() error paths, exit codes, and output wiring
+# ---------------------------------------------------------------------------
+
+class TestMainErrorPaths:
+    _SCANNER_PATH  = "apotrope.scanner.Scanner"
+    _REPORTER_PATH = "apotrope.reporter.Reporter"
+    _ADMIN_PATH    = "apotrope.utils.is_admin"
+    _PROFILE_PATH  = "apotrope.profile.load_profile"
+
+    def _patches(self, argv, mock_reporter):
+        mock_scanner = MagicMock(is_admin=False)
+        return (
+            patch("sys.argv", ["apotrope"] + argv),
+            patch(self._SCANNER_PATH, return_value=mock_scanner),
+            patch(self._REPORTER_PATH, return_value=mock_reporter),
+            patch(self._ADMIN_PATH, return_value=False),
+            patch(self._PROFILE_PATH, return_value=MagicMock()),
+        )
+
+    def _reporter_with_report(self, score=80):
+        mock_report = MagicMock(fail_count=0, error_count=0, score=score)
+        mock_reporter = MagicMock()
+        mock_reporter.run_with_progress.return_value = mock_report
+        return mock_reporter, mock_report
+
+    def _run_main(self, argv, mock_reporter):
+        from apotrope.cli import main
+
+        p1, p2, p3, p4, p5 = self._patches(argv, mock_reporter)
+        with p1, p2, p3, p4, p5:
+            main()
+
+    def test_compare_missing_baseline_exits_2(self, tmp_path, capsys):
+        mock_reporter, _ = self._reporter_with_report()
+        missing = str(tmp_path / "no-such-baseline.json")
+        with pytest.raises(SystemExit) as exc:
+            self._run_main(["--compare", missing], mock_reporter)
+        assert exc.value.code == 2
+        assert "Cannot load baseline" in capsys.readouterr().err
+        mock_reporter.run_with_progress.assert_not_called()
+
+    def test_compare_corrupt_baseline_exits_2(self, tmp_path, capsys):
+        bad = tmp_path / "corrupt.json"
+        bad.write_text("{not valid json", encoding="utf-8")
+        mock_reporter, _ = self._reporter_with_report()
+        with pytest.raises(SystemExit) as exc:
+            self._run_main(["--compare", str(bad)], mock_reporter)
+        assert exc.value.code == 2
+        assert "Cannot load baseline" in capsys.readouterr().err
+
+    def test_fatal_scan_error_exits_2(self, capsys):
+        mock_reporter = MagicMock()
+        mock_reporter.run_with_progress.side_effect = RuntimeError("kaboom")
+        with pytest.raises(SystemExit) as exc:
+            self._run_main([], mock_reporter)
+        assert exc.value.code == 2
+        err = capsys.readouterr().err
+        assert "[FATAL]" in err
+        assert "kaboom" in err
+
+    def test_compare_success_prints_comparison(self, tmp_path):
+        baseline = MagicMock()
+        diff = MagicMock()
+        mock_reporter, mock_report = self._reporter_with_report()
+        # Baseline file must exist only as a path argument; loading is mocked.
+        with (
+            patch("apotrope.compare.load_baseline", return_value=baseline),
+            patch("apotrope.compare.compare_reports", return_value=diff) as cmp_mock,
+        ):
+            self._run_main(["--compare", "baseline.json"], mock_reporter)
+        cmp_mock.assert_called_once_with(baseline, mock_report)
+        mock_reporter.print_comparison.assert_called_once_with(diff)
+
+    def test_no_comparison_without_flag(self):
+        mock_reporter, _ = self._reporter_with_report()
+        self._run_main([], mock_reporter)
+        mock_reporter.print_comparison.assert_not_called()
+
+    def test_baseline_flag_saves_baseline(self):
+        mock_reporter, mock_report = self._reporter_with_report()
+        with patch("apotrope.compare.save_baseline") as save_mock:
+            self._run_main(["--baseline", "base.json"], mock_reporter)
+        save_mock.assert_called_once_with(mock_report, "base.json")
+
+    def test_no_baseline_saved_by_default(self):
+        mock_reporter, _ = self._reporter_with_report()
+        with patch("apotrope.compare.save_baseline") as save_mock:
+            self._run_main([], mock_reporter)
+        save_mock.assert_not_called()
+
+    def test_html_and_json_paths_passed_to_print_terminal(self):
+        mock_reporter, mock_report = self._reporter_with_report()
+        self._run_main(["--html", "out.html", "--json", "out.json"], mock_reporter)
+        mock_reporter.print_terminal.assert_called_once_with(
+            mock_report, html_path="out.html", json_path="out.json"
+        )
+
+    def test_fix_flag_passed_to_reporter(self):
+        from apotrope.cli import main
+
+        mock_reporter, _ = self._reporter_with_report()
+        p1, p2, p3, p4, p5 = self._patches(["--fix"], mock_reporter)
+        with p1, p2, p3 as MockReporter, p4, p5:
+            main()
+        MockReporter.assert_called_once_with(verbose=False, no_color=False, fix=True)
+
+    def test_dry_run_prints_module_names(self, capsys):
+        mock_reporter, _ = self._reporter_with_report()
+        mock_scanner = MagicMock()
+        mock_scanner.dry_run.return_value = [
+            "apotrope.checks.firewall", "apotrope.checks.smb",
+        ]
+        from apotrope.cli import main
+
+        with (
+            patch("sys.argv", ["apotrope", "--dry-run"]),
+            patch(self._SCANNER_PATH, return_value=mock_scanner),
+            patch(self._REPORTER_PATH, return_value=mock_reporter),
+            patch(self._ADMIN_PATH, return_value=False),
+            patch(self._PROFILE_PATH, return_value=MagicMock()),
+        ):
+            main()
+        out = capsys.readouterr().out
+        assert "dry run" in out
+        assert "apotrope.checks.firewall" in out
+        assert "apotrope.checks.smb" in out
+        mock_reporter.run_with_progress.assert_not_called()
+
+    def test_profile_path_forwarded_to_load_profile(self):
+        from apotrope.cli import main
+
+        mock_reporter, _ = self._reporter_with_report()
+        p1, p2, p3, p4, p5 = self._patches(
+            ["--profile", "custom.toml"], mock_reporter
+        )
+        with p1, p2, p3, p4, p5 as load_mock:
+            main()
+        load_mock.assert_called_once_with("custom.toml")
+
+
+# ---------------------------------------------------------------------------
+# python -m apotrope entry point
+# ---------------------------------------------------------------------------
+
+class TestModuleEntryPoint:
+    def test_dash_m_version_exits_zero(self, capsys):
+        import runpy
+
+        with (
+            patch("sys.argv", ["apotrope", "--version"]),
+            pytest.raises(SystemExit) as exc,
+        ):
+            runpy.run_module("apotrope", run_name="__main__")
+        assert exc.value.code == 0
+        assert "apotrope" in capsys.readouterr().out

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -194,3 +194,23 @@ class TestBaselineSerialization:
                 load_baseline(path)
         finally:
             os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# One-sided good results count as unchanged
+# ---------------------------------------------------------------------------
+
+class TestOneSidedGoodResults:
+    def test_current_only_pass_counts_as_unchanged(self):
+        baseline = _make_report([])
+        current = _make_report([_make_result("New Pass", Status.PASS)])
+        diff = compare_reports(baseline, current)
+        assert diff.new_findings == []
+        assert diff.unchanged_count == 1
+
+    def test_baseline_only_pass_counts_as_unchanged(self):
+        baseline = _make_report([_make_result("Old Pass", Status.PASS)])
+        current = _make_report([])
+        diff = compare_reports(baseline, current)
+        assert diff.resolved_findings == []
+        assert diff.unchanged_count == 1

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,40 @@
+"""Tests for apotrope.models — CheckResult/AuditReport helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from apotrope.models import AuditReport, CheckResult, Severity, Status
+
+
+def _result(category: str, name: str = "Check") -> CheckResult:
+    return CheckResult(
+        category=category, check_name=name, status=Status.PASS,
+        severity=Severity.LOW, description="d", details="ok",
+    )
+
+
+def _report(results: list[CheckResult]) -> AuditReport:
+    return AuditReport(
+        hostname="PC",
+        os_version="Win11",
+        scan_timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        scan_duration=1.0,
+        results=results,
+    )
+
+
+class TestByCategory:
+    def test_returns_matching_results(self):
+        report = _report([_result("Firewall", "A"), _result("Accounts", "B")])
+        matches = report.by_category("Firewall")
+        assert [r.check_name for r in matches] == ["A"]
+
+    def test_match_is_case_insensitive(self):
+        report = _report([_result("Firewall")])
+        assert len(report.by_category("FIREWALL")) == 1
+        assert len(report.by_category("firewall")) == 1
+
+    def test_unknown_category_returns_empty(self):
+        report = _report([_result("Firewall")])
+        assert report.by_category("Nope") == []

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -128,3 +128,51 @@ class TestLoadProfileFromToml:
         )
         p = load_profile()
         assert p.name == "AutoDetected"
+
+
+# ---------------------------------------------------------------------------
+# TOML library fallback (tomllib → tomli)
+# ---------------------------------------------------------------------------
+
+class TestTomlLibraryFallback:
+    def _write_toml(self, tmp_path):
+        path = tmp_path / "apotrope-profile.toml"
+        path.write_text('[profile]\nname = "fallback"\n', encoding="utf-8")
+        return path
+
+    def test_tomli_used_when_tomllib_missing(self, tmp_path):
+        import sys
+        import tomllib
+        from types import ModuleType
+        from unittest.mock import patch
+
+        from apotrope.profile import _parse_toml
+
+        fake_tomli = ModuleType("tomli")
+        fake_tomli.load = tomllib.load
+        path = self._write_toml(tmp_path)
+        with patch.dict(sys.modules, {"tomllib": None, "tomli": fake_tomli}):
+            profile = _parse_toml(path)
+        assert profile.name == "fallback"
+
+    def test_import_error_when_no_toml_library(self, tmp_path):
+        import sys
+        from unittest.mock import patch
+
+        import pytest
+
+        from apotrope.profile import _parse_toml
+
+        path = self._write_toml(tmp_path)
+        with patch.dict(sys.modules, {"tomllib": None, "tomli": None}):
+            with pytest.raises(ImportError, match="tomli"):
+                _parse_toml(path)
+
+    def test_load_profile_falls_back_to_defaults_without_toml_library(self, tmp_path):
+        import sys
+        from unittest.mock import patch
+
+        path = self._write_toml(tmp_path)
+        with patch.dict(sys.modules, {"tomllib": None, "tomli": None}):
+            profile = load_profile(str(path))
+        assert profile.name == "default"

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -139,6 +139,56 @@ class TestGenerateHtmlReport:
         assert "Top Issues" in html
         assert "CRITICAL" in html
 
+    def test_no_file_written_when_jinja2_missing(self):
+        import sys
+        from unittest import mock
+
+        reporter = Reporter()
+        with tempfile.NamedTemporaryFile(suffix=".html", delete=False) as f:
+            path = f.name
+        os.unlink(path)
+        try:
+            with mock.patch.dict(sys.modules, {"jinja2": None}):
+                reporter.generate_html_report(_make_report(), path)
+            assert not os.path.exists(path)
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_no_file_written_when_template_load_fails(self):
+        from unittest import mock
+
+        from jinja2 import Environment
+
+        reporter = Reporter()
+        with tempfile.NamedTemporaryFile(suffix=".html", delete=False) as f:
+            path = f.name
+        os.unlink(path)
+        try:
+            with mock.patch.object(
+                Environment, "get_template", side_effect=OSError("boom")
+            ):
+                reporter.generate_html_report(_make_report(), path)
+            assert not os.path.exists(path)
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_frozen_bundle_uses_meipass_template_dir(self):
+        """PyInstaller path: templates resolve under sys._MEIPASS/templates."""
+        import sys
+        from unittest import mock
+
+        import apotrope.reporter as reporter_mod
+
+        # Point _MEIPASS at the package dir so _MEIPASS/templates is the real
+        # template directory and rendering still succeeds.
+        package_dir = Path(reporter_mod.__file__).parent
+        with mock.patch.object(sys, "frozen", True, create=True), \
+             mock.patch.object(sys, "_MEIPASS", str(package_dir), create=True):
+            html = self._generate(_make_report())
+        assert "<!DOCTYPE html>" in html
+
     def test_html_special_chars_escaped(self):
         """Regression: autoescape=True must escape user-controlled fields.
 

--- a/tests/test_reporter_terminal.py
+++ b/tests/test_reporter_terminal.py
@@ -1,0 +1,698 @@
+"""Tests for apotrope.reporter — Rich terminal rendering paths.
+
+Covers the terminal output surface that test_reporter.py (HTML/JSON) does not:
+the score panel, top-findings blocks, --fix block, --verbose category detail,
+footer variants, comparison view, progress runner, glyph/ASCII fallbacks, and
+the plain-text fallback used when Rich is not installed.
+
+All tests render to an in-memory console (StringIO file, colors stripped) so
+assertions run against plain text on any OS.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest import mock
+
+from apotrope.compare import ScanDiff
+from apotrope.models import AuditReport, CheckResult, Severity, Status
+from apotrope.reporter import (
+    Reporter,
+    _console_is_unicode,
+    _glyphs,
+    _grade_hex,
+    _truncate,
+    _u,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _AsciiStringIO(io.StringIO):
+    """A StringIO that reports a non-Unicode encoding (forces ASCII glyphs)."""
+
+    encoding = "cp437"
+
+
+def _make_console(ascii_console: bool = False, width: int = 200):
+    """Build a Rich console that records plain text into a StringIO."""
+    from rich.console import Console
+
+    file = _AsciiStringIO() if ascii_console else io.StringIO()
+    return Console(
+        file=file, force_terminal=False, width=width,
+        no_color=True, highlight=False,
+    )
+
+
+def _result(
+    category: str = "Firewall",
+    name: str = "Check",
+    status: Status = Status.PASS,
+    severity: Severity = Severity.HIGH,
+    details: str = "found",
+    remediation: str = "",
+    command: str = "",
+    cis: str = "",
+) -> CheckResult:
+    return CheckResult(
+        category=category,
+        check_name=name,
+        status=status,
+        severity=severity,
+        description="desc",
+        details=details,
+        remediation=remediation,
+        command=command,
+        cis_reference=cis,
+    )
+
+
+def _report(
+    results: list[CheckResult],
+    score: int = 70,
+    is_admin: bool = True,
+) -> AuditReport:
+    return AuditReport(
+        hostname="TEST-PC",
+        os_version="10.0.22621",
+        scan_timestamp=datetime(2026, 3, 17, 12, 0, 0, tzinfo=timezone.utc),
+        scan_duration=1.5,
+        results=results,
+        score=score,
+        is_admin=is_admin,
+    )
+
+
+def _render(
+    reporter: Reporter,
+    method: str,
+    *args,
+    ascii_console: bool = False,
+    **kwargs,
+) -> str:
+    """Call *method* on *reporter* with a captive console; return its text."""
+    console = _make_console(ascii_console=ascii_console)
+    with mock.patch.object(Reporter, "_make_console", return_value=console):
+        getattr(reporter, method)(*args, **kwargs)
+    return console.file.getvalue()
+
+
+def _default_results() -> list[CheckResult]:
+    return [
+        _result("Firewall", "Domain Profile", Status.PASS),
+        _result("Antivirus", "Defender Status", Status.FAIL, Severity.CRITICAL,
+                remediation="Enable Defender", command="Set-MpPreference X"),
+        _result("RDP", "RDP Enabled", Status.WARN, Severity.MEDIUM,
+                remediation="Disable RDP", command="Stop-Service TermService"),
+        _result("System", "OS Version", Status.INFO, Severity.INFO),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Score panel (default print_terminal view)
+# ---------------------------------------------------------------------------
+
+class TestScorePanel:
+    def test_score_and_grade_shown(self):
+        out = _render(Reporter(), "print_terminal", _report(_default_results(), score=70))
+        assert "70 / 100" in out
+        assert "C" in out  # grade letter
+
+    def test_hostname_and_os_version_shown(self):
+        out = _render(Reporter(), "print_terminal", _report(_default_results()))
+        assert "TEST-PC" in out
+        assert "10.0.22621" in out
+
+    def test_status_distribution_counts(self):
+        out = _render(Reporter(), "print_terminal", _report(_default_results()))
+        assert "1 pass" in out
+        assert "1 fail" in out
+        assert "1 warn" in out
+        assert "1 info" in out
+
+    def test_total_checks_evaluated(self):
+        out = _render(Reporter(), "print_terminal", _report(_default_results()))
+        assert "4 checks evaluated" in out
+
+    def test_error_count_in_distribution(self):
+        results = _default_results() + [
+            _result("SMB", "SMB Signing", Status.ERROR, Severity.INFO),
+        ]
+        out = _render(Reporter(), "print_terminal", _report(results))
+        assert "1 error" in out
+
+    def test_no_error_segment_when_clean(self):
+        out = _render(Reporter(), "print_terminal", _report(_default_results()))
+        assert "error" not in out.split("checks evaluated")[0]
+
+
+# ---------------------------------------------------------------------------
+# Top findings (TOP FAILURES / TOP WARNINGS)
+# ---------------------------------------------------------------------------
+
+class TestTopFindings:
+    def test_failures_and_warnings_headers(self):
+        out = _render(Reporter(), "print_terminal", _report(_default_results()))
+        assert "TOP FAILURES" in out
+        assert "TOP WARNINGS" in out
+
+    def test_no_headers_when_clean(self):
+        results = [_result(name="Only Pass", status=Status.PASS)]
+        out = _render(Reporter(), "print_terminal", _report(results, score=100))
+        assert "TOP FAILURES" not in out
+        assert "TOP WARNINGS" not in out
+
+    def test_failures_sorted_by_severity(self):
+        results = [
+            _result(name="Low Severity Fail", status=Status.FAIL, severity=Severity.LOW),
+            _result(name="Critical Severity Fail", status=Status.FAIL,
+                    severity=Severity.CRITICAL),
+        ]
+        out = _render(Reporter(), "print_terminal", _report(results))
+        assert out.index("Critical Severity Fail") < out.index("Low Severity Fail")
+
+    def test_capped_at_five_rows(self):
+        results = [
+            _result(name=f"Failure Number {i}", status=Status.FAIL, severity=Severity.HIGH)
+            for i in range(1, 8)
+        ]
+        out = _render(Reporter(), "print_terminal", _report(results))
+        assert "Failure Number 5" in out
+        assert "Failure Number 6" not in out
+        assert "Failure Number 7" not in out
+
+    def test_long_check_name_truncated(self):
+        long_name = "A" * 40
+        results = [_result(name=long_name, status=Status.FAIL)]
+        out = _render(Reporter(), "print_terminal", _report(results))
+        assert long_name not in out
+        assert "A" * 26 + "~" in out
+
+    def test_cis_reference_appended(self):
+        results = [_result(name="Tagged Fail", status=Status.FAIL, cis="CIS 9.2.1")]
+        out = _render(Reporter(), "print_terminal", _report(results))
+        assert "CIS 9.2.1" in out
+
+    def test_severity_abbreviations_used(self):
+        results = [
+            _result(name="Crit Fail", status=Status.FAIL, severity=Severity.CRITICAL),
+            _result(name="Med Warn", status=Status.WARN, severity=Severity.MEDIUM),
+        ]
+        out = _render(Reporter(), "print_terminal", _report(results))
+        assert "CRIT" in out
+        assert "MED" in out
+
+
+# ---------------------------------------------------------------------------
+# --fix: TOP FIXES block
+# ---------------------------------------------------------------------------
+
+class TestTopFixes:
+    def test_header_and_paste_hint(self):
+        out = _render(Reporter(fix=True), "print_terminal", _report(_default_results()))
+        assert "TOP FIXES" in out
+        assert "elevated PowerShell" in out
+
+    def test_commands_printed_verbatim(self):
+        out = _render(Reporter(fix=True), "print_terminal", _report(_default_results()))
+        assert "Set-MpPreference X" in out
+        assert "Stop-Service TermService" in out
+
+    def test_multiline_command_all_lines_present(self):
+        results = [_result(
+            name="Multi Step Fix", status=Status.FAIL,
+            command="First-Command -A 1\nSecond-Command -B 2",
+        )]
+        out = _render(Reporter(fix=True), "print_terminal", _report(results))
+        assert "First-Command -A 1" in out
+        assert "Second-Command -B 2" in out
+
+    def test_findings_without_command_excluded(self):
+        results = [
+            _result(name="Fixable Fail", status=Status.FAIL, command="Do-Fix"),
+            _result(name="Unfixable Fail", status=Status.FAIL, command=""),
+        ]
+        out = _render(Reporter(fix=True), "print_terminal", _report(results))
+        fixes_block = out[out.index("TOP FIXES"):]
+        assert "Fixable Fail" in fixes_block
+        assert "Unfixable Fail" not in fixes_block
+
+    def test_pass_results_never_included(self):
+        results = [_result(name="Passing Check", status=Status.PASS, command="Noop")]
+        out = _render(Reporter(fix=True), "print_terminal", _report(results, score=100))
+        assert "TOP FIXES" not in out
+
+    def test_fail_ordered_before_warn_within_severity(self):
+        results = [
+            _result(name="Warn Finding", status=Status.WARN,
+                    severity=Severity.CRITICAL, command="Fix-Warn"),
+            _result(name="Fail Finding", status=Status.FAIL,
+                    severity=Severity.CRITICAL, command="Fix-Fail"),
+        ]
+        out = _render(Reporter(fix=True), "print_terminal", _report(results))
+        assert out.index("Fail Finding") < out.index("Warn Finding")
+
+    def test_no_block_when_no_fix_candidates(self):
+        results = [_result(name="No Command Fail", status=Status.FAIL)]
+        out = _render(Reporter(fix=True), "print_terminal", _report(results))
+        assert "TOP FIXES" not in out
+
+    def test_footer_counts_overflow_fixes(self):
+        results = [
+            _result(name=f"Fix {i}", status=Status.FAIL, command=f"Cmd-{i}")
+            for i in range(7)
+        ]
+        out = _render(Reporter(fix=True), "print_terminal", _report(results))
+        assert "5 of 7 fixes shown" in out
+        assert "run --verbose for every fix" in out
+
+    def test_footer_hint_when_all_fixes_shown(self):
+        out = _render(Reporter(fix=True), "print_terminal", _report(_default_results()))
+        assert "run with --verbose for per-check detail" in out
+
+    def test_cis_reference_shown_on_fix_row(self):
+        results = [_result(name="Tagged Fix", status=Status.FAIL,
+                           command="Do-Fix", cis="CIS 18.9.1")]
+        out = _render(Reporter(fix=True), "print_terminal", _report(results))
+        assert "CIS 18.9.1" in out
+
+
+# ---------------------------------------------------------------------------
+# --verbose: per-category detail
+# ---------------------------------------------------------------------------
+
+class TestCategoryDetail:
+    def test_category_headers_with_score_badge(self):
+        out = _render(Reporter(verbose=True), "print_terminal",
+                      _report(_default_results()))
+        assert "Antivirus" in out
+        assert "Firewall" in out
+        assert "/100" in out
+
+    def test_categories_sorted_alphabetically(self):
+        out = _render(Reporter(verbose=True), "print_terminal",
+                      _report(_default_results()))
+        assert out.index("Antivirus") < out.index("Firewall") < out.index("RDP")
+
+    def test_severity_details_fix_labels(self):
+        out = _render(Reporter(verbose=True), "print_terminal",
+                      _report(_default_results()))
+        assert "severity" in out
+        assert "details" in out
+        assert "fix" in out
+        assert "CRITICAL" in out
+        assert "Enable Defender" in out
+
+    def test_command_printed_with_run_label(self):
+        out = _render(Reporter(verbose=True), "print_terminal",
+                      _report(_default_results()))
+        assert "run" in out
+        assert "Set-MpPreference X" in out
+
+    def test_multiline_command_kept_verbatim(self):
+        results = [_result(
+            name="Multi", status=Status.FAIL,
+            command="Step-One -Very -Long\nStep-Two",
+        )]
+        out = _render(Reporter(verbose=True), "print_terminal", _report(results))
+        assert "Step-One -Very -Long" in out
+        assert "Step-Two" in out
+
+    def test_long_details_wrapped(self):
+        results = [_result(name="Wordy", status=Status.FAIL,
+                           details="word " * 40)]
+        out = _render(Reporter(verbose=True), "print_terminal", _report(results))
+        detail_lines = [ln for ln in out.splitlines() if "word" in ln]
+        assert len(detail_lines) >= 2
+
+    def test_no_top_findings_in_verbose_mode(self):
+        out = _render(Reporter(verbose=True), "print_terminal",
+                      _report(_default_results()))
+        assert "TOP FAILURES" not in out
+
+    def test_cis_reference_shown_next_to_check(self):
+        results = [_result(name="Tagged Check", status=Status.FAIL, cis="CIS 2.3.1")]
+        out = _render(Reporter(verbose=True), "print_terminal", _report(results))
+        assert "CIS 2.3.1" in out
+
+
+# ---------------------------------------------------------------------------
+# Footer
+# ---------------------------------------------------------------------------
+
+class TestFooter:
+    def test_html_path_with_issues(self):
+        out = _render(Reporter(), "print_terminal", _report(_default_results()),
+                      html_path="report.html")
+        assert "report.html written" in out
+        assert "open to triage all 2 issues" in out
+
+    def test_html_path_clean(self):
+        results = [_result(status=Status.PASS)]
+        out = _render(Reporter(), "print_terminal", _report(results, score=100),
+                      html_path="report.html")
+        assert "clean — no issues to triage" in out
+
+    def test_issues_without_html_suggests_html_flag(self):
+        out = _render(Reporter(), "print_terminal", _report(_default_results()))
+        assert "2 issues to triage" in out
+        assert "--html report.html" in out
+
+    def test_singular_issue_pluralization(self):
+        results = [_result(name="Solo Fail", status=Status.FAIL)]
+        out = _render(Reporter(), "print_terminal", _report(results))
+        assert "1 issue to triage" in out
+
+    def test_clean_without_html(self):
+        results = [_result(status=Status.PASS)]
+        out = _render(Reporter(), "print_terminal", _report(results, score=100))
+        assert "clean — no issues found" in out
+
+    def test_json_path_mentioned(self):
+        out = _render(Reporter(), "print_terminal", _report(_default_results()),
+                      json_path="report.json")
+        assert "report.json written" in out
+
+    def test_error_caveat(self):
+        results = [_result(name="Broken", status=Status.ERROR, severity=Severity.INFO)]
+        out = _render(Reporter(), "print_terminal", _report(results, score=100))
+        assert "1 check could not complete" in out
+        assert "run as Administrator" in out
+
+    def test_error_caveat_pluralized(self):
+        results = [
+            _result(name=f"Broken {i}", status=Status.ERROR, severity=Severity.INFO)
+            for i in range(2)
+        ]
+        out = _render(Reporter(), "print_terminal", _report(results, score=100))
+        assert "2 checks could not complete" in out
+
+    def test_non_admin_note(self):
+        out = _render(Reporter(), "print_terminal",
+                      _report(_default_results(), is_admin=False))
+        assert "some checks skipped" in out
+
+    def test_no_non_admin_note_when_admin(self):
+        out = _render(Reporter(), "print_terminal",
+                      _report(_default_results(), is_admin=True))
+        assert "some checks skipped" not in out
+
+    def test_default_hint_mentions_verbose_and_fix(self):
+        out = _render(Reporter(), "print_terminal", _report(_default_results()))
+        assert "--verbose for per-check detail" in out
+        assert "--fix for paste-ready commands" in out
+
+
+# ---------------------------------------------------------------------------
+# print_comparison
+# ---------------------------------------------------------------------------
+
+def _diff(
+    baseline_score: int = 60,
+    current_score: int = 75,
+    new: list[CheckResult] | None = None,
+    resolved: list[CheckResult] | None = None,
+    worsened: list[CheckResult] | None = None,
+    unchanged_bad: list[CheckResult] | None = None,
+    unchanged_count: int = 0,
+) -> ScanDiff:
+    return ScanDiff(
+        baseline_score=baseline_score,
+        current_score=current_score,
+        score_delta=current_score - baseline_score,
+        new_findings=new or [],
+        resolved_findings=resolved or [],
+        worsened_findings=worsened or [],
+        unchanged_bad=unchanged_bad or [],
+        unchanged_count=unchanged_count,
+    )
+
+
+class TestPrintComparison:
+    def test_score_transition_with_positive_delta(self):
+        out = _render(Reporter(), "print_comparison", _diff(60, 75))
+        assert "60" in out
+        assert "75" in out
+        assert "+15" in out
+
+    def test_negative_delta_has_no_plus_sign(self):
+        out = _render(Reporter(), "print_comparison", _diff(80, 65))
+        assert "-15" in out
+        assert "+-15" not in out
+
+    def test_sections_rendered_with_findings(self):
+        resolved = [_result(name="Fixed Check", status=Status.PASS)]
+        new = [_result(name="Fresh Fail", status=Status.FAIL)]
+        worsened = [_result(name="Regressed Check", status=Status.WARN)]
+        ongoing = [_result(name="Still Bad", status=Status.FAIL)]
+        out = _render(Reporter(), "print_comparison",
+                      _diff(resolved=resolved, new=new, worsened=worsened,
+                            unchanged_bad=ongoing))
+        for label in ("Resolved", "New", "Worsened", "Ongoing"):
+            assert label in out
+        for name in ("Fixed Check", "Fresh Fail", "Regressed Check", "Still Bad"):
+            assert name in out
+
+    def test_no_changes_message(self):
+        out = _render(Reporter(), "print_comparison", _diff(70, 70, unchanged_count=4))
+        assert "No changes detected" in out
+
+    def test_summary_counts_line(self):
+        out = _render(Reporter(), "print_comparison",
+                      _diff(new=[_result(name="N", status=Status.FAIL)],
+                            unchanged_count=3))
+        assert "Resolved: 0" in out
+        assert "New: 1" in out
+        assert "Unchanged: 3" in out
+
+
+# ---------------------------------------------------------------------------
+# run_with_progress
+# ---------------------------------------------------------------------------
+
+class _StubScanner:
+    """Scanner stand-in: fixed module list, canned report, records callbacks."""
+
+    def __init__(self, report: AuditReport, is_admin: bool = True) -> None:
+        self._report = report
+        self.is_admin = is_admin
+        self.started: list[object] = []
+        self.run_called_with_modules: object = "unset"
+
+    def discover_modules(self) -> list:
+        return [SimpleNamespace(__name__="mod_a"), SimpleNamespace(__name__="mod_b")]
+
+    def run(self, modules=None, on_module_start=None) -> AuditReport:
+        self.run_called_with_modules = modules
+        if on_module_start is not None:
+            for m in modules or []:
+                on_module_start(m)
+                self.started.append(m)
+        return self._report
+
+
+class TestRunWithProgress:
+    def test_returns_report_and_prints_banner(self):
+        scanner = _StubScanner(_report(_default_results()))
+        console = _make_console()
+        with mock.patch.object(Reporter, "_make_console", return_value=console):
+            report = Reporter().run_with_progress(scanner)
+        out = console.file.getvalue()
+        assert report is scanner._report
+        assert "APOTROPE" in out
+        assert "Windows Security Posture Auditor" in out
+
+    def test_completion_line_shows_count_and_duration(self):
+        scanner = _StubScanner(_report(_default_results()))
+        out = _render(Reporter(), "run_with_progress", scanner)
+        assert "scanning 4 controls" in out
+        assert "done" in out
+        assert "1.5s" in out
+
+    def test_passes_discovered_modules_to_run(self):
+        scanner = _StubScanner(_report(_default_results()))
+        _render(Reporter(), "run_with_progress", scanner)
+        assert scanner.run_called_with_modules != "unset"
+        assert len(scanner.run_called_with_modules) == 2
+        assert len(scanner.started) == 2
+
+    def test_non_admin_warning_shown(self):
+        scanner = _StubScanner(_report(_default_results()), is_admin=False)
+        out = _render(Reporter(), "run_with_progress", scanner)
+        assert "running without administrator privileges" in out
+        assert "run elevated for a full audit" in out
+
+    def test_no_warning_when_admin(self):
+        scanner = _StubScanner(_report(_default_results()), is_admin=True)
+        out = _render(Reporter(), "run_with_progress", scanner)
+        assert "running without administrator privileges" not in out
+
+    def test_falls_back_to_plain_run_without_rich_progress(self):
+        scanner = _StubScanner(_report(_default_results()))
+        with mock.patch.dict(sys.modules, {"rich.progress": None}):
+            report = Reporter().run_with_progress(scanner)
+        assert report is scanner._report
+        # Fallback path calls scanner.run() with default (None) modules.
+        assert scanner.run_called_with_modules is None
+
+
+# ---------------------------------------------------------------------------
+# Plain-text fallback (Rich unavailable)
+# ---------------------------------------------------------------------------
+
+class TestPlainFallback:
+    def test_print_terminal_falls_back_without_rich(self, capsys):
+        report = _report(_default_results())
+        with mock.patch.dict(sys.modules, {"rich.console": None}):
+            Reporter().print_terminal(report)
+        out = capsys.readouterr().out
+        assert "TEST-PC" in out
+        assert "Score: 70/100" in out
+
+    def test_plain_lists_every_result_with_icon(self, capsys):
+        Reporter()._print_plain(_report(_default_results()))
+        out = capsys.readouterr().out
+        assert "PASS: 1  FAIL: 1  WARN: 1" in out
+        assert "[✓]" in out
+        assert "[✗]" in out
+        assert "[!]" in out
+        assert "Antivirus: Defender Status" in out
+
+    def test_plain_verbose_shows_details_fix_and_command(self, capsys):
+        Reporter(verbose=True)._print_plain(_report(_default_results()))
+        out = capsys.readouterr().out
+        assert "RealTimeProtectionEnabled" not in out  # not in our fixture details
+        assert "found" in out
+        assert "Fix: Enable Defender" in out
+        assert "Set-MpPreference X" in out
+
+    def test_plain_non_verbose_hides_details(self, capsys):
+        Reporter()._print_plain(_report(_default_results()))
+        out = capsys.readouterr().out
+        assert "Fix: Enable Defender" not in out
+
+
+# ---------------------------------------------------------------------------
+# ASCII fallback rendering (non-Unicode console)
+# ---------------------------------------------------------------------------
+
+class TestAsciiFallback:
+    def test_print_terminal_uses_ascii_glyphs(self):
+        out = _render(Reporter(), "print_terminal", _report(_default_results()),
+                      ascii_console=True)
+        assert "[+]" in out   # pass glyph
+        assert "[x]" in out   # fail glyph
+        assert "#" in out     # score bar fill
+        assert "✓" not in out
+        assert "█" not in out
+
+    def test_footer_arrow_is_ascii(self):
+        out = _render(Reporter(), "print_terminal", _report(_default_results()),
+                      ascii_console=True)
+        assert "->" in out
+        assert "→" not in out
+
+
+# ---------------------------------------------------------------------------
+# Executive summary branches not covered by the HTML-focused tests
+# ---------------------------------------------------------------------------
+
+class TestExecutiveSummaryBranches:
+    def _results_multi_cat_with_error(self) -> list[CheckResult]:
+        return [
+            _result("Firewall", "FW Fail", Status.FAIL, Severity.HIGH,
+                    remediation="fix"),
+            _result("RDP", "RDP Warn", Status.WARN, Severity.MEDIUM,
+                    remediation="fix"),
+            _result("SMB", "SMB Error", Status.ERROR, Severity.INFO),
+        ]
+
+    def test_plain_summary_joins_multiple_categories(self):
+        s = Reporter()._build_executive_summary(
+            _report(self._results_multi_cat_with_error()))
+        assert "primary areas of concern" in s
+        assert "Firewall" in s and "RDP" in s
+        assert " and " in s
+
+    def test_plain_summary_notes_incomplete_checks(self):
+        s = Reporter()._build_executive_summary(
+            _report(self._results_multi_cat_with_error()))
+        assert "1 check could not complete" in s
+
+    def test_html_summary_joins_multiple_categories(self):
+        s = str(Reporter()._build_executive_summary_html(
+            _report(self._results_multi_cat_with_error())))
+        assert "primary areas of concern" in s
+        assert "<b>Firewall</b>" in s and "<b>RDP</b>" in s
+
+    def test_html_summary_notes_incomplete_checks(self):
+        s = str(Reporter()._build_executive_summary_html(
+            _report(self._results_multi_cat_with_error())))
+        assert "1 check could not complete" in s
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+class TestMakeConsole:
+    def test_returns_console_honouring_no_color(self):
+        from rich.console import Console
+
+        console = Reporter(no_color=True)._make_console()
+        assert isinstance(console, Console)
+        assert console.no_color is True
+
+    def test_color_enabled_by_default(self):
+        assert Reporter()._make_console().no_color is False
+
+
+class TestGlyphHelpers:
+    def test_console_is_unicode_for_utf8(self):
+        assert _console_is_unicode(SimpleNamespace(encoding="utf-8")) is True
+
+    def test_console_is_unicode_for_utf_16(self):
+        assert _console_is_unicode(SimpleNamespace(encoding="UTF-16")) is True
+
+    def test_console_not_unicode_for_codepage(self):
+        assert _console_is_unicode(SimpleNamespace(encoding="cp1252")) is False
+
+    def test_missing_encoding_defaults_to_unicode(self):
+        assert _console_is_unicode(SimpleNamespace()) is True
+
+    def test_u_picks_unicode_or_ascii(self):
+        utf = SimpleNamespace(encoding="utf-8")
+        cp = SimpleNamespace(encoding="cp850")
+        assert _u(utf, "→", "->") == "→"
+        assert _u(cp, "→", "->") == "->"
+
+    def test_glyph_sets_differ(self):
+        utf = _glyphs(SimpleNamespace(encoding="utf-8"))
+        asc = _glyphs(SimpleNamespace(encoding="ascii"))
+        assert utf["pass"] == "✓"
+        assert asc["pass"] == "[+]"
+        assert asc["flag"] == ""  # no ASCII flag glyph
+
+    def test_truncate_short_string_unchanged(self):
+        assert _truncate("short", 10) == "short"
+
+    def test_truncate_exact_length_unchanged(self):
+        assert _truncate("x" * 10, 10) == "x" * 10
+
+    def test_truncate_long_string_marked(self):
+        out = _truncate("a" * 20, 10)
+        assert out == "a" * 9 + "~"
+        assert len(out) == 10
+
+    def test_grade_hex_bands(self):
+        assert _grade_hex(100) == _grade_hex(80)   # green band
+        assert _grade_hex(79) == _grade_hex(60)    # amber band
+        assert _grade_hex(59) == _grade_hex(0)     # red band
+        assert _grade_hex(80) != _grade_hex(79)
+        assert _grade_hex(60) != _grade_hex(59)

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -236,3 +236,214 @@ class TestOnModuleStart:
             report = scanner.run(on_module_start=_bad_cb)
 
         assert len(report.results) == 1
+
+
+# ---------------------------------------------------------------------------
+# Module discovery (_discover_modules / discover_modules / dry_run)
+# ---------------------------------------------------------------------------
+
+class TestDiscoverModules:
+    def test_discovers_all_check_modules(self):
+        mods = Scanner()._discover_modules()
+        short_names = {m.__name__.rsplit(".", 1)[-1] for m in mods}
+        assert {"firewall", "smb", "updates", "uac"} <= short_names
+        assert len(mods) >= 14
+        assert all(callable(m.run) for m in mods)
+
+    def test_public_wrapper_matches_dry_run(self):
+        scanner = Scanner()
+        assert [m.__name__ for m in scanner.discover_modules()] == scanner.dry_run()
+
+    def test_dry_run_returns_full_module_names(self):
+        names = Scanner().dry_run()
+        assert "apotrope.checks.firewall" in names
+        assert all(isinstance(n, str) for n in names)
+
+    def test_category_filter_selects_matching_module(self):
+        mods = Scanner(categories=["firewall"])._discover_modules()
+        assert [m.__name__ for m in mods] == ["apotrope.checks.firewall"]
+
+    def test_category_filter_matches_category_attribute_not_filename(self):
+        # updates.py declares CATEGORY = "Patching"
+        mods = Scanner(categories=["patching"])._discover_modules()
+        assert [m.__name__ for m in mods] == ["apotrope.checks.updates"]
+
+    def test_category_filter_no_match_returns_empty(self):
+        assert Scanner(categories=["nonexistent"])._discover_modules() == []
+
+    def test_module_without_run_is_skipped(self):
+        from types import SimpleNamespace
+
+        bad = ModuleType("apotrope.checks.badmod")
+        bad.CATEGORY = "Bad"
+        with (
+            patch("apotrope.scanner.pkgutil.iter_modules",
+                  return_value=[SimpleNamespace(name="badmod")]),
+            patch("apotrope.scanner.importlib.import_module", return_value=bad),
+        ):
+            assert Scanner()._discover_modules() == []
+
+    def test_private_modules_ignored(self):
+        from types import SimpleNamespace
+
+        with patch("apotrope.scanner.pkgutil.iter_modules",
+                   return_value=[SimpleNamespace(name="_private")]):
+            assert Scanner()._discover_modules() == []
+
+    def test_import_failure_skips_module(self):
+        from types import SimpleNamespace
+
+        with (
+            patch("apotrope.scanner.pkgutil.iter_modules",
+                  return_value=[SimpleNamespace(name="broken")]),
+            patch("apotrope.scanner.importlib.import_module",
+                  side_effect=ImportError("nope")),
+        ):
+            assert Scanner()._discover_modules() == []
+
+    def test_frozen_bundle_uses_module_registry(self):
+        """PyInstaller path: discovery reads checks.MODULES, not pkgutil."""
+        import sys
+
+        good = _make_module("apotrope.checks.frozen_mod", "Frozen")
+        with (
+            patch.object(sys, "frozen", True, create=True),
+            patch("apotrope.checks.MODULES", ["frozen_mod"]),
+            patch("apotrope.scanner.importlib.import_module",
+                  return_value=good) as imp,
+        ):
+            mods = Scanner()._discover_modules()
+        assert mods == [good]
+        imp.assert_called_once_with("apotrope.checks.frozen_mod")
+
+
+# ---------------------------------------------------------------------------
+# Profile integration (_apply_profile, configure() thresholds)
+# ---------------------------------------------------------------------------
+
+def _named_result(name: str, severity: Severity = Severity.HIGH) -> CheckResult:
+    return CheckResult(
+        category="Test", check_name=name, status=Status.FAIL,
+        severity=severity, description="d", details="found", remediation="fix",
+    )
+
+
+class TestApplyProfile:
+    def _run_with_profile(self, profile, results) -> AuditReport:
+        from apotrope.profile import Profile  # noqa: F401 — type for clarity
+
+        scanner = Scanner(profile=profile)
+        mod = _make_module(results=results)
+        with patch.object(scanner, "_discover_modules", return_value=[mod]):
+            return scanner.run()
+
+    def test_disabled_checks_removed_from_report(self):
+        from apotrope.profile import Profile
+
+        report = self._run_with_profile(
+            Profile(disabled_checks=["Noisy Check"]),
+            [_named_result("Noisy Check"), _named_result("Kept Check")],
+        )
+        names = [r.check_name for r in report.results]
+        assert "Noisy Check" not in names
+        assert "Kept Check" in names
+
+    def test_severity_override_applied_case_insensitively(self):
+        from apotrope.profile import Profile
+
+        report = self._run_with_profile(
+            Profile(severity_overrides={"Kept Check": "low"}),
+            [_named_result("Kept Check", Severity.HIGH)],
+        )
+        assert report.results[0].severity == Severity.LOW
+
+    def test_invalid_severity_override_ignored(self):
+        from apotrope.profile import Profile
+
+        report = self._run_with_profile(
+            Profile(severity_overrides={"Kept Check": "BOGUS"}),
+            [_named_result("Kept Check", Severity.HIGH)],
+        )
+        assert report.results[0].severity == Severity.HIGH
+
+    def test_checks_without_override_untouched(self):
+        from apotrope.profile import Profile
+
+        report = self._run_with_profile(
+            Profile(severity_overrides={"Other Check": "LOW"}),
+            [_named_result("Kept Check", Severity.CRITICAL)],
+        )
+        assert report.results[0].severity == Severity.CRITICAL
+
+    def test_score_reflects_filtered_results(self):
+        from apotrope.profile import Profile
+
+        # A CRITICAL FAIL (-15) that is disabled must not affect the score.
+        report = self._run_with_profile(
+            Profile(disabled_checks=["Noisy Check"]),
+            [_named_result("Noisy Check", Severity.CRITICAL)],
+        )
+        assert report.score == 100
+
+
+class TestProfileThresholds:
+    def _profile(self, thresholds):
+        from apotrope.profile import Profile
+
+        return Profile(thresholds=thresholds)
+
+    def test_configure_called_with_thresholds(self):
+        from unittest.mock import MagicMock
+
+        mod = _make_module()
+        mod.configure = MagicMock()
+        scanner = Scanner(profile=self._profile({"max_update_age_warn": 45}))
+        scanner._run_module(mod)
+        mod.configure.assert_called_once_with({"max_update_age_warn": 45})
+
+    def test_configure_failure_does_not_abort_module(self):
+        from unittest.mock import MagicMock
+
+        mod = _make_module()
+        mod.configure = MagicMock(side_effect=RuntimeError("bad config"))
+        scanner = Scanner(profile=self._profile({"k": 1}))
+        results = scanner._run_module(mod)
+        assert results[0].status == Status.PASS
+
+    def test_module_without_configure_runs_normally(self):
+        mod = _make_module()
+        assert not hasattr(mod, "configure")
+        scanner = Scanner(profile=self._profile({"k": 1}))
+        results = scanner._run_module(mod)
+        assert results[0].status == Status.PASS
+
+    def test_empty_thresholds_skip_configure(self):
+        from unittest.mock import MagicMock
+
+        mod = _make_module()
+        mod.configure = MagicMock()
+        scanner = Scanner(profile=self._profile({}))
+        scanner._run_module(mod)
+        mod.configure.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# run() with pre-discovered modules; CIS references preserved
+# ---------------------------------------------------------------------------
+
+class TestRunWithExplicitModules:
+    def test_pre_discovered_modules_skip_discovery(self):
+        scanner = Scanner()
+        mod = _make_module()
+        with patch.object(scanner, "_discover_modules") as discover:
+            report = scanner.run(modules=[mod])
+        discover.assert_not_called()
+        assert len(report.results) == 1
+
+
+class TestApplyCisReferences:
+    def test_existing_reference_not_overwritten(self):
+        result = _pass_result()
+        result.cis_reference = "CIS 1.2.3"
+        Scanner._apply_cis_references([result])
+        assert result.cis_reference == "CIS 1.2.3"

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -223,3 +223,12 @@ class TestScoreLabel:
     ])
     def test_labels(self, score: int, expected: str):
         assert score_label(score) == expected
+
+
+# ---------------------------------------------------------------------------
+# score_grade defensive fallback
+# ---------------------------------------------------------------------------
+
+class TestScoreGradeFallback:
+    def test_negative_score_grades_f(self):
+        assert score_grade(-5) == ("F", "Critical")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -390,3 +390,13 @@ class TestPsBool:
         ):
             with pytest.raises(ApotropeError):
                 utils.ps_bool("broken-command")
+
+
+# ---------------------------------------------------------------------------
+# get_wmi_object — scalar JSON payload fallback
+# ---------------------------------------------------------------------------
+
+class TestGetWmiObjectScalarJson:
+    def test_scalar_json_returns_empty_list(self):
+        with patch("apotrope.utils.run_powershell", return_value="42"):
+            assert utils.get_wmi_object("Win32_Weird") == []


### PR DESCRIPTION
reporter.py was the largest coverage gap in the codebase (48%): the
entire terminal output surface — score panel, top-findings blocks, the
--fix block, --verbose category detail, footer variants, comparison
view, progress runner, glyph/ASCII fallbacks, and the plain-text
fallback used when Rich is absent — had no tests.

Add tests/test_reporter_terminal.py (79 tests) rendering to an
in-memory Rich console (StringIO file, colors stripped) so assertions
run against plain text on any OS. Key behaviors pinned down:

- severity-sorted, capped top-findings blocks with name truncation
  and CIS tags
- --fix block: verbatim multi-line commands, FAIL-before-WARN
  ordering, candidate filtering, overflow footer
- footer variants (html/json paths, clean vs issues, error caveat,
  non-admin note)
- run_with_progress banner/completion line and the no-rich fallback
- ASCII glyph rendering on non-Unicode consoles
- plain-text fallback when rich is not importable

Also extend test_reporter.py with the HTML generation guard paths
(jinja2 missing, template load failure, PyInstaller frozen template
dir) and executive-summary multi-category/error-note branches.

reporter.py: 48% -> 99% line coverage; project total: 82% -> 94%.