### PR TITLE
feat(cis): detect Server 2019/2016 via ProductType; honest server caveats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,164 @@
+# Apotrope — Codex Project Context
+
+## Git Commit Author
+
+Always use these credentials for commits in this repo:
+
+```
+git config user.name "hexorcist404"
+git config user.email "hexorcist404@pm.me"
+```
+
+The `Co-Authored-By` trailer should also use this identity:
+`Co-Authored-By: hexorcist404 <hexorcist404@pm.me>`
+
+## Project Overview
+
+Apotrope is a portable Windows security posture auditor. It runs locally on a
+Windows machine, audits common security configurations, scores the result (0–100),
+and produces a terminal report (Rich) and/or HTML/JSON output.
+
+## Language & Runtime
+
+- Python 3.12+
+- Type hints on **all** functions and methods (no bare `Any` unless unavoidable)
+- Docstrings on all public functions/classes
+- Logging via Python's `logging` module — never use `print()` for diagnostic output
+
+## Architecture
+
+```
+cli.py  →  scanner.py  →  checks/*.py  →  models.CheckResult
+                      ↓
+                  reporter.py  (terminal via Rich, HTML via Jinja2)
+                  scoring.py   (0-100 score from results list)
+```
+
+### Check Modules (`src/apotrope/checks/`)
+
+Each file is an independent audit module. Conventions:
+
+- Expose a `run() -> list[CheckResult]` function (the scanner calls this)
+- Never call `sys.exit()` or raise unhandled exceptions — return a result with
+  `status=Status.ERROR` and the exception message in `details` instead
+- All PowerShell / WMI / registry calls go through helpers in `utils.py`
+- A single module may return multiple `CheckResult` objects
+
+### `utils.py`
+
+Shared helpers only. Key functions to build out:
+
+- `run_powershell(script: str) -> str` — runs a PS snippet, returns stdout
+- `read_registry(hive, key, value)` — reads a registry value safely
+- `is_admin() -> bool` — checks for elevated privileges
+
+### Data Model (`models.py`)
+
+```python
+@dataclass
+class CheckResult:
+    category: str       # e.g. "Firewall", "Encryption"
+    check_name: str     # e.g. "Windows Firewall - Domain Profile"
+    status: Status      # PASS | FAIL | WARN | INFO | ERROR
+    severity: Severity  # CRITICAL | HIGH | MEDIUM | LOW | INFO
+    description: str    # What is being verified
+    details: str        # What was actually found
+    remediation: str    # How to fix it (empty string if status is PASS)
+```
+
+## Check Categories (files in `checks/`)
+
+| File | Category | Notes |
+|------|----------|-------|
+| `os_info.py` | System | Version, build, patch level |
+| `updates.py` | Patching | Windows Update status |
+| `firewall.py` | Firewall | All three profiles |
+| `antivirus.py` | Antivirus | Defender / third-party AV |
+| `encryption.py` | Encryption | BitLocker per drive |
+| `accounts.py` | Accounts | Local users, admins, guest, password policy |
+| `services.py` | Services | Risky/unnecessary running services |
+| `network.py` | Network | Open ports, listening services |
+| `startup.py` | Persistence | Startup programs, scheduled tasks |
+| `smb.py` | File Sharing | SMBv1 disabled? Signing? |
+| `rdp.py` | Remote Access | Enabled? NLA enforced? |
+| `uac.py` | Access Control | UAC level |
+| `powershell.py` | PowerShell | Execution policy, logging, constrained mode |
+| `misc.py` | Hardening | AutoPlay, remote registry, LLMNR |
+
+## Testing
+
+- Framework: **pytest**
+- Mock all subprocess / WMI / registry calls with `unittest.mock` so tests run on
+  any OS (including Linux CI)
+- Test files mirror the source: `tests/test_checks/test_firewall.py` etc.
+- `tests/conftest.py` holds shared fixtures (sample `CheckResult`, mock PS output…)
+
+## Target Platforms
+
+- Windows 10 (21H2+) and Windows 11
+- Windows Server 2019 and 2022
+
+## Output Formats
+
+- **Terminal**: Rich tables with color-coded status/severity
+- **HTML**: Jinja2 template at `src/apotrope/templates/report.html.j2`
+- **JSON**: Serialized `AuditReport` dataclass (use `dataclasses.asdict`)
+
+## Scoring Logic (`scoring.py`)
+
+Start at 100. Deduct points per failed/warned check weighted by severity:
+
+| Outcome | Severity | Deduction |
+|---------|----------|-----------|
+| FAIL    | CRITICAL | −15       |
+| FAIL    | HIGH     | −10       |
+| FAIL    | MEDIUM   | −5        |
+| FAIL    | LOW      | −2        |
+| WARN    | CRITICAL | −7        |
+| WARN    | HIGH     | −5        |
+| WARN    | MEDIUM   | −2        |
+| WARN    | LOW      | −1        |
+
+Clamp to [0, 100]. INFO and ERROR results do not affect the score.
+
+## Gstack
+
+For all web browsing, use the `/browse` skill from gstack. Never use `mcp__claude-in-chrome__*` tools directly.
+
+### Available Skills
+
+- `/office-hours` — YC-style forcing questions for startup/product decisions
+- `/plan-ceo-review` — CEO/founder-mode plan review
+- `/plan-eng-review` — Eng manager-mode plan review
+- `/plan-design-review` — Designer's eye plan review
+- `/design-consultation` — Understand product and research the landscape
+- `/design-shotgun` — Generate multiple AI design variants
+- `/design-html` — Generate production-quality HTML
+- `/review` — Pre-landing PR review
+- `/ship` — Ship workflow: merge base, run tests, review diff
+- `/land-and-deploy` — Merge PR, wait for CI and deploy
+- `/canary` — Post-deploy canary monitoring
+- `/benchmark` — Performance regression detection
+- `/browse` — Fast headless browser for QA and dogfooding
+- `/connect-chrome` — Launch GStack Browser (AI-controlled Chromium)
+- `/qa` — Systematically QA test a web app and fix bugs
+- `/qa-only` — Report-only QA testing
+- `/design-review` — Designer's eye QA for visual issues
+- `/setup-browser-cookies` — Import cookies from real Chromium into headless browser
+- `/setup-deploy` — Configure deployment settings for `/land-and-deploy`
+- `/setup-gbrain` — Configure gbrain settings
+- `/retro` — Weekly engineering retrospective
+- `/investigate` — Systematic debugging with root cause investigation
+- `/document-release` — Post-ship documentation update
+- `/document-generate` — Generate documentation
+- `/codex` — OpenAI Codex CLI wrapper for code review and generation
+- `/cso` — Chief Security Officer mode security audit
+- `/autoplan` — Auto-review pipeline
+- `/plan-devex-review` — Developer experience plan review
+- `/devex-review` — Live developer experience audit
+- `/careful` — Safety guardrails for destructive commands
+- `/freeze` — Restrict file edits to a specific directory
+- `/guard` — Full safety mode: destructive warnings + directory-scoped edits
+- `/unfreeze` — Clear the freeze boundary set by `/freeze`
+- `/gstack-upgrade` — Upgrade gstack to the latest version
+- `/learn` — Manage project learnings

