### PR TITLE
fix: address verified findings from external code review

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,16 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install package and dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        # Gate publication on the tagged commit passing tests. test.yml does
+        # NOT run on tags, so without this gate a v* tag could publish untested
+        # code. This is a representative gate (ubuntu / Python 3.12), not the
+        # full windows+ubuntu x 3.12+3.13 matrix that test.yml runs on PRs.
+        run: pytest tests/ -q --tb=short --cov --cov-fail-under=95
+
       - name: Build sdist and wheel
         run: |
           python -m pip install --upgrade build twine

--- a/gen_screenshots.py
+++ b/gen_screenshots.py
@@ -12,7 +12,6 @@ Usage:  python gen_screenshots.py <outdir>
 
 from __future__ import annotations
 
-import dataclasses
 import io
 import sys
 from pathlib import Path
@@ -21,9 +20,8 @@ from unittest import mock
 from rich.console import Console
 from rich.terminal_theme import TerminalTheme
 
-from apotrope import __version__
 from apotrope.models import Status
-from apotrope.reporter import Reporter, _text, _GREEN, _MUTED, _CYAN, _BRIGHT
+from apotrope.reporter import Reporter, _text, _MUTED, _CYAN, _BRIGHT
 from apotrope.scanner import Scanner
 from apotrope.utils import is_admin
 

--- a/src/apotrope/checks/network.py
+++ b/src/apotrope/checks/network.py
@@ -191,10 +191,12 @@ def _check_netbios() -> list[CheckResult]:
     # Normalise to plain ints
     opt_ints = []
     for o in options:
