### PR TITLE
Default triage view with per-category issue boxes; retire --fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,8 @@ apotrope.exe --html report.html
 
 Then open `report.html` in your browser.
 
-To get a copy-paste-ready PowerShell command for each issue, add `--fix`:
-
-```
-apotrope.exe --fix
-```
+Every issue is shown with a copy-paste-ready PowerShell command by default —
+no extra flags needed.
 
 ---
 
@@ -134,8 +131,6 @@ Options:
   --category CATS      Comma-separated list of categories to audit
                        (e.g. firewall,encryption,patching)
   --dry-run            List check modules that would run without executing them
-  --fix                Print a copy-paste-ready PowerShell command for each
-                       failing/warning check (a "TOP FIXES" block)
   --verbose            Show detail for every check, including PASSes
   --no-color           Disable Rich color output (for CI / log files)
   --log-level LEVEL    Logging verbosity: DEBUG, INFO, WARNING (default), ERROR
@@ -162,9 +157,6 @@ apotrope --json report.json
 
 # Audit only firewall and patching
 apotrope --category firewall,patching
-
-# Print a copy-paste-ready PowerShell fix for each failing/warning check
-apotrope --fix
 
 # Show pass/fail details for every check
 apotrope --verbose

--- a/README.md
+++ b/README.md
@@ -65,17 +65,16 @@ apotrope.exe --fix
 
 ## Terminal Output
 
-**Standard scan (default view):**
+**Standard scan (default view)** — a triage view: every category with issues gets
+its own box listing each FAIL/WARN finding with its fix and a ready-to-paste
+PowerShell command:
 
 ![Apotrope scan overview](assets/screenshots/Ap-scan-overview.png)
 
-**Verbose mode (`--verbose`) — full details and remediation steps for every check:**
+**Verbose mode (`--verbose`) — the same boxes for every category and every check,
+passing ones included:**
 
 ![Apotrope verbose output](assets/screenshots/Ap-scan-verbose.png)
-
-**Top issues summary (shown at the end of every scan):**
-
-![Apotrope top issues](assets/screenshots/Ap-scan-top-issues.png)
 
 ---
 

--- a/src/apotrope/cli.py
+++ b/src/apotrope/cli.py
@@ -34,7 +34,6 @@ def build_parser() -> argparse.ArgumentParser:
             "  apotrope --category firewall,encryption  Specific categories only\n"
             "  apotrope --dry-run                   List checks without running\n"
             "  apotrope --verbose                   Show details for every check\n"
-            "  apotrope --fix                       Print paste-ready PowerShell fixes\n"
             "\n"
             "NOTICE: Apotrope is a READ-ONLY tool for AUTHORISED auditing only.\n"
             "It makes no changes to the system.  Do not run on systems you do\n"
@@ -92,7 +91,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--fix",
         action="store_true",
-        help="Print copy-paste-ready PowerShell remediation for each failing/warning check",
+        # Retired: fixes are shown by default in the triage view. Kept as a
+        # hidden no-op so existing scripts don't error. Do not repurpose the
+        # name — a future auto-remediation flag should be e.g. --remediate.
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--no-color",
@@ -133,7 +135,18 @@ def main() -> None:
 
     admin    = is_admin()
     scanner  = Scanner(categories=categories, is_admin=admin, profile=profile)
-    reporter = Reporter(verbose=args.verbose, no_color=args.no_color, fix=args.fix)
+    reporter = Reporter(verbose=args.verbose, no_color=args.no_color)
+
+    if args.fix:
+        # Retired flag — fixes print by default now.
+        notice = "--fix is no longer needed — fixes are shown by default"
+        try:
+            from rich.console import Console
+            Console(no_color=args.no_color, highlight=False).print(
+                f"  [#5d776c]{notice}[/]"
+            )
+        except ImportError:
+            print(f"  {notice}")
 
     # --dry-run: list modules and exit without scanning
     if args.dry_run:

--- a/src/apotrope/reporter.py
+++ b/src/apotrope/reporter.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import dataclasses
 import json
 import logging
+import shutil
 import textwrap
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -84,13 +85,12 @@ _SEV_ORDER: dict[Severity, int] = {
     Severity.INFO:     4,
 }
 
-_TOP_N        = 5    # cap on rows in TOP FAILURES / TOP WARNINGS
 _BAR_CELLS    = 24   # score-panel bar width (spec)
 _PROG_CELLS   = 20   # banner progress bar width
-_SEV_WIDTH    = 5    # severity column width in top findings (spec)
-_DESC_WIDTH   = 27   # description column width in top findings (spec)
 _PANEL_WIDTH  = 56   # inner width for right-aligned hostname / grade
-_REM_WRAP_WIDTH = 72  # detail / remediation wrap width (verbose)
+_REM_WRAP_WIDTH = 72  # detail / remediation wrap width (un-boxed fallback)
+_BOX_W        = 74   # inner content width of a category box (total 78 + 2 indent)
+_SEV_COL      = 4    # right-aligned severity column width inside a box
 
 
 def _grade_hex(score: int) -> str:
@@ -165,11 +165,15 @@ def _glyphs(console) -> dict[str, str]:
             "brand": "◈", "rail": "▌", "bar_full": "█", "bar_empty": "░",
             "pass": "✓", "fail": "✗", "warn": "!", "info": "i", "error": "·",
             "flag": "⚑", "arrow": "→", "sep": "·",
+            "box_tl": "┌", "box_tr": "┐", "box_bl": "└", "box_br": "┘",
+            "box_h": "─", "box_v": "│",
         }
     return {
         "brand": "*", "rail": "|", "bar_full": "#", "bar_empty": "-",
         "pass": "[+]", "fail": "[x]", "warn": "[!]", "info": "[i]", "error": "[.]",
         "flag": "", "arrow": "->", "sep": "-",
+        "box_tl": "+", "box_tr": "+", "box_bl": "+", "box_br": "+",
+        "box_h": "-", "box_v": "|",
     }
 
 
