### PR TITLE
docs: drop outdated winposture repo-slug note from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Renamed the project from WinPosture to Apotrope.** The Python package is now
   `apotrope`, the console script and bundled executable are `apotrope` / `apotrope.exe`,
   and all documentation, templates, and tests reference the new name. No functional
-  audit logic changed. (The GitHub repository slug remains `winposture`.)
+  audit logic changed.
 - Build icon now renders an "A" glyph to match the new name.
 
 ---


### PR DESCRIPTION
The repository is now `github.com/hexorcist404/apotrope`, so the v0.1.3 CHANGELOG parenthetical claiming the GitHub slug "remains `winposture`" is no longer accurate.

- Removes the stale `(The GitHub repository slug remains winposture.)` note.
- Leaves the historical rename entry ("Renamed the project from WinPosture to Apotrope") intact, since it documents the rename event itself.

This was the last factual `winposture` reference in the tracked tree (remote URL and package paths are already `apotrope`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)