--- a/src/apotrope/cis_map.py
+++ b/src/apotrope/cis_map.py
@@ -71,7 +71,9 @@ from __future__ import annotations
 from enum import Enum
 
 # CIS Benchmark editions these IDs are verified against, by OS family.
-# Windows 11 uses the v5.0.0 benchmark; Windows 10 / Server 2019 uses v4.0.0.
+# Windows 11 uses the v5.0.0 benchmark; Windows 10 uses v4.0.0. The Server
+# families (2016/2019/2022) ride the v4.0.0 ID set as a best-effort baseline
+# (each flagged with a caveat) until their own official benchmarks are sourced.
 CIS_VERSION_WIN11 = "v5.0.0"
 CIS_VERSION_WIN10 = "v4.0.0"
 
@@ -81,22 +83,48 @@ class OSFamily(Enum):
 
     WIN10 = "Windows 10"
     WIN11 = "Windows 11"
+    SERVER_2016 = "Windows Server 2016"
     SERVER_2019 = "Windows Server 2019"
     SERVER_2022 = "Windows Server 2022"
 
 
-def family_for_build(build: int) -> OSFamily:
+# Win32_OperatingSystem.ProductType values that denote a server SKU (vs. a
+# client workstation, which is 1). 2 = Domain Controller, 3 = Server.
+_SERVER_PRODUCT_TYPES = frozenset({2, 3})
+
+# Server builds that share a number with a client Windows release, keyed by
+# build → the server family ProductType disambiguates them into.
+_SHARED_SERVER_BUILDS: dict[int, OSFamily] = {
+    17763: OSFamily.SERVER_2019,  # also Windows 10 1809
+    14393: OSFamily.SERVER_2016,  # also Windows 10 1607
+}
+
+
+def family_for_build(build: int, product_type: int | None = None) -> OSFamily:
     """Classify a Windows build number into an :class:`OSFamily`.
 
-    Note: build numbers do NOT uniquely identify server vs client. Build 17763
-    is shared by Windows 10 1809 and Server 2019, and 14393 by Win10 1607 and
-    Server 2016 — so those server editions cannot be told apart from client
-    Windows 10 by build alone (that needs ``Win32_OperatingSystem.ProductType``).
-    Build 20348 is unambiguous (no client Windows uses it) → Server 2022.
-    Anything else below 22000 is treated as the Windows 10 / v4.0.0 family.
+    Build numbers do NOT uniquely identify server vs client: build 17763 is
+    shared by Windows 10 1809 and Server 2019, and 14393 by Win10 1607 and
+    Server 2016. ``Win32_OperatingSystem.ProductType`` (1 = Workstation,
+    2 = Domain Controller, 3 = Server) is what tells them apart, so callers that
+    can read it pass it as *product_type*. Build 20348 is unambiguous (no client
+    Windows uses it) → Server 2022, classified even when *product_type* is
+    unknown. Anything else below 22000 is treated as the Windows 10 / v4.0.0
+    family.
+
+    Args:
+        build:        Windows build number (the trailing field of the OS version).
+        product_type: ``Win32_OperatingSystem.ProductType``, or ``None`` when it
+                      could not be read (e.g. WMI unavailable). Without it, the
+                      shared server builds fall back to the Win10 baseline.
+
+    Returns:
+        The matching :class:`OSFamily`.
     """
     if build == 20348:
         return OSFamily.SERVER_2022