@@ -201,10 +205,11 @@ class Reporter:
     """Formats and outputs Apotrope audit reports.
 
     Args:
-        verbose:  Show details and remediation for every check result.
+        verbose:  Box every category and show every check (passing ones too).
+                  The default view is a triage view: only categories with
+                  FAIL/WARN findings, each with its fix and command.
         no_color: Disable Rich color markup (produces plain, no-ANSI output).
-        fix:      Print a copy-paste-ready "TOP FIXES" block with the exact
-                  PowerShell command for each failing/warning check.
+        fix:      Deprecated and ignored — fixes are shown by default.
     """
 
     def __init__(
@@ -212,7 +217,7 @@ class Reporter:
     ) -> None:
         self.verbose = verbose
         self.no_color = no_color
-        self.fix = fix
+        self.fix = fix  # retained for API compatibility; no longer changes output
 
     # ── Public API ────────────────────────────────────────────────────────────
 
@@ -295,16 +300,17 @@ class Reporter:
 
         console = self._make_console()
         self._print_score_panel(console, report)
-        if self.verbose:
-            # Full per-category detail lives here (and in the HTML report).
-            self._print_category_detail(console, report)
+        # Default = triage view: one box per category with FAIL/WARN findings.
+        # --verbose widens the selection: every category, every check.
+        # (console.width can come in below the OS-reported size — e.g. Rich
+        # reserves a column on legacy Windows consoles — so check both.)
+        if min(shutil.get_terminal_size().columns, console.width) < _BOX_W + 6:
+            # Console too narrow for 78-column boxes — un-boxed fallback.
+            self._print_category_detail(console, report,
+                                        only_issues=not self.verbose)
         else:
-            # Default view stays concise: prioritised failures, then warnings.
-            self._print_top_findings(console, report, Status.FAIL)
-            self._print_top_findings(console, report, Status.WARN)
-            # --fix: append a copy-paste-ready block of exact PowerShell commands.
-            if self.fix:
-                self._print_top_fixes(console, report)
+            self._print_category_boxes(console, report,
+                                       only_issues=not self.verbose)
         self._print_footer(console, report, html_path, json_path)
 
     def generate_html_report(self, report: AuditReport, path: str) -> None:
@@ -776,7 +782,19 @@ class Reporter:
         return Markup(" ".join(parts))
 
     def _make_console(self):
+        import sys
+
         from rich.console import Console
+
+        # Check data (details/remediation) may contain characters a non-UTF-8
+        # console (e.g. cp1252) cannot encode; degrade them to '?' rather than
+        # letting the report crash mid-render.
+        try:
+            enc = (getattr(sys.stdout, "encoding", None) or "utf-8").lower()
+            if "utf" not in enc.replace("-", ""):
+                sys.stdout.reconfigure(errors="replace")
+        except (AttributeError, ValueError):
+            pass
         return Console(no_color=self.no_color, highlight=False)
 
     def _print_non_admin_warning(self, console) -> None:
@@ -863,99 +881,150 @@ class Reporter:
         self._rail(console, _text((f"{total} checks evaluated", _FAINT)))
         console.print()
 
-    def _print_top_findings(
-        self, console, report: AuditReport, status: Status
-    ) -> None:
-        """Print a prioritised FAIL or WARN block (severity-sorted, capped)."""
-        g = _glyphs(console)
-        rows = sorted(
-            (r for r in report.results if r.status == status),
-            key=lambda r: _SEV_ORDER.get(r.severity, 5),
-        )[:_TOP_N]
-        if not rows:
-            return
+    # ── Category boxes (default triage view and --verbose) ───────────────────
 
-        if status == Status.FAIL:
-            head_glyph, head_text, accent, row_glyph = (
-                g["flag"], "TOP FAILURES", _RED, g["fail"]
-            )
-        else:
-            head_glyph, head_text, accent, row_glyph = (
-                g["warn"], "TOP WARNINGS", _AMBER, g["warn"]
-            )
+    @staticmethod
+    def _issue_sort_key(r: CheckResult) -> tuple[int, int]:
+        """FAIL before WARN, then severity CRITICAL→LOW."""
+        return (0 if r.status == Status.FAIL else 1,
+                _SEV_ORDER.get(r.severity, 5))
 
-        prefix = f"{head_glyph} " if head_glyph else ""
-        console.print(_text("  ", (f"{prefix}{head_text}", f"bold {accent}")))
+    def _box_row(self, console, g, segs=()) -> None:
+        """Print one box content line: `  │ <segs padded to _BOX_W> │`."""
+        pad = _BOX_W - sum(len(s[0]) if isinstance(s, tuple) else len(s)
+                           for s in segs)
+        line = _text("  ", (g["box_v"] + " ", _FAINT))
+        if segs:
+            line.append_text(_text(*segs))
+        line.append(" " * max(0, pad))
+        line.append(" " + g["box_v"], style=_FAINT)
+        console.print(line)
 
