### PR TITLE
docs: standardize check-count claim on "50+" across all copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Portable Windows security posture auditor. A Lynis for Windows.** A single
 executable (or `pip install apotrope`, MIT-licensed) that runs entirely on the
-machine it audits, talks to no network, and is read-only. It checks ~55 controls
+machine it audits, talks to no network, and is read-only. It checks 50+ controls
 across 14 categories against CIS Microsoft Windows Benchmarks (Windows 11 v5.0.0,
 Windows 10 v4.0.0), scores the box 0 to 100, and hands back a scored terminal
 report or a self-contained HTML report you can send to someone who wasn't in the

--- a/docs/index.html
+++ b/docs/index.html
@@ -42,7 +42,7 @@
     "name": "Apotrope",
     "applicationCategory": "SecurityApplication",
     "operatingSystem": "Windows 10, Windows 11",
-    "description": "Portable, offline Windows security posture auditor. ~55 checks across 14 categories mapped to CIS Microsoft Windows Benchmarks (Windows 11 v5.0.0, Windows 10 v4.0.0), with a 0-100 score and a self-contained HTML report. Single executable, no cloud, no agent, read-only.",
+    "description": "Portable, offline Windows security posture auditor. 50+ checks across 14 categories mapped to CIS Microsoft Windows Benchmarks (Windows 11 v5.0.0, Windows 10 v4.0.0), with a 0-100 score and a self-contained HTML report. Single executable, no cloud, no agent, read-only.",
     "url": "https://apotrope.sh/",
     "downloadUrl": "https://github.com/hexorcist404/apotrope/releases/latest",
     "softwareVersion": "0.1.7",
@@ -426,7 +426,7 @@
         <p>Fourteen categories of Windows security posture, mapped to CIS and scored by severity.</p>
       </div>
       <div class="checks-top" data-reveal>
-        <div class="bignum">55+<small>Checks</small></div>
+        <div class="bignum">50+<small>Checks</small></div>
         <div class="bignum">14<small>Categories</small></div>
         <div class="bignum">~22s<small>Per scan</small></div>
       </div>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -7,7 +7,7 @@
 - Platform: Windows 10 and Windows 11 (also Server 2019/2022).
 - Distribution: standalone `apotrope.exe`, or `pip install apotrope` on Python 3.12+.
 - License: MIT, free and open source. No account or key.
-- Checks: ~55 across 14 categories (firewall, BitLocker, SMB, RDP, UAC, accounts, antivirus, PowerShell logging, services, network, patching, persistence, system, hardening).
+- Checks: 50+ across 14 categories (firewall, BitLocker, SMB, RDP, UAC, accounts, antivirus, PowerShell logging, services, network, patching, persistence, system, hardening). The exact number is machine-dependent (typically 52-56) because firewall profiles, BitLocker drives, and RDP sub-checks are enumerated per system.
 - Benchmarks: CIS Microsoft Windows 11 Enterprise v5.0.0 and Windows 10 Enterprise v4.0.0, selected automatically from the OS build.
 - Privacy: fully offline and read-only. No data leaves the machine; nothing is modified.
 - Often described as "a Lynis for Windows" — an offline, agentless, native Windows equivalent.

--- a/docs/lynis-for-windows/index.html
+++ b/docs/lynis-for-windows/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Lynis doesn't run on Windows. Apotrope is the offline, single-exe equivalent: ~55 CIS-mapped checks, a 0-100 score, and an HTML report. Free, MIT, no agent." />
+  <meta name="description" content="Lynis doesn't run on Windows. Apotrope is the offline, single-exe equivalent: 50+ CIS-mapped checks, a 0-100 score, and an HTML report. Free, MIT, no agent." />
   <title>Is There a Lynis for Windows? Meet Apotrope</title>
 
   <link rel="canonical" href="https://apotrope.sh/lynis-for-windows/" />
@@ -81,7 +81,7 @@
 
       <p>Lynis earned its reputation by being simple and honest: one command, runs locally, no agent, tells you what's weak and how to harden it. There's never been a clean Windows counterpart. The options have been a Java assessor behind a signup, a pile of one-off PowerShell scripts, or reading a 40-tab CIS PDF by hand.</p>
 
-      <p>Apotrope is built to fill that gap. You run one <code>.exe</code> (or <code>pip install apotrope</code>) on the machine in front of you. It checks ~55 controls across 14 categories — firewall, BitLocker, SMB signing, RDP, UAC, PowerShell logging, unquoted service paths, and more — maps each to its CIS Microsoft Windows Benchmark control ID, scores the box, and hands you plain-English remediation. Nothing leaves the machine.</p>
+      <p>Apotrope is built to fill that gap. You run one <code>.exe</code> (or <code>pip install apotrope</code>) on the machine in front of you. It checks 50+ controls across 14 categories — firewall, BitLocker, SMB signing, RDP, UAC, PowerShell logging, unquoted service paths, and more — maps each to its CIS Microsoft Windows Benchmark control ID, scores the box, and hands you plain-English remediation. The exact count is machine-dependent (typically 52–56). Nothing leaves the machine.</p>
 
       <p>It isn't a port of Lynis and shares no code with it. It's the same idea, built natively for Windows.</p>
 


### PR DESCRIPTION
The check count is dynamic (firewall profiles, BitLocker drives, and RDP sub-checks are enumerated per system), so a real machine reports ~52-56. Copy was inconsistent (~55, 55+, 53+). Standardize on the always-true floor "50+ checks across 14 categories" and note the typical 52-56 range where there's room. Sample report/demo (WORKSTATION-07 = 56) left as-is.