+    if product_type in _SERVER_PRODUCT_TYPES and build in _SHARED_SERVER_BUILDS:
+        return _SHARED_SERVER_BUILDS[build]
     if build >= 22000:
         return OSFamily.WIN11
     return OSFamily.WIN10
@@ -117,21 +145,34 @@ _WIN10_OVERRIDES: dict[str, str] = {
     "SMB Encryption":                   "",   # not present in Win10 v4.0.0
 }
 
+
+def _server_baseline_caveat(server_name: str) -> str:
+    """Best-effort caveat for a Server family ridden on the Win10 v4.0.0 baseline.
+
+    A server family that borrows the Windows 10 v4.0.0 ID set is an
+    approximation; the caveat keeps the report honest about it instead of
+    silently stamping a Win10 edition. Drops to ``""`` once the family's own
+    official benchmark IDs are sourced.
+    """
+    return (
+        f"Windows 10 v4.0.0 baseline — {server_name} control IDs are best-effort; "
+        f"verify against the CIS Microsoft {server_name} Benchmark."
+    )
+
+
 # Additive family → benchmark registry: (cis_version, overrides_map, caveat).
-# Each family is one self-contained entry. To support a real CIS Server 2022
-# Benchmark later, swap that one tuple for
+# Each family is one self-contained entry. Server 2016/2019/2022 all ride the
+# Windows 10 v4.0.0 ID set as a best-effort baseline and carry a caveat so their
+# reports are honest about the approximation. To support a real CIS Server 2022
+# Benchmark later, source the official document, add a ``CIS_VERSION_SERVER_2022``
+# constant and a ``_SERVER2022_OVERRIDES`` map, then swap that one tuple for
 # ``(CIS_VERSION_SERVER_2022, _SERVER2022_OVERRIDES, "")`` — no call site changes.
-# Server 2019/2022 ride the Windows 10 v4.0.0 ID set as a best-effort baseline;
-# Server 2022 also carries a caveat so its report is honest about the approximation.
-_SERVER2022_CAVEAT = (
-    "Windows 10 v4.0.0 baseline — Server 2022 control IDs are best-effort; "
-    "verify against the CIS Microsoft Windows Server 2022 Benchmark."
-)
 _FAMILY_BENCHMARKS: dict[OSFamily, tuple[str, dict[str, str], str]] = {
     OSFamily.WIN11:       (CIS_VERSION_WIN11, {},               ""),
     OSFamily.WIN10:       (CIS_VERSION_WIN10, _WIN10_OVERRIDES, ""),
-    OSFamily.SERVER_2019: (CIS_VERSION_WIN10, _WIN10_OVERRIDES, ""),
-    OSFamily.SERVER_2022: (CIS_VERSION_WIN10, _WIN10_OVERRIDES, _SERVER2022_CAVEAT),
+    OSFamily.SERVER_2016: (CIS_VERSION_WIN10, _WIN10_OVERRIDES, _server_baseline_caveat("Windows Server 2016")),
+    OSFamily.SERVER_2019: (CIS_VERSION_WIN10, _WIN10_OVERRIDES, _server_baseline_caveat("Windows Server 2019")),
+    OSFamily.SERVER_2022: (CIS_VERSION_WIN10, _WIN10_OVERRIDES, _server_baseline_caveat("Windows Server 2022")),
 }
 
 