-        try:
-            opt_ints.append(int(o))
-        except (TypeError, ValueError):
-            pass
+        # Elements come from JSON (dict | list | scalar); only coerce scalars.
+        if isinstance(o, (int, str)):
+            try:
+                opt_ints.append(int(o))
+            except (TypeError, ValueError):
+                pass
 
     if not opt_ints:
         return [CheckResult(

--- a/src/apotrope/cis_map.py
+++ b/src/apotrope/cis_map.py
@@ -2,9 +2,9 @@
 
 Maps check_name values to CIS Microsoft Windows Benchmark control IDs.
 The base map (_PREFIX_MAP) uses CIS Microsoft Windows 11 Enterprise Benchmark
-v5.0.0 IDs.  When running on Windows 10, pass ``is_win10=True`` to ``lookup``
-and the eight IDs that differ in CIS Microsoft Windows 10 Enterprise Benchmark
-v4.0.0 will be substituted from ``_WIN10_OVERRIDES`` automatically.
+v5.0.0 IDs.  For Windows 10 / Server families, pass the matching ``OSFamily``
+to ``lookup`` and the IDs that differ in CIS Microsoft Windows 10 Enterprise
+Benchmark v4.0.0 are substituted from ``_WIN10_OVERRIDES`` automatically.
 
 References are approximate — always verify against the current official
 benchmark for your specific OS version and edition before use in a formal
@@ -68,23 +68,38 @@ NEEDS MANUAL REVIEW (no direct CIS admin template control in v5.0.0):
 
 from __future__ import annotations
 
+from enum import Enum
+
 # CIS Benchmark editions these IDs are verified against, by OS family.
 # Windows 11 uses the v5.0.0 benchmark; Windows 10 / Server 2019 uses v4.0.0.
 CIS_VERSION_WIN11 = "v5.0.0"
 CIS_VERSION_WIN10 = "v4.0.0"
 
 
-def benchmark_version(is_win10: bool = False) -> str:
-    """Return the CIS Benchmark edition string for the audited OS family.
+class OSFamily(Enum):
+    """Operating-system family used to select a CIS Benchmark edition + ID set."""
 
-    Args:
-        is_win10: ``True`` for Windows 10 / Server 2019 hosts (build < 22000),
-                  ``False`` for Windows 11.
+    WIN10 = "Windows 10"
+    WIN11 = "Windows 11"
+    SERVER_2019 = "Windows Server 2019"
+    SERVER_2022 = "Windows Server 2022"
 
-    Returns:
-        ``"v4.0.0"`` for Windows 10, ``"v5.0.0"`` for Windows 11.
+
+def family_for_build(build: int) -> OSFamily:
+    """Classify a Windows build number into an :class:`OSFamily`.
+
+    Note: build numbers do NOT uniquely identify server vs client. Build 17763
+    is shared by Windows 10 1809 and Server 2019, and 14393 by Win10 1607 and
+    Server 2016 — so those server editions cannot be told apart from client
+    Windows 10 by build alone (that needs ``Win32_OperatingSystem.ProductType``).
+    Build 20348 is unambiguous (no client Windows uses it) → Server 2022.
+    Anything else below 22000 is treated as the Windows 10 / v4.0.0 family.
     """
-    return CIS_VERSION_WIN10 if is_win10 else CIS_VERSION_WIN11
+    if build == 20348:
+        return OSFamily.SERVER_2022
+    if build >= 22000:
+        return OSFamily.WIN11
+    return OSFamily.WIN10
 
 
 # Win10 v4.0.0 IDs that differ from the Win11 v5.0.0 base map.
@@ -101,6 +116,34 @@ _WIN10_OVERRIDES: dict[str, str] = {
     "Pending Windows Updates":          "CIS 18.10.93.2.1",
     "SMB Encryption":                   "",   # not present in Win10 v4.0.0
 }
+
+# Additive family → benchmark registry: (cis_version, overrides_map, caveat).
+# Each family is one self-contained entry. To support a real CIS Server 2022
+# Benchmark later, swap that one tuple for
+# ``(CIS_VERSION_SERVER_2022, _SERVER2022_OVERRIDES, "")`` — no call site changes.
+# Server 2019/2022 ride the Windows 10 v4.0.0 ID set as a best-effort baseline;
+# Server 2022 also carries a caveat so its report is honest about the approximation.
+_SERVER2022_CAVEAT = (
+    "Windows 10 v4.0.0 baseline — Server 2022 control IDs are best-effort; "
+    "verify against the CIS Microsoft Windows Server 2022 Benchmark."
+)
+_FAMILY_BENCHMARKS: dict[OSFamily, tuple[str, dict[str, str], str]] = {
+    OSFamily.WIN11:       (CIS_VERSION_WIN11, {},               ""),
+    OSFamily.WIN10:       (CIS_VERSION_WIN10, _WIN10_OVERRIDES, ""),
+    OSFamily.SERVER_2019: (CIS_VERSION_WIN10, _WIN10_OVERRIDES, ""),
+    OSFamily.SERVER_2022: (CIS_VERSION_WIN10, _WIN10_OVERRIDES, _SERVER2022_CAVEAT),
+}
+
+
+def benchmark_version(family: OSFamily = OSFamily.WIN11) -> str:
+    """Return the CIS Benchmark edition string for an OS *family*."""
+    return _FAMILY_BENCHMARKS[family][0]
+
+
+def benchmark_caveat(family: OSFamily = OSFamily.WIN11) -> str:
+    """Return a best-effort caveat for *family*, or ``""`` when the mapping is exact."""
+    return _FAMILY_BENCHMARKS[family][2]
+
 
 # Maps check_name prefix → CIS control ID.
 # Prefix matching allows one entry to cover dynamically-named checks
@@ -207,7 +250,7 @@ _PREFIX_MAP: dict[str, str] = {
 }
 
 
-def lookup(check_name: str, is_win10: bool = False) -> str:
+def lookup(check_name: str, family: OSFamily = OSFamily.WIN11) -> str:
     """Return the CIS Benchmark control ID for *check_name*, or ``''`` if unknown.
 
     Matching is done by prefix so that dynamically-named checks (e.g.
@@ -215,17 +258,17 @@ def lookup(check_name: str, is_win10: bool = False) -> str:
 
     Args:
         check_name: The ``check_name`` field from a ``CheckResult``.
-        is_win10:   Set to ``True`` when auditing a Windows 10 host so that
-                    IDs from ``_WIN10_OVERRIDES`` are substituted where the
-                    v4.0.0 and v5.0.0 benchmarks differ.
+        family:     The audited :class:`OSFamily`.  Families on the v4.0.0
+                    baseline (Win10 / Server 2019 / Server 2022) substitute IDs
+                    from their override map where v4.0.0 and v5.0.0 differ.
 
     Returns:
         CIS control ID string (e.g. ``"CIS 9.1.1"``), or empty string.
     """
-    if is_win10:
-        for prefix, cis_id in _WIN10_OVERRIDES.items():
-            if check_name.startswith(prefix):
-                return cis_id
+    overrides = _FAMILY_BENCHMARKS[family][1]
+    for prefix, cis_id in overrides.items():
+        if check_name.startswith(prefix):
+            return cis_id
     for prefix, cis_id in _PREFIX_MAP.items():
         if check_name.startswith(prefix):
             return cis_id

--- a/src/apotrope/compare.py
+++ b/src/apotrope/compare.py
@@ -38,7 +38,13 @@ class ScanDiff:
         current_score:     Security score from the current scan.
         score_delta:       current_score − baseline_score (positive = improved).
         new_findings:      Checks that are FAIL/WARN now but were not in baseline.
-        resolved_findings: Checks that were FAIL/WARN in baseline but are now PASS/INFO.
+        resolved_findings: Checks that were FAIL/WARN in baseline but are now PASS/INFO
+                           (present in BOTH scans — genuinely remediated).
+        missing_findings:  Checks that were FAIL/WARN in baseline but ABSENT from the
+                           current scan. This is coverage lost (a narrower --category,
+                           a disabled/admin-gated check, an import failure, or a rename)
+                           — NOT proof of remediation. Tracked separately so a reduced
+                           scan is never mistaken for fixed risk.
         worsened_findings: Checks that were PASS/INFO in baseline but are now FAIL/WARN.
         unchanged_bad:     Checks that were FAIL/WARN in both scans.
         unchanged_count:   Total number of checks with the same status in both scans.
@@ -52,6 +58,7 @@ class ScanDiff:
     worsened_findings: list[CheckResult]
     unchanged_bad: list[CheckResult]
     unchanged_count: int
+    missing_findings: list[CheckResult] = dataclasses.field(default_factory=list)
 
 
 def compare_reports(baseline: AuditReport, current: AuditReport) -> ScanDiff:
@@ -75,6 +82,7 @@ def compare_reports(baseline: AuditReport, current: AuditReport) -> ScanDiff:
 
     new_findings: list[CheckResult] = []
     resolved_findings: list[CheckResult] = []
+    missing_findings: list[CheckResult] = []
     worsened_findings: list[CheckResult] = []
     unchanged_bad: list[CheckResult] = []
     unchanged_count = 0
@@ -90,9 +98,12 @@ def compare_reports(baseline: AuditReport, current: AuditReport) -> ScanDiff:
             else:
                 unchanged_count += 1
         elif c is None and b is not None:
-            # Only in baseline (check no longer running)
+            # Only in baseline: this check did not run in the current scan.
+            # A bad check vanishing is NOT remediation — it can be a narrower
+            # --category set, a disabled/admin-gated check, an import failure,
+            # or a rename. Bucket it as coverage lost, never as resolved.
             if b.status in _BAD:
-                resolved_findings.append(b)
+                missing_findings.append(b)
             else:
                 unchanged_count += 1
         else:
@@ -117,6 +128,7 @@ def compare_reports(baseline: AuditReport, current: AuditReport) -> ScanDiff:
         score_delta=score_delta,
         new_findings=new_findings,
         resolved_findings=resolved_findings,
+        missing_findings=missing_findings,
         worsened_findings=worsened_findings,
         unchanged_bad=unchanged_bad,
         unchanged_count=unchanged_count,

--- a/src/apotrope/models.py
+++ b/src/apotrope/models.py
@@ -78,6 +78,8 @@ class AuditReport:
     score: int = 0
     is_admin: bool = False
     cis_version: str = ""  # CIS Benchmark edition used (e.g. "v5.0.0" / "v4.0.0")
+    cis_caveat: str = ""   # Best-effort note when the edition is an approximation
+                           # (e.g. Server 2022 mapped onto the Win10 v4.0.0 baseline)
 
     # ------------------------------------------------------------------
     # Convenience helpers

--- a/src/apotrope/reporter.py
+++ b/src/apotrope/reporter.py
@@ -13,7 +13,7 @@ import json
 import logging
 import textwrap
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from apotrope.scanner import Scanner
@@ -140,8 +140,10 @@ def _cis_version_for(report: AuditReport) -> str:
         return report.cis_version
     m = re.search(r"(\d{3,})\s*$", (report.os_version or "").strip())
     build = int(m.group(1)) if m else 0
-    # Match scanner.run's test, but treat an unparseable build as current (Win11).
-    return cis_map.benchmark_version(is_win10=bool(build) and build < 22000)
+    # Treat an unparseable build as current (Win11); otherwise key on OS family.
+    if not build:
+        return cis_map.benchmark_version(cis_map.OSFamily.WIN11)
+    return cis_map.benchmark_version(cis_map.family_for_build(build))
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -398,10 +400,11 @@ class Reporter:
         console.print(f"  {sep * 65}")
 
         sections: list[tuple[str, str, list]] = [
-            ("green",  "Resolved", diff.resolved_findings),
-            ("red",    "New",      diff.new_findings),
-            ("yellow", "Worsened", diff.worsened_findings),
-            ("yellow", "Ongoing",  diff.unchanged_bad),
+            ("green",   "Resolved", diff.resolved_findings),
+            ("magenta", "Not scanned (coverage lost)", diff.missing_findings),
+            ("red",     "New",      diff.new_findings),
+            ("yellow",  "Worsened", diff.worsened_findings),
+            ("yellow",  "Ongoing",  diff.unchanged_bad),
         ]
 
         any_printed = False
@@ -425,6 +428,7 @@ class Reporter:
         console.print(f"  {sep * 65}")
         console.print(
             f"  Resolved: {len(diff.resolved_findings)}  |  "
+            f"Not scanned: {len(diff.missing_findings)}  |  "
             f"New: {len(diff.new_findings)}  |  "
             f"Worsened: {len(diff.worsened_findings)}  |  "
             f"Unchanged: {diff.unchanged_count}"
@@ -512,7 +516,7 @@ class Reporter:
         category_bars = sorted(
             ({"name": c["name"], "slug": c["slug"],
               "score": c["score"], "band": c["band"]} for c in category_data),
-            key=lambda c: c["score"],
+            key=lambda c: cast(int, c["score"]),  # score is always an int at runtime
         )
 
         # ── Top issues: FAIL/WARN with remediation, CRITICAL/HIGH or any FAIL ─
@@ -603,6 +607,7 @@ class Reporter:
             "n_cats":             len(category_data),
             "top_issues":         top_issues,
             "cis_version":        _cis_version_for(report),
+            "cis_caveat":         report.cis_caveat,
         }
 
     def _build_executive_summary(self, report: AuditReport) -> str:

--- a/src/apotrope/scanner.py
+++ b/src/apotrope/scanner.py
@@ -20,6 +20,7 @@ from apotrope.models import AuditReport, CheckResult, Status, Severity
 from apotrope.scoring import calculate_score
 
 if TYPE_CHECKING:
+    from apotrope import cis_map
     from apotrope.profile import Profile
 
 log = logging.getLogger(__name__)
@@ -96,17 +97,17 @@ class Scanner:
             module_results = self._run_module(module)
             results.extend(module_results)
 
-        # Apply CIS references from the central map.
-        # Build numbers < 22000 are Windows 10 / Server 2019; use Win10 IDs.
+        # Apply CIS references from the central map, keyed on OS family.
         try:
             build = int(platform.version().split(".")[-1])
         except (ValueError, IndexError):
             build = 0
-        is_win10 = build < 22000
-        self._apply_cis_references(results, is_win10=is_win10)
-
         from apotrope import cis_map
-        cis_version = cis_map.benchmark_version(is_win10=is_win10)
+        family = cis_map.family_for_build(build)
+        self._apply_cis_references(results, family=family)
+
+        cis_version = cis_map.benchmark_version(family)
+        cis_caveat = cis_map.benchmark_caveat(family)
 
         # Apply profile transforms (disabled checks, severity overrides)
         if self.profile:
@@ -133,6 +134,7 @@ class Scanner:
             score=score,
             is_admin=self.is_admin,
             cis_version=cis_version,
+            cis_caveat=cis_caveat,
         )
         log.info(
             "Scan complete: %d results, score=%d, duration=%.2fs",
@@ -254,12 +256,15 @@ class Scanner:
         return results
 
     @staticmethod
-    def _apply_cis_references(results: list[CheckResult], is_win10: bool = False) -> None:
+    def _apply_cis_references(
+        results: list[CheckResult], family: "cis_map.OSFamily | None" = None
+    ) -> None:
         """Populate the cis_reference field on results that don't already have one."""
         from apotrope import cis_map
+        fam = family or cis_map.OSFamily.WIN11
         for r in results:
             if not r.cis_reference:
-                r.cis_reference = cis_map.lookup(r.check_name, is_win10=is_win10)
+                r.cis_reference = cis_map.lookup(r.check_name, fam)
 
     def _apply_profile(self, results: list[CheckResult]) -> list[CheckResult]:
         """Apply profile transforms: disabled_checks filter and severity_overrides."""

--- a/src/apotrope/templates/report.html.j2
+++ b/src/apotrope/templates/report.html.j2
@@ -567,7 +567,7 @@
 
     <!-- ── Footer ──────────────────────────────────────────────────────── -->
     <div class="foot">
-      <span class="auth">For authorized security assessment use only · <strong style="color:var(--green);font-weight:600;text-shadow:0 0 9px rgba(43,255,136,0.45)">No data left this machine</strong> · CIS Benchmark {{ cis_version }}</span>
+      <span class="auth">For authorized security assessment use only · <strong style="color:var(--green);font-weight:600;text-shadow:0 0 9px rgba(43,255,136,0.45)">No data left this machine</strong> · CIS Benchmark {{ cis_version }}{% if cis_caveat %} · <span class="cis-caveat" style="color:#ffb23d">{{ cis_caveat }}</span>{% endif %}</span>
       <span>apotrope.sh · <a href="https://github.com/hexorcist404/apotrope">github.com/hexorcist404/apotrope</a> · MIT</span>
     </div>
 

--- a/src/apotrope/utils.py
+++ b/src/apotrope/utils.py
@@ -101,17 +101,23 @@ def run_powershell_json(command: str, timeout: int = 30) -> dict | list:
         timeout: Seconds before the subprocess is killed (default 30).
 
     Returns:
-        Parsed Python ``dict`` or ``list``.
+        Parsed Python ``dict`` or ``list``.  An **empty list** is returned
+        when the command produces no output: a PowerShell pipeline matching
+        zero objects emits empty stdout after ``ConvertTo-Json``, which is a
+        valid "nothing found" result — not an error (mirrors
+        :func:`get_wmi_object`).  Callers should treat a falsy result as
+        "none found".
 
     Raises:
-        ApotropeError: On PowerShell failure, empty output, or invalid JSON.
+        ApotropeError: On PowerShell failure or invalid (non-empty) JSON.
     """
     output = run_powershell(command, timeout=timeout)
 
+    # Zero pipeline objects -> empty stdout. Treat as "no rows" ([]) so that
+    # callers' graceful "none found" paths are reachable on real machines;
+    # only *malformed* non-empty JSON below is a genuine error.
     if not output:
-        raise ApotropeError(
-            "PowerShell command returned empty output (expected JSON)"
-        )
+        return []
 
     try:
         return json.loads(output)

--- a/tests/test_checks/test_accounts.py
+++ b/tests/test_checks/test_accounts.py
@@ -84,6 +84,17 @@ class TestCheckBuiltinAdmin:
         assert r.status == Status.INFO
         assert "not found" in r.details.lower()
 
+    def test_renamed_admin_empty_stdout_is_info(self):
+        # Regression: a renamed/absent Administrator produces empty PowerShell
+        # stdout. Exercise the REAL run_powershell_json (patch the lower-level
+        # run_powershell) to prove empty output surfaces as INFO "not found",
+        # not a confusing Status.ERROR. This failed before the empty-output fix.
+        with patch("apotrope.utils.run_powershell", return_value=""):
+            results = accounts._check_builtin_admin()
+        r = results[0]
+        assert r.status == Status.INFO
+        assert "not found" in r.details.lower()
+
     def test_list_data_uses_first_element(self):
         results = self._run([{"Name": "Administrator", "Enabled": False}])
         assert results[0].status == Status.PASS

--- a/tests/test_checks/test_startup.py
+++ b/tests/test_checks/test_startup.py
@@ -82,6 +82,16 @@ class TestCheckScheduledTasks:
         r = self._run([])[0]
         assert "No non-Microsoft" in r.details
 
+    def test_no_tasks_empty_stdout_is_info(self):
+        # Regression: a clean machine can have zero non-Microsoft scheduled
+        # tasks, yielding empty PowerShell stdout. Exercise the REAL
+        # run_powershell_json (patch lower-level run_powershell) to prove the
+        # "none found" INFO path is reachable, not a Status.ERROR.
+        with patch("apotrope.utils.run_powershell", return_value=""):
+            r = startup._check_scheduled_tasks()[0]
+        assert r.status == Status.INFO
+        assert "No non-Microsoft" in r.details
+
     def test_tasks_reported(self):
         r = self._run([self._task("BackupJob"), self._task("Updater")])[0]
         assert "2" in r.details

--- a/tests/test_cis_version.py
+++ b/tests/test_cis_version.py
@@ -27,13 +27,26 @@ from apotrope.scanner import Scanner
 
 class TestBenchmarkVersion:
     def test_win11_is_v5(self):
-        assert cis_map.benchmark_version(is_win10=False) == "v5.0.0"
+        assert cis_map.benchmark_version(cis_map.OSFamily.WIN11) == "v5.0.0"
 
     def test_win10_is_v4(self):
-        assert cis_map.benchmark_version(is_win10=True) == "v4.0.0"
+        assert cis_map.benchmark_version(cis_map.OSFamily.WIN10) == "v4.0.0"
 
     def test_default_is_win11(self):
         assert cis_map.benchmark_version() == "v5.0.0"
+
+    def test_server_2022_is_v4_baseline_with_caveat(self):
+        # Best-effort: Server 2022 rides the Win10 v4.0.0 baseline and is
+        # flagged with a caveat until its own benchmark IDs are sourced.
+        assert cis_map.benchmark_version(cis_map.OSFamily.SERVER_2022) == "v4.0.0"
+        assert cis_map.benchmark_caveat(cis_map.OSFamily.SERVER_2022)       # non-empty
+        assert cis_map.benchmark_caveat(cis_map.OSFamily.WIN11) == ""        # exact → none
+
+    def test_family_for_build(self):
+        assert cis_map.family_for_build(20348) == cis_map.OSFamily.SERVER_2022
+        assert cis_map.family_for_build(22631) == cis_map.OSFamily.WIN11
+        assert cis_map.family_for_build(22000) == cis_map.OSFamily.WIN11
+        assert cis_map.family_for_build(19045) == cis_map.OSFamily.WIN10
 
     def test_constants_match(self):
         assert cis_map.CIS_VERSION_WIN11 == "v5.0.0"
@@ -51,10 +64,15 @@ class TestLookupOsAware:
 
     def test_win10_substitutes_override(self):
         # Win10 v4.0.0 renumbers section 88 → 87, so the ID must differ.
-        win10 = cis_map.lookup("PowerShell Script Block Logging", is_win10=True)
-        win11 = cis_map.lookup("PowerShell Script Block Logging", is_win10=False)
+        win10 = cis_map.lookup("PowerShell Script Block Logging", cis_map.OSFamily.WIN10)
+        win11 = cis_map.lookup("PowerShell Script Block Logging", cis_map.OSFamily.WIN11)
         assert win10 == "CIS 18.10.87.1"
         assert win10 != win11
+
+    def test_server_2022_uses_v4_baseline_ids(self):
+        # Server 2022 shares the Win10 v4.0.0 override set as its best-effort baseline.
+        srv = cis_map.lookup("PowerShell Script Block Logging", cis_map.OSFamily.SERVER_2022)
+        assert srv == "CIS 18.10.87.1"
 
 
 # ---------------------------------------------------------------------------
@@ -62,9 +80,10 @@ class TestLookupOsAware:
 # ---------------------------------------------------------------------------
 
 def _fake_module() -> ModuleType:
+    # setattr (not mod.attr =) so mypy accepts dynamic attributes on ModuleType.
     mod = ModuleType("fake")
-    mod.CATEGORY = "Test"
-    mod.run = lambda: [CheckResult("Test", "x", Status.PASS, Severity.LOW, "d", "ok")]
+    setattr(mod, "CATEGORY", "Test")
+    setattr(mod, "run", lambda: [CheckResult("Test", "x", Status.PASS, Severity.LOW, "d", "ok")])
     return mod
 
 
@@ -88,6 +107,11 @@ class TestScannerStampsVersion:
         report = _run_with_build("10.0.22000")  # first Win11 build
         assert report.cis_version == "v5.0.0"
 
+    def test_server_2022_build_stamps_v4_with_caveat(self):
+        report = _run_with_build("10.0.20348")  # Server 2022 (unambiguous build)
+        assert report.cis_version == "v4.0.0"
+        assert report.cis_caveat  # honest best-effort caveat, not a silent Win10 stamp
+
 
 # ---------------------------------------------------------------------------
 # Reporter HTML footer shows the detected edition
@@ -103,7 +127,11 @@ def _render(report: AuditReport) -> str:
         os.unlink(path)
 
 
-def _report(cis_version: str = "", os_version: str = "Windows 11 Pro 10.0.22631") -> AuditReport:
+def _report(
+    cis_version: str = "",
+    os_version: str = "Windows 11 Pro 10.0.22631",
+    cis_caveat: str = "",
+) -> AuditReport:
     return AuditReport(
         hostname="PC",
         os_version=os_version,
@@ -112,6 +140,7 @@ def _report(cis_version: str = "", os_version: str = "Windows 11 Pro 10.0.22631"
         results=[CheckResult("Firewall", "FW", Status.PASS, Severity.LOW, "d", "ok")],
         score=100,
         cis_version=cis_version,
+        cis_caveat=cis_caveat,
     )
 
 
@@ -133,3 +162,16 @@ class TestReporterFooterVersion:
     def test_fallback_parses_win11_build(self):
         html = _render(_report(cis_version="", os_version="Windows 11 Pro 10.0.26100"))
         assert "CIS Benchmark v5.0.0" in html
+
+    def test_fallback_unparseable_build_defaults_win11(self):
+        # os_version with no trailing build number → treat as current (Win11).
+        html = _render(_report(cis_version="", os_version="Windows (unknown build)"))
+        assert "CIS Benchmark v5.0.0" in html
+
+    def test_caveat_rendered_when_present(self):
+        html = _render(_report(cis_version="v4.0.0", cis_caveat="Server 2022 best-effort"))
+        assert "Server 2022 best-effort" in html
+
+    def test_no_caveat_when_absent(self):
+        html = _render(_report(cis_version="v5.0.0"))
+        assert "best-effort" not in html

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -102,12 +102,26 @@ class TestCompareReports:
         diff = compare_reports(baseline, current)
         assert len(diff.new_findings) == 1
 
-    def test_check_removed_from_current(self):
-        """A failing check in baseline but absent in current → resolved."""
+    def test_check_removed_from_current_is_missing_not_resolved(self):
+        """A failing check absent from current is coverage lost, NOT resolved.
+
+        Absence can be a narrower --category set, a disabled/admin-gated check,
+        an import failure, or a rename — none of which is remediation.
+        """
         baseline = _make_report([_make_result("OldCheck", Status.FAIL)])
         current  = _make_report([])
         diff = compare_reports(baseline, current)
+        assert len(diff.missing_findings) == 1
+        assert diff.missing_findings[0].check_name == "OldCheck"
+        assert diff.resolved_findings == []
+
+    def test_genuinely_remediated_check_is_resolved(self):
+        """A check present in BOTH scans that left FAIL/WARN is truly resolved."""
+        baseline = _make_report([_make_result("Firewall", Status.FAIL)])
+        current  = _make_report([_make_result("Firewall", Status.PASS)])
+        diff = compare_reports(baseline, current)
         assert len(diff.resolved_findings) == 1
+        assert diff.missing_findings == []
 
     def test_pass_to_pass_unchanged(self):
         baseline = _make_report([_make_result("X", Status.PASS)])

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -22,15 +22,16 @@ def _make_module(
     run_raises: Exception | None = None,
 ) -> ModuleType:
     """Return a minimal fake check module."""
+    # setattr (not mod.attr =) so mypy accepts dynamic attributes on ModuleType.
     mod = ModuleType(name)
-    mod.CATEGORY = category
+    setattr(mod, "CATEGORY", category)
     if requires_admin:
-        mod.REQUIRES_ADMIN = True
+        setattr(mod, "REQUIRES_ADMIN", True)
 
     if run_raises is not None:
         def _run():
             raise run_raises
-        mod.run = _run
+        setattr(mod, "run", _run)
     else:
         _results = results or [CheckResult(
             category=category,
@@ -40,7 +41,7 @@ def _make_module(
             description="desc",
             details="ok",
         )]
-        mod.run = lambda: _results
+        setattr(mod, "run", lambda: _results)
 
     return mod
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -141,10 +141,13 @@ class TestRunPowershellJson:
             result = utils.run_powershell_json("... | ConvertTo-Json")
         assert result == [{"Port": 80}, {"Port": 443}]
 
-    def test_empty_output_raises(self):
+    def test_empty_output_returns_empty_list(self):
+        # Zero pipeline objects -> empty stdout is a valid "no rows" result,
+        # not an error: the helper returns [] so callers' "none found" paths
+        # stay reachable (test_malformed_json_raises covers real bad JSON).
         with patch("apotrope.utils.subprocess.run", return_value=_mock_ps("")):
-            with pytest.raises(ApotropeError, match="empty output"):
-                utils.run_powershell_json("Get-Nothing | ConvertTo-Json")
+            result = utils.run_powershell_json("Get-Nothing | ConvertTo-Json")
+        assert result == []
 
     def test_malformed_json_raises(self):
         with patch("apotrope.utils.subprocess.run", return_value=_mock_ps("{not valid json}")):


### PR DESCRIPTION
## Context

An external Sakana/fugu code review flagged several issues. I independently verified every claim against the code (reading the cited file:line locations and cross-checking adversarially) — **all findings were accurate, no false positives**. The baseline reproduced fugu's dashboard exactly (ruff 3, mypy 9, pytest 720). This PR fixes the five priority findings.

## Fixes

| # | Finding | Change |
|---|---|---|
| **P1-B** | Empty PowerShell JSON treated as fatal error | `run_powershell_json` returns `[]` on empty output (mirrors `get_wmi_object`). Renaming the Administrator account — a CIS hardening step — now reports **INFO "good practice"**, not a confusing `ERROR`. Same for a clean machine with zero non-Microsoft scheduled tasks. |
| **P1-A** | Vanished failing checks reported as "Resolved" | New `ScanDiff.missing_findings` bucket. A baseline-only `FAIL`/`WARN` that's absent from the current scan now renders as **"Not scanned (coverage lost)"** instead of green "Resolved" — so a narrower `--category`, non-admin run, or disabled check is never mistaken for fixed risk. |
| **P2-A** | PyPI publish could ship untested tags | `publish.yml` now runs the test suite before build/upload (`test.yml` doesn't trigger on tags). |
| **P2-B** | Server 2022 mapped through Windows 10 logic | Replaced `is_win10: bool` with an `OSFamily` enum + an **additive** family→benchmark registry. Server 2022 (build 20348) is detected explicitly and stamped with an honest best-effort caveat in the report footer instead of silently using Win10 references. |
| **P3** | 3 unused imports, 9 mypy errors | Removed dead imports; `isinstance` narrowing (`network.py`), `cast` on a sort key (`reporter.py`), `setattr` for dynamic test-module attrs. |

## Verification

- `ruff check .` → clean (was 3)
- `mypy src tests` → clean, 55 files (was 9)
- `pytest --cov` → **730 passed, 98.96% coverage** (was 720)
- Manual end-to-end: renamed-admin and zero-tasks paths confirmed to return `INFO`, not `ERROR`
- New regression tests cover the empty-output and missing-check cases (the originals mocked the helper directly, which masked the bug)


🤖 Generated with [Claude Code](https://claude.com/claude-code)