-        for r in rows:
-            sev  = _SEVERITY_ABBR.get(r.severity, "?").ljust(_SEV_WIDTH)
-            desc = _truncate(r.check_name, _DESC_WIDTH).ljust(_DESC_WIDTH)
-            line = _text(
-                "  ",
-                (row_glyph + " ", accent),
-                (sev + " ", _SEVERITY_HEX.get(r.severity, _TEXT)),
-                (desc, _TEXT),
-            )
-            if r.cis_reference:
-                line.append(" " + r.cis_reference, style=_FAINT)
-            console.print(line)
-        console.print()
-
-    def _fix_candidates(self, report: AuditReport) -> list[CheckResult]:
-        """FAIL/WARN findings that carry a command, ordered for the fixes block.
-
-        Severity-sorted (CRITICAL→LOW), FAIL before WARN — same priority the
-        HTML top-issues panel uses.
-        """
-        rows = [
-            r for r in report.results
-            if r.status in (Status.FAIL, Status.WARN) and r.command
-        ]
-        rows.sort(key=lambda r: (
-            _SEV_ORDER.get(r.severity, 5),
-            0 if r.status == Status.FAIL else 1,
-        ))
-        return rows
-
-    def _print_top_fixes(self, console, report: AuditReport) -> None:
-        """Print copy-paste-ready PowerShell for the top failing/warning checks.
-
-        Each finding gets a header line (glyph/severity/name/CIS) followed by its
-        exact command on indented bare lines — no glyph, rail, or prompt — so a
-        user can select and paste straight into an elevated PowerShell.
-        """
-        rows = self._fix_candidates(report)[:_TOP_N]
-        if not rows:
-            return
-
-        g = _glyphs(console)
-        flag = f"{g['flag']} " if g["flag"] else ""
+    def _print_box_top(self, console, g, name: str, score: int) -> None:
+        """Centered box header: `┌──── NAME  score/100 G ────┐`."""
+        letter, _ = score_grade(score)
+        gc    = _grade_hex(score)
+        label = name.upper()
+        badge = f"{score}/100 {letter}"
+        content_len = 1 + len(label) + 2 + len(badge) + 1
+        dashes_left  = (_BOX_W + 2 - content_len) // 2
+        dashes_right = _BOX_W + 2 - content_len - dashes_left
         console.print(_text(
             "  ",
-            (f"{flag}TOP FIXES", f"bold {_RED}"),
-            ("   copy-paste into an elevated PowerShell", _MUTED),
+            (g["box_tl"] + g["box_h"] * dashes_left, _FAINT),
+            " ",
+            (label, f"bold {_BRIGHT}"),
+            "  ",
+            (badge, gc),
+            " ",
+            (g["box_h"] * dashes_right + g["box_tr"], _FAINT),
         ))
+
+    def _print_box_bottom(self, console, g) -> None:
+        console.print(_text(
+            "  ", (g["box_bl"] + g["box_h"] * (_BOX_W + 2) + g["box_br"], _FAINT),
+        ))
+
+    def _print_box_check(self, console, g, r: CheckResult) -> None:
+        """One check inside a box: name row, details, then fix/run if actionable."""
+        glyph_for = {
+            Status.PASS: g["pass"], Status.FAIL: g["fail"], Status.WARN: g["warn"],
+            Status.INFO: g["info"], Status.ERROR: g["error"],
+        }
+        actionable = r.status in (Status.FAIL, Status.WARN)
+        glyph = glyph_for.get(r.status, "?")
+        sev   = _SEVERITY_ABBR.get(r.severity, "?").rjust(_SEV_COL)
+        name_hex = {Status.FAIL: _RED, Status.WARN: _AMBER}.get(r.status, _TEXT)
+        sev_hex  = _SEVERITY_HEX.get(r.severity, _TEXT) if actionable else _FAINT
+        name = _truncate(r.check_name,
+                         _BOX_W - len(glyph) - 1 - _SEV_COL - 2)
+        gap = _BOX_W - len(glyph) - 1 - len(name) - _SEV_COL
+        self._box_row(console, g, [
+            (glyph, _STATUS_HEX.get(r.status, _MUTED)),
+            " ",
+            (name, name_hex),
+            " " * gap,
+            (sev, sev_hex),
+        ])
+        if r.details:
+            body_hex = _TEXT if actionable else _MUTED
+            for ln in textwrap.wrap(r.details, _BOX_W - 4):
+                self._box_row(console, g, [("    " + ln, body_hex)])
+        if actionable and r.remediation:
+            for i, ln in enumerate(textwrap.wrap(r.remediation, _BOX_W - 9)):
+                self._box_row(console, g,
+                              [("    ", ""), ("fix", _MUTED), ("  ", ""), (ln, _TEXT)]
+                              if i == 0 else [(" " * 9 + ln, _TEXT)])
+        if actionable and r.command:
+            first = True
+            for stmt in r.command.split("\n"):
+                # Wrap at spaces only — never inside a command token like
+                # Select-String (textwrap breaks on hyphens by default).
+                for ln in textwrap.wrap(stmt, _BOX_W - 9,
+                                        break_on_hyphens=False) or [""]:
+                    self._box_row(console, g,
+                                  [("    ", ""), ("run", _MUTED), ("  ", ""), (ln, _GREEN)]
+                                  if first else [(" " * 9 + ln, _GREEN)])
+                    first = False
+
+    def _print_category_box(
+        self, console, g, name: str, score: int, results: list[CheckResult]
+    ) -> None:
+        """One category box: centered header, checks separated by blank rail rows."""
+        self._print_box_top(console, g, name, score)
+        for i, r in enumerate(results):
+            if i:
+                self._box_row(console, g)
+            self._print_box_check(console, g, r)
+        self._print_box_bottom(console, g)
         console.print()
 
-        for r in rows:
-            sev  = _SEVERITY_ABBR.get(r.severity, "?").ljust(_SEV_WIDTH)
-            desc = _truncate(r.check_name, _DESC_WIDTH).ljust(_DESC_WIDTH)
-            line = _text(
-                "  ",
-                (g["fail"] + " ", _RED),
-                (sev + " ", _SEVERITY_HEX.get(r.severity, _TEXT)),
-                (desc, _TEXT),
-            )
-            if r.cis_reference:
-                line.append(" " + r.cis_reference, style=_FAINT)
-            console.print(line)
-            # Bare command lines — nothing but the command, indented 6 spaces.
-            for cmd_line in r.command.split("\n"):
-                console.print(_text("      ", (cmd_line, _GREEN)))
-            console.print()
+    def _print_category_boxes(
+        self, console, report: AuditReport, only_issues: bool
+    ) -> None:
+        """Boxed per-category view.
 
-    def _print_category_detail(self, console, report: AuditReport) -> None:
-        """Verbose view: every check, grouped by category, in the rail language."""
+        only_issues=True (the default run) boxes only categories with FAIL/WARN
+        findings — and only those findings — worst category score first.
+        only_issues=False (--verbose) boxes every category alphabetically with
+        every check.
+        """
+        from collections import defaultdict
+
+        g = _glyphs(console)
+        cat_scores = calculate_category_scores(report.results)
+        by_cat: dict[str, list[CheckResult]] = defaultdict(list)
+        for r in report.results:
+            by_cat[r.category].append(r)
+
+        if only_issues:
+            selected = []
+            for cat, results in by_cat.items():
+                issues = sorted(
+                    (r for r in results
+                     if r.status in (Status.FAIL, Status.WARN)),
+                    key=self._issue_sort_key,
+                )
+                if issues:
+                    selected.append((cat, issues))
+            # Worst category first; alphabetical tie-break.
+            selected.sort(key=lambda c: (cat_scores.get(c[0], 100), c[0]))
+        else:
+            selected = [(cat, by_cat[cat]) for cat in sorted(by_cat)]
+
+        for cat, results in selected:
+            self._print_category_box(
+                console, g, cat, cat_scores.get(cat, 100), results,
+            )
+
+    def _print_category_detail(
+        self, console, report: AuditReport, only_issues: bool = False
+    ) -> None:
+        """Un-boxed per-category view for consoles too narrow for the boxes.
+
+        Same selection rules as the boxed view: only_issues=True restricts to
+        categories (and checks) with FAIL/WARN findings, worst category first.
+        """
         g = _glyphs(console)
         glyph_for = {
             Status.PASS:  g["pass"],  Status.FAIL: g["fail"], Status.WARN: g["warn"],
@@ -963,8 +1032,23 @@ class Reporter:
         }
         cat_scores = calculate_category_scores(report.results)
 