--- a/src/apotrope/scanner.py
+++ b/src/apotrope/scanner.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 from apotrope import checks as checks_pkg
 from apotrope.models import AuditReport, CheckResult, Status, Severity
 from apotrope.scoring import calculate_score
+from apotrope.utils import get_wmi_object
 
 if TYPE_CHECKING:
     from apotrope import cis_map
@@ -103,7 +104,7 @@ class Scanner:
         except (ValueError, IndexError):
             build = 0
         from apotrope import cis_map
-        family = cis_map.family_for_build(build)
+        family = cis_map.family_for_build(build, self._detect_product_type())
         self._apply_cis_references(results, family=family)
 
         cis_version = cis_map.benchmark_version(family)
@@ -254,6 +255,23 @@ class Scanner:
             r.check_duration = duration
         log.debug("%s finished in %.2fs", module.__name__, duration)
         return results
+
+    @staticmethod
+    def _detect_product_type() -> int | None:
+        """Return ``Win32_OperatingSystem.ProductType``, or ``None`` if unreadable.
+
+        ProductType (1 = Workstation, 2 = Domain Controller, 3 = Server) is what
+        distinguishes a server SKU from client Windows on the build numbers they
+        share (17763 = Win10 1809 / Server 2019; 14393 = Win10 1607 / Server
+        2016). Returns ``None`` when WMI yields nothing — non-Windows, access
+        denied, or a missing/non-integer value — so ``family_for_build`` falls
+        back to build-only classification.
+        """
+        rows = get_wmi_object("Win32_OperatingSystem", properties=["ProductType"])
+        if not rows:
+            return None
+        product_type = rows[0].get("ProductType")
+        return product_type if isinstance(product_type, int) else None
 
     @staticmethod
     def _apply_cis_references(

--- a/tests/test_cis_version.py
+++ b/tests/test_cis_version.py
@@ -48,6 +48,35 @@ class TestBenchmarkVersion:
         assert cis_map.family_for_build(22000) == cis_map.OSFamily.WIN11
         assert cis_map.family_for_build(19045) == cis_map.OSFamily.WIN10
 
+    def test_family_for_build_disambiguates_server_by_product_type(self):
+        # Builds 17763 / 14393 are shared by client Windows and a Server SKU.
+        # ProductType (1=Workstation, 2=Domain Controller, 3=Server) is what
+        # tells them apart — without it, both look like the Win10 baseline.
+        assert cis_map.family_for_build(17763, 1) == cis_map.OSFamily.WIN10
+        assert cis_map.family_for_build(17763, 2) == cis_map.OSFamily.SERVER_2019
+        assert cis_map.family_for_build(17763, 3) == cis_map.OSFamily.SERVER_2019
+        assert cis_map.family_for_build(14393, 1) == cis_map.OSFamily.WIN10
+        assert cis_map.family_for_build(14393, 2) == cis_map.OSFamily.SERVER_2016
+        assert cis_map.family_for_build(14393, 3) == cis_map.OSFamily.SERVER_2016
+
+    def test_family_for_build_product_type_none_falls_back_to_build(self):
+        # No ProductType available → shared server builds classify as Win10.
+        assert cis_map.family_for_build(17763) == cis_map.OSFamily.WIN10
+        assert cis_map.family_for_build(14393) == cis_map.OSFamily.WIN10
+
+    def test_family_for_build_20348_is_server_2022_regardless_of_product_type(self):
+        # 20348 ships only on Server 2022 — unambiguous with or without ProductType.
+        assert cis_map.family_for_build(20348, None) == cis_map.OSFamily.SERVER_2022
+        assert cis_map.family_for_build(20348, 1) == cis_map.OSFamily.SERVER_2022
+        assert cis_map.family_for_build(20348, 3) == cis_map.OSFamily.SERVER_2022
+
+    def test_server_2016_2019_are_v4_baseline_with_caveat(self):
+        # Both ride the Win10 v4.0.0 baseline as a best-effort and must say so —
+        # a reachable server family with no caveat would be a silent Win10 stamp.
+        for fam in (cis_map.OSFamily.SERVER_2016, cis_map.OSFamily.SERVER_2019):
+            assert cis_map.benchmark_version(fam) == "v4.0.0"
+            assert cis_map.benchmark_caveat(fam)  # non-empty best-effort caveat
+
     def test_constants_match(self):
         assert cis_map.CIS_VERSION_WIN11 == "v5.0.0"
         assert cis_map.CIS_VERSION_WIN10 == "v4.0.0"
@@ -87,10 +116,13 @@ def _fake_module() -> ModuleType:
     return mod
 
 
-def _run_with_build(build_version: str) -> AuditReport:
+def _run_with_build(build_version: str, product_type: int | None = 1) -> AuditReport:
+    # product_type defaults to 1 (Workstation) so the existing client-Windows
+    # cases are unaffected; server cases pass 2 (Domain Controller) or 3 (Server).
     scanner = Scanner()
     with patch("apotrope.scanner.platform.version", return_value=build_version), \
-         patch.object(scanner, "_discover_modules", return_value=[_fake_module()]):
+         patch.object(scanner, "_discover_modules", return_value=[_fake_module()]), \
+         patch.object(scanner, "_detect_product_type", return_value=product_type):
         return scanner.run()
 
 
@@ -111,6 +143,43 @@ class TestScannerStampsVersion:
         report = _run_with_build("10.0.20348")  # Server 2022 (unambiguous build)
         assert report.cis_version == "v4.0.0"
         assert report.cis_caveat  # honest best-effort caveat, not a silent Win10 stamp
+
+    def test_server_2019_build_stamps_v4_with_caveat(self):
+        # Same build as Win10 1809 — ProductType 3 (Server) is what makes it 2019.
+        report = _run_with_build("10.0.17763", product_type=3)
+        assert report.cis_version == "v4.0.0"
+        assert report.cis_caveat  # best-effort, not a silent Win10 stamp
+
+    def test_win10_1809_same_build_no_caveat(self):
+        # Build 17763 with Workstation ProductType stays client Win10 (exact, no caveat).
+        report = _run_with_build("10.0.17763", product_type=1)
+        assert report.cis_version == "v4.0.0"
+        assert not report.cis_caveat
+
+    def test_server_2016_build_stamps_v4_with_caveat(self):
+        # Build 14393 with Domain Controller ProductType → Server 2016 best-effort.
+        report = _run_with_build("10.0.14393", product_type=2)
+        assert report.cis_version == "v4.0.0"
+        assert report.cis_caveat
+
+
+# ---------------------------------------------------------------------------
+# Scanner._detect_product_type — WMI ProductType used to disambiguate servers
+# ---------------------------------------------------------------------------
+
+class TestDetectProductType:
+    def test_returns_int_product_type(self):
+        with patch("apotrope.scanner.get_wmi_object", return_value=[{"ProductType": 3}]):
+            assert Scanner._detect_product_type() == 3
+
+    def test_none_when_wmi_returns_no_rows(self):
+        # get_wmi_object returns [] on non-Windows / access-denied / class-missing.
+        with patch("apotrope.scanner.get_wmi_object", return_value=[]):
+            assert Scanner._detect_product_type() is None
+
+    def test_none_when_product_type_absent_or_non_int(self):
+        with patch("apotrope.scanner.get_wmi_object", return_value=[{"ProductType": None}]):
+            assert Scanner._detect_product_type() is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Thread Win32_OperatingSystem.ProductType into cis_map.family_for_build so builds shared by client and server SKUs classify correctly: 17763 (Win10 1809 / Server 2019) and 14393 (Win10 1607 / Server 2016) now resolve by ProductType (1=Workstation, 2=Domain Controller, 3=Server) instead of always falling to the Win10 baseline. Build 20348 still short-circuits to Server 2022 and works even when WMI is unavailable.

- Add OSFamily.SERVER_2016 plus a _SHARED_SERVER_BUILDS table.
- Scanner gains _detect_product_type() (reads ProductType via get_wmi_object, returns None gracefully when unreadable) and threads it into the lookup.
- Give Server 2016/2019/2022 honest best-effort caveats: a now-reachable server family riding the Win10 v4.0.0 baseline must say so rather than silently stamp a Win10 edition.

Server 2022's real CIS benchmark mapping stays deferred — the official CIS Microsoft Windows Server 2022 Benchmark is registration-gated and was not sourced, so no control IDs were fabricated.

Also add the standard gstack section to AGENTS.md.

Tests: ruff + mypy clean; 740 passed, 98.96% coverage.