### PR TITLE
fix: PSModulePath pollution breaks Execution Policy check when run from pwsh 7

### DIFF
--- a/src/apotrope/reporter.py
+++ b/src/apotrope/reporter.py
@@ -684,9 +684,13 @@ class Reporter:
 
         if report.error_count:
             n = report.error_count
+            hint = (
+                "see the per-check detail for the cause"
+                if report.is_admin
+                else "run as Administrator for full results"
+            )
             parts.append(
-                f"Note: {n} check{'s' if n != 1 else ''} could not complete "
-                "(run as Administrator for full results)."
+                f"Note: {n} check{'s' if n != 1 else ''} could not complete ({hint})."
             )
 
         return "  ".join(parts)
@@ -773,9 +777,13 @@ class Reporter:
 
         if report.error_count:
             n = report.error_count
+            hint = (
+                "see the per-check detail for the cause"
+                if report.is_admin
+                else "run as Administrator for full results"
+            )
             parts.append(
-                f"Note: {n} check{'s' if n != 1 else ''} could not complete "
-                "— run as Administrator for full results."
+                f"Note: {n} check{'s' if n != 1 else ''} could not complete — {hint}."
             )
 
         return Markup(" ".join(parts))
@@ -1129,10 +1137,15 @@ class Reporter:
             console.print(_text("  ", (f"{g['sep']} {json_path} written", _MUTED)))
         if report.error_count:
             n = report.error_count
+            hint = (
+                " — run with --log-level DEBUG to see why"
+                if report.is_admin
+                else " — run as Administrator for full results"
+            )
             console.print(_text(
                 "  ",
                 (f"{n} check{'s' if n != 1 else ''} could not complete", _AMBER),
-                (" — run as Administrator for full results", _MUTED),
+                (hint, _MUTED),
             ))
         if not report.is_admin:
             console.print(_text(

--- a/src/apotrope/scanner.py
+++ b/src/apotrope/scanner.py
@@ -117,10 +117,12 @@ class Scanner:
 
         error_count = sum(1 for r in results if r.status == Status.ERROR)
         if error_count:
-            log.warning(
-                "%d check(s) could not complete — rerun as Administrator for full results.",
-                error_count,
+            hint = (
+                "run with --log-level DEBUG to see why"
+                if self.is_admin
+                else "rerun as Administrator for full results"
             )
+            log.warning("%d check(s) could not complete — %s.", error_count, hint)
 
         report = AuditReport(
             hostname=socket.gethostname(),

--- a/src/apotrope/utils.py
+++ b/src/apotrope/utils.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import ctypes
 import json
 import logging
+import os
 import subprocess
 import sys
 
@@ -26,6 +27,20 @@ _PS_CMD = [
     "Bypass",
     "-Command",
 ]
+
+
+def _child_env() -> dict[str, str]:
+    """Environment for powershell.exe children, minus ``PSModulePath``.
+
+    A PowerShell 7 parent leaves its own Core-only module paths in the
+    inherited ``PSModulePath``; Windows PowerShell 5.1 then resolves modules
+    that exist in both editions (e.g. Microsoft.PowerShell.Security, home of
+    ``Get-ExecutionPolicy``) to the PS7 copy and fails to load it. pwsh strips
+    its paths when launching powershell.exe itself, but a Python parent passes
+    the environment through raw, so we strip the variable here — powershell.exe
+    rebuilds its correct default when it is absent.
+    """
+    return {k: v for k, v in os.environ.items() if k.lower() != "psmodulepath"}
 
 
 # ---------------------------------------------------------------------------
@@ -53,6 +68,7 @@ def run_powershell(command: str, timeout: int = 30) -> str:
             capture_output=True,
             text=True,
             timeout=timeout,
+            env=_child_env(),
         )
     except subprocess.TimeoutExpired as exc:
         raise ApotropeError(

--- a/tests/test_reporter_terminal.py
+++ b/tests/test_reporter_terminal.py
@@ -408,9 +408,17 @@ class TestFooter:
                       json_path="report.json")
         assert "report.json written" in out
 
-    def test_error_caveat(self):
+    def test_error_caveat_admin_points_to_debug(self):
         results = [_result(name="Broken", status=Status.ERROR, severity=Severity.INFO)]
         out = _render(Reporter(), "print_terminal", _report(results, score=100))
+        assert "1 check could not complete" in out
+        assert "--log-level DEBUG" in out
+        assert "run as Administrator" not in out
+
+    def test_error_caveat_non_admin_suggests_elevation(self):
+        results = [_result(name="Broken", status=Status.ERROR, severity=Severity.INFO)]
+        out = _render(Reporter(), "print_terminal",
+                      _report(results, score=100, is_admin=False))
         assert "1 check could not complete" in out
         assert "run as Administrator" in out
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -109,6 +109,19 @@ class TestRunPowershell:
             _, kwargs = mock_run.call_args
             assert kwargs["timeout"] == 5
 
+    def test_psmodulepath_stripped_from_child_env(self):
+        polluted = {
+            "PSModulePath": r"C:\Program Files\PowerShell\7\Modules",
+            "PATH": r"C:\Windows\System32",
+        }
+        with patch.dict("apotrope.utils.os.environ", polluted, clear=True):
+            with patch("apotrope.utils.subprocess.run", return_value=_mock_ps("ok")) as mock_run:
+                utils.run_powershell("Get-Date")
+                _, kwargs = mock_run.call_args
+        env = kwargs["env"]
+        assert not any(k.lower() == "psmodulepath" for k in env)
+        assert env["PATH"] == r"C:\Windows\System32"
+
 
 # ---------------------------------------------------------------------------
 # run_powershell_json


### PR DESCRIPTION
## Problem

Running apotrope from a PowerShell 7 session (admin or not) fails the **PowerShell Execution Policy** check:

```
Get-ExecutionPolicy : The 'Get-ExecutionPolicy' command was found in the module
'Microsoft.PowerShell.Security', but the module could not be loaded.
```

Root cause: pwsh 7 puts `C:\Program Files\PowerShell\7\Modules` into `PSModulePath`. When pwsh launches `powershell.exe` itself it strips its own paths from the child environment, but apotrope is a Python process in the middle — `subprocess.run` passes the environment through raw. The Windows PowerShell 5.1 child then autoloads `Microsoft.PowerShell.Security` from the PS7 directory (Core-only) and fails. It is the one module apotrope needs that exists in both editions, so exactly one check breaks.

Compounding it, every error-count message said "run as Administrator for full results" unconditionally — sending an already-elevated user down the wrong path (reported from an elevated PS 7.6.2 session on Win11 26200).

## Changes

- `utils.run_powershell` now spawns `powershell.exe` with `PSModulePath` removed from the child environment (`_child_env()`); Windows PowerShell rebuilds its correct default when the variable is absent. Fixes all checks at once.
- Scanner warning, terminal footer, and both executive summaries only suggest elevation when `is_admin` is false; otherwise they point to `--log-level DEBUG` / per-check detail.

## Verification

- Repro confirmed with no apotrope code involved: `python -c "subprocess.run(['powershell.exe', ..., 'Get-ExecutionPolicy -Scope LocalMachine'])"` fails from pwsh 7, succeeds with `PSModulePath` stripped.
- End-to-end on the affected machine: `python -m apotrope --category powershell` from a polluted pwsh session now returns `INFO: Execution policy is 'Undefined'` instead of ERROR.
- 720/720 tests pass; added coverage for env stripping and for the admin/non-admin hint variants.