-        for category in sorted({r.category for r in report.results}):
-            results   = [r for r in report.results if r.category == category]
+        categories = sorted({r.category for r in report.results})
+        if only_issues:
+            categories = [
+                c for c in categories
+                if any(r.category == c and r.status in (Status.FAIL, Status.WARN)
+                       for r in report.results)
+            ]
+            categories.sort(key=lambda c: (cat_scores.get(c, 100), c))
+
+        for category in categories:
+            results = [r for r in report.results if r.category == category]
+            if only_issues:
+                results = sorted(
+                    (r for r in results
+                     if r.status in (Status.FAIL, Status.WARN)),
+                    key=self._issue_sort_key,
+                )
             cat_score = cat_scores.get(category, 100)
             letter, _ = score_grade(cat_score)
             gc        = _grade_hex(cat_score)
@@ -1034,14 +1118,13 @@ class Reporter:
                 (f"{g['arrow']} {html_path} written", _GREEN),
                 (tail, _MUTED),
             ))
-        elif issues:
-            console.print(_text(
-                "  ",
-                (f"{g['arrow']} {issues} issue{plural} to triage", _AMBER),
-                (f" {g['sep']} run with --html report.html for the full report", _MUTED),
-            ))
         else:
-            console.print(_text("  ", (f"{g['arrow']} clean — no issues found", _GREEN)))
+            head = (f"{g['arrow']} {issues} issue{plural} to triage" if issues
+                    else f"{g['arrow']} no issues to triage")
+            tail = f" {g['sep']} --html report.html for the full report"
+            if not self.verbose and issues:
+                tail += f" {g['sep']} --verbose for per-check detail"
+            console.print(_text("  ", (head, _GREEN), (tail, _MUTED)))
 
         if json_path:
             console.print(_text("  ", (f"{g['sep']} {json_path} written", _MUTED)))
@@ -1057,25 +1140,6 @@ class Reporter:
                 "  ",
                 ("note: some checks skipped — run as Administrator for complete results",
                  _MUTED),
-            ))
-        if self.fix and not self.verbose:
-            total_fixes = len(self._fix_candidates(report))
-            shown = min(total_fixes, _TOP_N)
-            if total_fixes > shown:
-                console.print(_text(
-                    "  ",
-                    (f"{shown} of {total_fixes} fixes shown", _MUTED),
-                    (" — run --verbose for every fix", _MUTED),
-                ))
-            else:
-                console.print(_text(
-                    "  ", ("run with --verbose for per-check detail", _MUTED),
-                ))
-        elif not self.verbose:
-            console.print(_text(
-                "  ",
-                ("run with --verbose for per-check detail "
-                 f"{g['sep']} --fix for paste-ready commands", _MUTED),
             ))
         console.print()
 
@@ -1097,10 +1161,13 @@ class Reporter:
         for r in report.results:
             icon = _STATUS_ICON.get(r.status, "?")
             print(f"[{icon}] [{r.severity.value:8}] {r.category}: {r.check_name}")
-            if (self.verbose or self.fix) and r.details:
+            # Fixes are shown by default for actionable findings; --verbose
+            # additionally shows detail for passing checks.
+            show = self.verbose or r.status in (Status.FAIL, Status.WARN)
+            if show and r.details:
                 print(f"       {r.details}")
-            if (self.verbose or self.fix) and r.remediation:
+            if show and r.remediation:
                 print(f"       Fix: {r.remediation}")
-            if (self.verbose or self.fix) and r.command:
+            if show and r.command:
                 for ln in r.command.split("\n"):
                     print(f"       {ln}")

--- a/src/apotrope/reporter.py
+++ b/src/apotrope/reporter.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import dataclasses
 import json
 import logging
-import shutil
 import textwrap
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -302,9 +301,9 @@ class Reporter:
         self._print_score_panel(console, report)
         # Default = triage view: one box per category with FAIL/WARN findings.
         # --verbose widens the selection: every category, every check.
-        # (console.width can come in below the OS-reported size — e.g. Rich
-        # reserves a column on legacy Windows consoles — so check both.)
-        if min(shutil.get_terminal_size().columns, console.width) < _BOX_W + 6:
+        # console.width tracks the real terminal (including the column Rich
+        # reserves on legacy Windows consoles, which would break the boxes).
+        if console.width < _BOX_W + 6:
             # Console too narrow for 78-column boxes — un-boxed fallback.
             self._print_category_detail(console, report,
                                         only_issues=not self.verbose)

