### PR TITLE
fix(build): exe silently shipped with zero check modules when apotrope not pip-installed

### DIFF
--- a/build_exe.py
+++ b/build_exe.py
@@ -15,6 +15,8 @@ The exe runs on any Windows 10/11 machine without a Python installation.
 from __future__ import annotations
 
 import argparse
+import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -124,18 +126,43 @@ def build(use_icon: bool = True) -> int:
         else:
             print("[build] No icon found — building without custom icon")
 
+    # --collect-submodules imports the package in an isolated subprocess that
+    # does NOT see --paths; unless apotrope is importable there (installed, or
+    # src on PYTHONPATH) it silently collects nothing and the exe ships with
+    # zero check modules.
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        p for p in (str(ROOT / "src"), env.get("PYTHONPATH")) if p
+    )
+
     print(f"[build] Running: {' '.join(cmd)}\n")
-    result = subprocess.run(cmd, cwd=str(ROOT))
+    result = subprocess.run(cmd, cwd=str(ROOT), env=env)
 
-    if result.returncode == 0:
-        exe = ROOT / "dist" / "apotrope.exe"
-        size_mb = exe.stat().st_size / 1024 / 1024 if exe.exists() else 0
-        print(f"\n[build] SUCCESS — dist/apotrope.exe ({size_mb:.1f} MB)")
-        print("[build] Test with:  dist\\apotrope.exe --version")
-    else:
+    if result.returncode != 0:
         print(f"\n[build] FAILED (exit {result.returncode})")
+        return result.returncode
 
-    return result.returncode
+    exe = ROOT / "dist" / "apotrope.exe"
+    size_mb = exe.stat().st_size / 1024 / 1024 if exe.exists() else 0
+
+    # Smoke test: a build where collect_submodules found nothing still exits 0
+    # but bundles no checks — fail loudly instead of shipping a useless exe.
+    probe = subprocess.run(
+        [str(exe), "--dry-run", "--no-color"],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+        timeout=120,
+    )
+    match = re.search(r"\((\d+) module\(s\) would run\)", probe.stdout)
+    bundled = int(match.group(1)) if match else 0
+    if probe.returncode != 0 or bundled == 0:
+        print("\n[build] FAILED — exe bundles no check modules "
+              "(--dry-run probe). Is apotrope importable at build time?")
+        return 1
+
+    print(f"\n[build] SUCCESS — dist/apotrope.exe ({size_mb:.1f} MB)")
+    print(f"[build] Probe: {bundled} check module(s) bundled")
+    print("[build] Test with:  dist\\apotrope.exe --version")
+    return 0
 
 
 def main() -> None:


### PR DESCRIPTION
## Problem

`python build_exe.py` on a machine where apotrope is not pip-installed produces a 20.8 MB exe that discovers check names from the `checks.MODULES` registry but fails to import every one of them — every scan returns 0 results. The build still printed SUCCESS.

Root cause: `--collect-submodules apotrope.checks` resolves the package in an isolated subprocess that does not see `--paths src`. Verified directly: `collect_submodules("apotrope.checks")` returns `[]` without src importable, the full 15-module list with it. (Previous release builds presumably worked because an editable install was present in the build Python.)

## Changes

- `build_exe.py` now puts `src` on `PYTHONPATH` for the PyInstaller subprocess (prepended, preserving any existing value), so builds work with or without an installed package.
- Added a post-build smoke test: the freshly built exe is probed with `--dry-run` and the build fails loudly if it bundles zero check modules, instead of reporting SUCCESS on a useless artifact.

## Verification

Rebuilt on the affected machine: probe reports `14 check module(s) bundled`; full scan from a PowerShell 7 session completes 53 checks with 0 errors (also confirming #50 works in packaged form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)