### PR TITLE
v0.1.7 release: PS7 compatibility fix, triage-view default, build probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.1.7] - 2026-06-12
+
+### Changed
+- **Triage view is now the default terminal output.** Every category with
+  issues gets its own box listing each FAIL/WARN finding with its fix and a
+  ready-to-paste PowerShell command — no flag needed. `--fix` is retired and
+  kept only as a hidden no-op so existing scripts don't error; `--verbose`
+  shows the same boxes for every category and check, passing ones included.
+- **Error messages no longer tell elevated users to "run as Administrator".**
+  When a check errors during an already-elevated scan, the terminal footer,
+  scanner warning, and report summaries now point to `--log-level DEBUG` /
+  per-check detail instead of suggesting elevation that wouldn't help.
+
+### Fixed
+- **PowerShell Execution Policy check no longer errors when Apotrope is
+  launched from PowerShell 7.** pwsh 7 leaves its own Core-only module paths
+  in `PSModulePath`; the Windows PowerShell 5.1 subprocesses then resolved
+  `Microsoft.PowerShell.Security` to the PS7 copy and failed to load it.
+  Apotrope now strips `PSModulePath` from check subprocesses so Windows
+  PowerShell rebuilds its correct default.
+- **`build_exe.py` can no longer ship an exe with zero check modules.**
+  PyInstaller's `--collect-submodules` silently collected nothing unless
+  apotrope was pip-installed in the build Python; the build script now puts
+  `src` on `PYTHONPATH` for the build and probes the finished exe with
+  `--dry-run`, failing loudly if no check modules are bundled.
+
+### Docs
+- All PowerShell run examples now use `.\apotrope.exe` (bare `apotrope.exe`
+  fails in PowerShell, which doesn't run programs from the current folder by
+  name) and `cd $env:USERPROFILE\Downloads` for navigation.
+- README terminal screenshots regenerated for the triage-box output.
+
+### Tests
+- Rich terminal rendering paths in the reporter are now covered end-to-end,
+  including the new admin-aware error hints and build-probe behaviors.
+
+---
+
 ## [0.1.6] - 2026-06-06
 
 ### Added

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ Apotrope is a **read-only** security auditing tool. It does not modify system co
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 0.1.6    | :white_check_mark: |
-| < 0.1.6  | :x:                |
+| 0.1.7    | :white_check_mark: |
+| < 0.1.7  | :x:                |
 
 Only the latest release is actively supported with security updates.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apotrope"
-version = "0.1.6"
+version = "0.1.7"
 description = "A portable Windows security posture auditor"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/apotrope/__init__.py
+++ b/src/apotrope/__init__.py
@@ -1,4 +1,4 @@
 """Apotrope — Windows Security Posture Auditor."""
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

Release bookkeeping for **v0.1.7** — version bump (pyproject.toml + `__init__.py`), CHANGELOG entry, and SECURITY.md supported-versions refresh. The substantive work shipped in #45-#51 and is already on main; this PR cuts the release that delivers it to exe users:

**Fixed**
- PowerShell Execution Policy check no longer errors when launched from PowerShell 7 — `PSModulePath` is stripped from check subprocesses (#50)
- `build_exe.py` can no longer silently ship an exe with zero check modules — PYTHONPATH fix + post-build `--dry-run` probe (#51)

**Changed**
- Triage view (per-category issue boxes with paste-ready commands) is the default terminal output; `--fix` retired to a hidden no-op (#47)
- Error messages are admin-aware — elevated users are pointed to `--log-level DEBUG`, not "run as Administrator" (#50)

**Docs / Tests**
- `.\apotrope.exe` PowerShell examples, regenerated screenshots, Rich rendering test coverage (#45, #46, #48, #49)

## Test results

720/720 tests pass on the release branch (run after the version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)