--- a/src/apotrope/templates/report.html.j2
+++ b/src/apotrope/templates/report.html.j2
@@ -235,7 +235,7 @@
   .cbar:hover .cbar-track { box-shadow: inset 0 0 0 1px var(--line); }
   .cbar-name { font-size:11.5px; color:var(--text); letter-spacing:0.04em; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
   .cbar-track { height:13px; background:#0a130d; border:1px solid rgba(43,255,136,0.12); border-radius:2px; overflow:hidden; position:relative; }
-  .cbar-fill { height:100%; border-radius:0; transition:width .6s cubic-bezier(.2,.7,.2,1); }
+  .cbar-fill { display:block; height:100%; width:0; border-radius:0; transition:width .6s cubic-bezier(.2,.7,.2,1); }
   /* HP-bar segmentation: 20 cells, score maps to filled cells */
   .cbar-track::after { content:""; position:absolute; inset:0; pointer-events:none; z-index:2;
      background: repeating-linear-gradient(90deg, transparent 0 calc(5% - 2px), var(--panel) calc(5% - 2px) 5%); }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,6 +75,14 @@ class TestBuildParser:
             self._parse("--version")
         assert exc_info.value.code == 0
 
+    def test_fix_still_parses_as_noop(self):
+        """Retired flag must not error for existing scripts."""
+        ns = self._parse("--fix")
+        assert ns.fix is True
+
+    def test_fix_hidden_from_help(self):
+        assert "--fix" not in build_parser().format_help()
+
 
 # ---------------------------------------------------------------------------
 # main() dispatch
@@ -217,7 +225,7 @@ class TestMain:
             importlib.reload(cli_mod)
             cli_mod.main()
 
-        MockReporter.assert_called_once_with(verbose=True, no_color=False, fix=False)
+        MockReporter.assert_called_once_with(verbose=True, no_color=False)
 
     def test_exit_1_when_score_below_70(self):
         """Score 69 → exit 1."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -388,14 +388,23 @@ class TestMainErrorPaths:
             mock_report, html_path="out.html", json_path="out.json"
         )
 
-    def test_fix_flag_passed_to_reporter(self):
+    def test_fix_flag_is_noop_with_notice(self, capsys):
+        """Retired --fix: not forwarded to Reporter; prints the muted notice."""
         from apotrope.cli import main
 
         mock_reporter, _ = self._reporter_with_report()
         p1, p2, p3, p4, p5 = self._patches(["--fix"], mock_reporter)
         with p1, p2, p3 as MockReporter, p4, p5:
             main()
-        MockReporter.assert_called_once_with(verbose=False, no_color=False, fix=True)
+        MockReporter.assert_called_once_with(verbose=False, no_color=False)
+        out = capsys.readouterr().out
+        assert "--fix is no longer needed" in out
+        mock_reporter.run_with_progress.assert_called_once()  # scan still runs
+
+    def test_no_fix_notice_without_flag(self, capsys):
+        mock_reporter, _ = self._reporter_with_report()
+        self._run_main([], mock_reporter)
+        assert "--fix is no longer needed" not in capsys.readouterr().out
 
     def test_dry_run_prints_module_names(self, capsys):
         mock_reporter, _ = self._reporter_with_report()

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -336,3 +336,92 @@ class TestBuildExecutiveSummary:
         ]
         s = self._summary(results, score=70)
         assert "2" in s or "failed" in s.lower()
+
+
+# ---------------------------------------------------------------------------
+# Terminal output — triage boxes (default) and --verbose boxes
+# ---------------------------------------------------------------------------
+
+class TestPrintTerminal:
+    def _boxed_report(self) -> AuditReport:
+        return _make_report(extra_results=[
+            CheckResult(
+                "Firewall", "Public Firewall", Status.FAIL, Severity.HIGH,
+                "desc", "Profile disabled.", "Turn the public profile on.",
+                command="Set-NetFirewallProfile -Profile Public -Enabled True",
+            ),
+        ])
+
+    def _output(self, report: AuditReport, capsys, monkeypatch,
+                verbose: bool = False, columns: int = 120) -> str:
+        # Pin the console width (Rich and shutil both honor COLUMNS) so the
+        # wide/narrow rendering path doesn't depend on the test runner's tty.
+        monkeypatch.setenv("COLUMNS", str(columns))
+        Reporter(verbose=verbose, no_color=True).print_terminal(report)
+        return capsys.readouterr().out
+
+    def test_default_boxes_issue_categories_only(self, capsys, monkeypatch):
+        out = self._output(self._boxed_report(), capsys, monkeypatch)
+        assert "FIREWALL" in out   # has FAIL findings → boxed
+        assert "SERVICES" in out   # has a WARN finding → boxed
+        assert "OS  " not in out   # INFO only → no box in the triage view
+
+    def test_default_hides_passing_checks(self, capsys, monkeypatch):
+        out = self._output(self._boxed_report(), capsys, monkeypatch)
+        assert "Domain Profile" not in out  # PASS check stays out of triage
+
+    def test_default_shows_fix_and_run(self, capsys, monkeypatch):
+        out = self._output(self._boxed_report(), capsys, monkeypatch)
+        assert "fix" in out
+        assert "Turn the public profile on." in out
+        assert "run" in out
+        assert "Set-NetFirewallProfile -Profile Public -Enabled True" in out
+
+    def test_old_summary_blocks_removed(self, capsys, monkeypatch):
+        out = self._output(self._boxed_report(), capsys, monkeypatch)
+        assert "TOP FAILURES" not in out
+        assert "TOP WARNINGS" not in out
+        assert "TOP FIXES" not in out
+
+    def test_box_frame_drawn(self, capsys, monkeypatch):
+        out = self._output(self._boxed_report(), capsys, monkeypatch)
+        assert "┌" in out and "┐" in out and "└" in out and "┘" in out
+
+    def test_box_lines_align_at_78_columns(self, capsys, monkeypatch):
+        out = self._output(self._boxed_report(), capsys, monkeypatch)
+        box_lines = [ln for ln in out.splitlines()
+                     if ln.lstrip().startswith(("┌", "│", "└"))]
+        assert box_lines
+        assert all(len(ln) == 80 for ln in box_lines)  # 2 indent + 78 box
+
+    def test_footer_default(self, capsys, monkeypatch):
+        out = self._output(self._boxed_report(), capsys, monkeypatch)
+        assert "issues to triage" in out
+        assert "--verbose for per-check detail" in out
+
+    def test_footer_zero_issues(self, capsys, monkeypatch):
+        clean = AuditReport(
+            hostname="TEST-PC",
+            os_version="Windows 11 Pro 10.0.22621",
+            scan_timestamp=datetime(2026, 3, 17, 12, 0, 0, tzinfo=timezone.utc),
+            scan_duration=2.5,
+            results=[
+                CheckResult("Firewall", "Domain Profile", Status.PASS,
+                            Severity.HIGH, "desc", "ok"),
+            ],
+            score=100,
+        )
+        out = self._output(clean, capsys, monkeypatch)
+        assert "no issues to triage" in out
+        assert "┌" not in out  # no boxes on a clean run
+
+    def test_verbose_boxes_every_category_and_check(self, capsys, monkeypatch):
+        out = self._output(self._boxed_report(), capsys, monkeypatch, verbose=True)
+        assert "OS Version" in out         # INFO-only category boxed now
+        assert "Domain Profile" in out     # passing check shown
+        assert "--verbose for per-check detail" not in out
+
+    def test_narrow_console_falls_back_unboxed(self, capsys, monkeypatch):
+        out = self._output(self._boxed_report(), capsys, monkeypatch, columns=70)
+        assert "┌" not in out
+        assert "Public Firewall" in out  # content still there, un-boxed

--- a/tests/test_reporter_terminal.py
+++ b/tests/test_reporter_terminal.py
@@ -1,9 +1,10 @@
 """Tests for apotrope.reporter — Rich terminal rendering paths.
 
 Covers the terminal output surface that test_reporter.py (HTML/JSON) does not:
-the score panel, top-findings blocks, --fix block, --verbose category detail,
-footer variants, comparison view, progress runner, glyph/ASCII fallbacks, and
-the plain-text fallback used when Rich is not installed.
+the score panel, the default triage boxes (per-category FAIL/WARN findings with
+fix + run), the --verbose all-category boxes, footer variants, comparison view,
+progress runner, glyph/ASCII fallbacks, the narrow-console un-boxed fallback,
+and the plain-text fallback used when Rich is not installed.
 
 All tests render to an in-memory console (StringIO file, colors stripped) so
 assertions run against plain text on any OS.
@@ -153,20 +154,23 @@ class TestScorePanel:
 
 
 # ---------------------------------------------------------------------------
-# Top findings (TOP FAILURES / TOP WARNINGS)
+# Default triage view (per-category issue boxes)
 # ---------------------------------------------------------------------------
 
-class TestTopFindings:
-    def test_failures_and_warnings_headers(self):
+class TestTriageBoxes:
+    def test_issue_categories_boxed_no_top_lists(self):
         out = _render(Reporter(), "print_terminal", _report(_default_results()))
-        assert "TOP FAILURES" in out
-        assert "TOP WARNINGS" in out
-
-    def test_no_headers_when_clean(self):
-        results = [_result(name="Only Pass", status=Status.PASS)]
-        out = _render(Reporter(), "print_terminal", _report(results, score=100))
         assert "TOP FAILURES" not in out
         assert "TOP WARNINGS" not in out
+        assert "ANTIVIRUS" in out   # has a FAIL → boxed
+        assert "RDP" in out         # has a WARN → boxed
+        assert "FIREWALL" not in out  # PASS only → not in the triage view
+
+    def test_no_boxes_when_clean(self):
+        results = [_result(name="Only Pass", status=Status.PASS)]
+        out = _render(Reporter(), "print_terminal", _report(results, score=100))
+        assert "┌" not in out
+        assert "Only Pass" not in out
 
     def test_failures_sorted_by_severity(self):
         results = [
@@ -177,26 +181,46 @@ class TestTopFindings:
         out = _render(Reporter(), "print_terminal", _report(results))
         assert out.index("Critical Severity Fail") < out.index("Low Severity Fail")
 
-    def test_capped_at_five_rows(self):
+    def test_worst_category_boxed_first(self):
+        results = [
+            _result("Mild", "Mild Warn", Status.WARN, Severity.LOW),
+            _result("Grave", "Grave Fail", Status.FAIL, Severity.CRITICAL),
+        ]
+        out = _render(Reporter(), "print_terminal", _report(results))
+        assert out.index("GRAVE") < out.index("MILD")
+
+    def test_uncapped_all_findings_shown(self):
         results = [
             _result(name=f"Failure Number {i}", status=Status.FAIL, severity=Severity.HIGH)
             for i in range(1, 8)
         ]
         out = _render(Reporter(), "print_terminal", _report(results))
-        assert "Failure Number 5" in out
-        assert "Failure Number 6" not in out
-        assert "Failure Number 7" not in out
+        for i in range(1, 8):
+            assert f"Failure Number {i}" in out
 
-    def test_long_check_name_truncated(self):
-        long_name = "A" * 40
+    def test_long_check_name_truncated_to_box_width(self):
+        long_name = "A" * 70
         results = [_result(name=long_name, status=Status.FAIL)]
         out = _render(Reporter(), "print_terminal", _report(results))
         assert long_name not in out
-        assert "A" * 26 + "~" in out
+        assert "A" * 65 + "~" in out
 
-    def test_cis_reference_appended(self):
+    def test_details_fix_and_run_inside_box(self):
+        out = _render(Reporter(), "print_terminal", _report(_default_results()))
+        assert "fix" in out
+        assert "Enable Defender" in out
+        assert "run" in out
+        assert "Set-MpPreference X" in out
+
+    def test_cis_reference_shown_in_narrow_fallback(self):
+        # Boxes omit CIS tags (per the redesign spec); the un-boxed fallback
+        # for narrow consoles keeps them.
         results = [_result(name="Tagged Fail", status=Status.FAIL, cis="CIS 9.2.1")]
-        out = _render(Reporter(), "print_terminal", _report(results))
+        console = _make_console(width=70)
+        with mock.patch.object(Reporter, "_make_console", return_value=console):
+            Reporter().print_terminal(_report(results))
+        out = console.file.getvalue()
+        assert "┌" not in out          # too narrow for boxes
         assert "CIS 9.2.1" in out
 
     def test_severity_abbreviations_used(self):
@@ -210,43 +234,49 @@ class TestTopFindings:
 
 
 # ---------------------------------------------------------------------------
-# --fix: TOP FIXES block
+# Fixes in boxes (--fix retired; commands print by default)
 # ---------------------------------------------------------------------------
 
-class TestTopFixes:
-    def test_header_and_paste_hint(self):
-        out = _render(Reporter(fix=True), "print_terminal", _report(_default_results()))
-        assert "TOP FIXES" in out
-        assert "elevated PowerShell" in out
+class TestFixesInBoxes:
+    def test_no_top_fixes_block(self):
+        out = _render(Reporter(), "print_terminal", _report(_default_results()))
+        assert "TOP FIXES" not in out
+        assert "elevated PowerShell" not in out
 
-    def test_commands_printed_verbatim(self):
-        out = _render(Reporter(fix=True), "print_terminal", _report(_default_results()))
+    def test_commands_printed_by_default(self):
+        out = _render(Reporter(), "print_terminal", _report(_default_results()))
         assert "Set-MpPreference X" in out
         assert "Stop-Service TermService" in out
+
+    def test_fix_param_is_noop(self):
+        report = _report(_default_results())
+        assert (_render(Reporter(fix=True), "print_terminal", report)
+                == _render(Reporter(), "print_terminal", report))
 
     def test_multiline_command_all_lines_present(self):
         results = [_result(
             name="Multi Step Fix", status=Status.FAIL,
             command="First-Command -A 1\nSecond-Command -B 2",
         )]
-        out = _render(Reporter(fix=True), "print_terminal", _report(results))
+        out = _render(Reporter(), "print_terminal", _report(results))
         assert "First-Command -A 1" in out
         assert "Second-Command -B 2" in out
 
-    def test_findings_without_command_excluded(self):
+    def test_finding_without_command_still_boxed(self):
         results = [
             _result(name="Fixable Fail", status=Status.FAIL, command="Do-Fix"),
             _result(name="Unfixable Fail", status=Status.FAIL, command=""),
         ]
-        out = _render(Reporter(fix=True), "print_terminal", _report(results))
-        fixes_block = out[out.index("TOP FIXES"):]
-        assert "Fixable Fail" in fixes_block
-        assert "Unfixable Fail" not in fixes_block
+        out = _render(Reporter(), "print_terminal", _report(results))
+        assert "Fixable Fail" in out
+        assert "Do-Fix" in out
+        assert "Unfixable Fail" in out  # shown, just without a run line
 
     def test_pass_results_never_included(self):
         results = [_result(name="Passing Check", status=Status.PASS, command="Noop")]
-        out = _render(Reporter(fix=True), "print_terminal", _report(results, score=100))
-        assert "TOP FIXES" not in out
+        out = _render(Reporter(), "print_terminal", _report(results, score=100))
+        assert "Passing Check" not in out
+        assert "Noop" not in out
 
     def test_fail_ordered_before_warn_within_severity(self):
         results = [
@@ -255,58 +285,44 @@ class TestTopFixes:
             _result(name="Fail Finding", status=Status.FAIL,
                     severity=Severity.CRITICAL, command="Fix-Fail"),
         ]
-        out = _render(Reporter(fix=True), "print_terminal", _report(results))
+        out = _render(Reporter(), "print_terminal", _report(results))
         assert out.index("Fail Finding") < out.index("Warn Finding")
 
-    def test_no_block_when_no_fix_candidates(self):
-        results = [_result(name="No Command Fail", status=Status.FAIL)]
-        out = _render(Reporter(fix=True), "print_terminal", _report(results))
-        assert "TOP FIXES" not in out
-
-    def test_footer_counts_overflow_fixes(self):
+    def test_all_fixes_shown_uncapped(self):
         results = [
             _result(name=f"Fix {i}", status=Status.FAIL, command=f"Cmd-{i}")
             for i in range(7)
         ]
-        out = _render(Reporter(fix=True), "print_terminal", _report(results))
-        assert "5 of 7 fixes shown" in out
-        assert "run --verbose for every fix" in out
-
-    def test_footer_hint_when_all_fixes_shown(self):
-        out = _render(Reporter(fix=True), "print_terminal", _report(_default_results()))
-        assert "run with --verbose for per-check detail" in out
-
-    def test_cis_reference_shown_on_fix_row(self):
-        results = [_result(name="Tagged Fix", status=Status.FAIL,
-                           command="Do-Fix", cis="CIS 18.9.1")]
-        out = _render(Reporter(fix=True), "print_terminal", _report(results))
-        assert "CIS 18.9.1" in out
+        out = _render(Reporter(), "print_terminal", _report(results))
+        for i in range(7):
+            assert f"Cmd-{i}" in out
+        assert "fixes shown" not in out  # old overflow counter is gone
 
 
 # ---------------------------------------------------------------------------
-# --verbose: per-category detail
+# --verbose: every category boxed, every check shown
 # ---------------------------------------------------------------------------
 
-class TestCategoryDetail:
+class TestVerboseBoxes:
     def test_category_headers_with_score_badge(self):
         out = _render(Reporter(verbose=True), "print_terminal",
                       _report(_default_results()))
-        assert "Antivirus" in out
-        assert "Firewall" in out
+        assert "ANTIVIRUS" in out
+        assert "FIREWALL" in out  # PASS-only category boxed under --verbose
         assert "/100" in out
 
     def test_categories_sorted_alphabetically(self):
         out = _render(Reporter(verbose=True), "print_terminal",
                       _report(_default_results()))
-        assert out.index("Antivirus") < out.index("Firewall") < out.index("RDP")
+        assert out.index("ANTIVIRUS") < out.index("FIREWALL") < out.index("RDP")
 
-    def test_severity_details_fix_labels(self):
+    def test_label_columns_dropped_fix_kept(self):
         out = _render(Reporter(verbose=True), "print_terminal",
                       _report(_default_results()))
-        assert "severity" in out
-        assert "details" in out
+        assert "severity" not in out   # old per-check label column is gone
+        assert "details" not in out
         assert "fix" in out
-        assert "CRITICAL" in out
+        assert "CRIT" in out           # abbreviated, right-aligned severity
         assert "Enable Defender" in out
 
     def test_command_printed_with_run_label(self):
@@ -336,9 +352,21 @@ class TestCategoryDetail:
                       _report(_default_results()))
         assert "TOP FAILURES" not in out
 
-    def test_cis_reference_shown_next_to_check(self):
+    def test_passing_check_has_no_fix_or_run(self):
+        results = [_result(name="Healthy Check", status=Status.PASS,
+                           remediation="Should not print", command="Should-Not-Run")]
+        out = _render(Reporter(verbose=True), "print_terminal",
+                      _report(results, score=100))
+        assert "Healthy Check" in out
+        assert "Should not print" not in out
+        assert "Should-Not-Run" not in out
+
+    def test_cis_reference_shown_in_narrow_fallback(self):
         results = [_result(name="Tagged Check", status=Status.FAIL, cis="CIS 2.3.1")]
-        out = _render(Reporter(verbose=True), "print_terminal", _report(results))
+        console = _make_console(width=70)
+        with mock.patch.object(Reporter, "_make_console", return_value=console):
+            Reporter(verbose=True).print_terminal(_report(results))
+        out = console.file.getvalue()
         assert "CIS 2.3.1" in out
 
 
@@ -372,7 +400,8 @@ class TestFooter:
     def test_clean_without_html(self):
         results = [_result(status=Status.PASS)]
         out = _render(Reporter(), "print_terminal", _report(results, score=100))
-        assert "clean — no issues found" in out
+        assert "no issues to triage" in out
+        assert "--html report.html for the full report" in out
 
     def test_json_path_mentioned(self):
         out = _render(Reporter(), "print_terminal", _report(_default_results()),
@@ -403,10 +432,16 @@ class TestFooter:
                       _report(_default_results(), is_admin=True))
         assert "some checks skipped" not in out
 
-    def test_default_hint_mentions_verbose_and_fix(self):
+    def test_default_hint_mentions_verbose_but_not_fix(self):
         out = _render(Reporter(), "print_terminal", _report(_default_results()))
         assert "--verbose for per-check detail" in out
-        assert "--fix for paste-ready commands" in out
+        assert "--fix" not in out  # retired flag is never advertised
+
+    def test_verbose_footer_drops_verbose_hint(self):
+        out = _render(Reporter(verbose=True), "print_terminal",
+                      _report(_default_results()))
+        assert "issues to triage" in out
+        assert "--verbose for per-check detail" not in out
 
 
 # ---------------------------------------------------------------------------
@@ -572,10 +607,19 @@ class TestPlainFallback:
         assert "Fix: Enable Defender" in out
         assert "Set-MpPreference X" in out
 
-    def test_plain_non_verbose_hides_details(self, capsys):
-        Reporter()._print_plain(_report(_default_results()))
+    def test_plain_non_verbose_shows_fixes_hides_pass_detail(self, capsys):
+        """Fixes print by default for FAIL/WARN; PASS detail needs --verbose."""
+        results = [
+            _result(name="Quiet Pass", status=Status.PASS,
+                    details="pass-only-detail"),
+            _result(name="Loud Fail", status=Status.FAIL,
+                    remediation="Enable Defender", command="Set-MpPreference X"),
+        ]
+        Reporter()._print_plain(_report(results))
         out = capsys.readouterr().out
-        assert "Fix: Enable Defender" not in out
+        assert "Fix: Enable Defender" in out
+        assert "Set-MpPreference X" in out
+        assert "pass-only-detail" not in out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements the Claude Design handoff (`design_handoff_apotrope_cleanup`): the default run becomes a **triage view**, `--verbose` gets the same boxed treatment, `--fix` is retired, and the HTML report's category score bars are fixed.

### Terminal: default run
- Each category with FAIL/WARN findings gets a 78-column box (centered `NAME  score/100 G` header, faint box chars) containing **only those findings** with details, `fix` prose, and green `run` commands — sorted worst category score first, FAIL before WARN inside.
- `TOP FAILURES` / `TOP WARNINGS` / `TOP FIXES` lists are removed; the boxes carry everything.
- New footer: `→ N issues to triage · --html report.html for the full report · --verbose for per-check detail`. Clean runs print no boxes.

### Terminal: --verbose
- Same boxes widened to every category (alphabetical) and every check; passing checks are tight rows (glyph + name + faint severity + muted detail) — the old `severity`/`details` label column is gone.

### --fix retired
- Hidden from `--help`, kept as a no-op that prints a muted notice (`--fix is no longer needed — fixes are shown by default`). The plain-text fallback also shows fix/run for FAIL/WARN without flags. README documentation from #45 updated accordingly.

### Fallbacks & robustness
- Consoles narrower than 80 columns fall back to the un-boxed rail layout (filtered to issues by default); non-Unicode consoles draw ASCII boxes.
- Non-UTF-8 stdout degrades unencodable characters instead of crashing (latent bug surfaced by printing remediation text by default — check data contains `→`).
- Command wrapping no longer breaks tokens at hyphens (`Select-String` stays intact).

### HTML report
- `.cbar-fill` gets `display:block; width:0;` so category score bars fill proportionally to score (the inline `width:{{score}}%` was silently ignored on the inline span).

### Tests
- Adapted the 17 tests from #46 that pinned the old output to specify the new behavior (uncapped fixes, box headers, no-op `--fix` equivalence proof, new footer wording); added triage-box coverage in `test_reporter.py`.
- **718 passed** locally; verified with real scans (default + `--verbose --fix`) against the handoff's `terminal-mock.html`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)