### PR TITLE
fix(os_info): SKU/edition-aware OS end-of-support with correct Home/Pro dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **OS End-of-Support check is now edition- and SKU-aware and uses the correct
+  consumer (Home/Pro) lifecycle dates.** The build→lifecycle table previously
+  carried Enterprise/Education end-of-servicing dates under a "Home/Pro" label,
+  so a Windows 11 24H2 Home/Pro machine was reported supported until 2027-10-12
+  instead of 2026-10-13, and 23H2 was shown supported roughly a year past its
+  actual consumer end of servicing. It also mapped any build ≥ 26100 to "Windows
+  11 24H2", mislabelling Windows 11 25H2 (build 26200), 26H1 (28000), and Windows
+  Server 2025 (build 26100, which shares 24H2's build). The check now resolves a
+  `(client|server, build)` key using `Win32_OperatingSystem.ProductType`, carries
+  Home/Pro dates for client releases and extended-support dates for server
+  releases, and adds 25H2, 26H1, and Windows Server 2025. Builds newer than the
+  known table now WARN ("verify on the Microsoft release-health page") instead of
+  silently inheriting the newest known release's support date.
+
+---
+
 ## [0.1.9] - 2026-06-25
 
 ### Fixed

--- a/src/apotrope/checks/os_info.py
+++ b/src/apotrope/checks/os_info.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from apotrope.exceptions import ApotropeError
@@ -13,62 +14,131 @@ log = logging.getLogger(__name__)
 
 CATEGORY = "System"
 
-# Build number → (friendly name, end-of-support date)
-# Uses Home/Pro dates (most restrictive). Server editions noted where the build overlaps.
+# Windows lifecycle data, reconciled against Microsoft release-health on the date
+# below. Client rows carry Home/Pro (consumer) end-of-servicing dates — the most
+# conservative choice for a posture auditor; the Enterprise/Education date is kept
+# alongside (unused today) so switching policy or going SKU-aware later is a one-line
+# change. Server rows carry the extended-support end date (when security updates stop).
+# Builds shared by a client and a server release (14393, 17763, 26100) appear under
+# BOTH channels and are disambiguated by ProductType, so a server is never labelled a
+# client edition (and vice versa).
 # Source: https://learn.microsoft.com/en-us/windows/release-health/
-_EOL_TABLE: dict[int, tuple[str, datetime]] = {
-    10240: ("Windows 10 1507",               datetime(2017,  5,  9, tzinfo=timezone.utc)),
-    10586: ("Windows 10 1511",               datetime(2017, 10, 10, tzinfo=timezone.utc)),
-    14393: ("Windows 10 1607 / Server 2016", datetime(2027,  1, 12, tzinfo=timezone.utc)),
-    15063: ("Windows 10 1703",               datetime(2018, 10,  9, tzinfo=timezone.utc)),
-    16299: ("Windows 10 1709",               datetime(2019,  4,  9, tzinfo=timezone.utc)),
-    17134: ("Windows 10 1803",               datetime(2019, 11, 12, tzinfo=timezone.utc)),
-    17763: ("Windows 10 1809 / Server 2019", datetime(2029,  1,  9, tzinfo=timezone.utc)),
-    18362: ("Windows 10 1903",               datetime(2020, 12,  8, tzinfo=timezone.utc)),
-    18363: ("Windows 10 1909",               datetime(2021,  5, 11, tzinfo=timezone.utc)),
-    19041: ("Windows 10 2004",               datetime(2021, 12, 14, tzinfo=timezone.utc)),
-    19042: ("Windows 10 20H2",               datetime(2022,  5, 10, tzinfo=timezone.utc)),
-    19043: ("Windows 10 21H1",               datetime(2022, 12, 13, tzinfo=timezone.utc)),
-    19044: ("Windows 10 21H2",               datetime(2023,  6, 13, tzinfo=timezone.utc)),
-    19045: ("Windows 10 22H2",               datetime(2025, 10, 14, tzinfo=timezone.utc)),
-    20348: ("Windows Server 2022",           datetime(2031, 10, 14, tzinfo=timezone.utc)),
-    22000: ("Windows 11 21H2",               datetime(2024, 10,  8, tzinfo=timezone.utc)),
-    22621: ("Windows 11 22H2",               datetime(2025, 10, 14, tzinfo=timezone.utc)),
-    22631: ("Windows 11 23H2",               datetime(2026, 11, 10, tzinfo=timezone.utc)),
-    26100: ("Windows 11 24H2",               datetime(2027, 10, 12, tzinfo=timezone.utc)),
+_LAST_VERIFIED = datetime(2026, 6, 26, tzinfo=timezone.utc)
+
+# Win32_OperatingSystem.ProductType: 1 = Workstation, 2 = Domain Controller, 3 = Server.
+_SERVER_PRODUCT_TYPES = frozenset({2, 3})
+
+
+def _d(year: int, month: int, day: int) -> datetime:
+    return datetime(year, month, day, tzinfo=timezone.utc)
+
+
+@dataclass(frozen=True)
+class _Release:
+    """A Windows release and the date it stops receiving security updates."""
+
+    name: str
+    eol: datetime
+    is_server: bool = False
+    eol_enterprise: datetime | None = None  # client-only; reserved for a SKU-aware policy
+
+    def eol_date(self) -> datetime:
+        return self.eol
+
+
+# (channel, base build) -> release. channel is "client" or "server".
+_RELEASES: dict[tuple[str, int], _Release] = {
+    # Windows 10 client (Home/Pro end of servicing)
+    ("client", 10240): _Release("Windows 10 1507", _d(2017, 5, 9)),
+    ("client", 10586): _Release("Windows 10 1511", _d(2017, 10, 10)),
+    ("client", 14393): _Release("Windows 10 1607", _d(2018, 4, 10)),
+    ("client", 15063): _Release("Windows 10 1703", _d(2018, 10, 9)),
+    ("client", 16299): _Release("Windows 10 1709", _d(2019, 4, 9)),
+    ("client", 17134): _Release("Windows 10 1803", _d(2019, 11, 12)),
+    ("client", 17763): _Release("Windows 10 1809", _d(2020, 11, 10)),
+    ("client", 18362): _Release("Windows 10 1903", _d(2020, 12, 8)),
+    ("client", 18363): _Release("Windows 10 1909", _d(2021, 5, 11)),
+    ("client", 19041): _Release("Windows 10 2004", _d(2021, 12, 14)),
+    ("client", 19042): _Release("Windows 10 20H2", _d(2022, 5, 10)),
+    ("client", 19043): _Release("Windows 10 21H1", _d(2022, 12, 13)),
+    ("client", 19044): _Release("Windows 10 21H2", _d(2023, 6, 13)),
+    ("client", 19045): _Release("Windows 10 22H2", _d(2025, 10, 14)),
+    # Windows 11 client (Home/Pro end of servicing; Enterprise/Education kept for reference)
+    ("client", 22000): _Release("Windows 11 21H2", _d(2023, 10, 10), eol_enterprise=_d(2024, 10, 8)),
+    ("client", 22621): _Release("Windows 11 22H2", _d(2024, 10, 8), eol_enterprise=_d(2025, 10, 14)),
+    ("client", 22631): _Release("Windows 11 23H2", _d(2025, 11, 11), eol_enterprise=_d(2026, 11, 10)),
+    ("client", 26100): _Release("Windows 11 24H2", _d(2026, 10, 13), eol_enterprise=_d(2027, 10, 12)),
+    ("client", 26200): _Release("Windows 11 25H2", _d(2027, 10, 12), eol_enterprise=_d(2028, 10, 10)),
+    ("client", 28000): _Release("Windows 11 26H1", _d(2028, 3, 14), eol_enterprise=_d(2029, 3, 13)),
+    # Windows Server (extended-support end = security updates stop)
+    ("server", 14393): _Release("Windows Server 2016", _d(2027, 1, 12), is_server=True),
+    ("server", 17763): _Release("Windows Server 2019", _d(2029, 1, 9), is_server=True),
+    ("server", 20348): _Release("Windows Server 2022", _d(2031, 10, 14), is_server=True),
+    ("server", 26100): _Release("Windows Server 2025", _d(2034, 11, 14), is_server=True),
 }
 
-# Cumulative updates can push build numbers past the base release build.
-# These ranges catch e.g. 26200 (post-24H2 CU) mapping to "Windows 11 24H2".
-# Sorted descending so the first match wins.
-_EOL_RANGES: list[tuple[int, tuple[str, datetime]]] = [
-    (26100, ("Windows 11 24H2",               datetime(2027, 10, 12, tzinfo=timezone.utc))),
-    (22631, ("Windows 11 23H2",               datetime(2026, 11, 10, tzinfo=timezone.utc))),
-    (22621, ("Windows 11 22H2",               datetime(2025, 10, 14, tzinfo=timezone.utc))),
-    (22000, ("Windows 11 21H2",               datetime(2024, 10,  8, tzinfo=timezone.utc))),
-    (20348, ("Windows Server 2022",           datetime(2031, 10, 14, tzinfo=timezone.utc))),
-    (19041, ("Windows 10 20xx",               datetime(2025, 10, 14, tzinfo=timezone.utc))),
-]
+# Highest known base build per channel, used by the "newer than anything we know" guard.
+_KNOWN_BUILDS: dict[str, list[int]] = {
+    "client": sorted(b for (ch, b) in _RELEASES if ch == "client"),
+    "server": sorted(b for (ch, b) in _RELEASES if ch == "server"),
+}
 
 
-def _lookup_eol(build: int) -> tuple[str, datetime] | None:
-    """Return (friendly_name, eol_date) for a build number, using range fallback.
+class _NewerThanKnown:
+    """Sentinel type: a build newer than every known release on its channel."""
 
-    Tries exact match first, then falls back to the largest known base build
-    that is <= the given build (handles post-GA cumulative update builds).
+
+# A build newer than the whole table must NOT be silently mapped to the newest known
+# release (that would report an unsupported future build as "supported"); callers WARN.
+_NEWER_THAN_KNOWN = _NewerThanKnown()
+
+
+def _channel_for(product_type: int | None, build: int) -> str:
+    """Pick the client/server lifecycle track for a build.
+
+    A build that exists only as a server release always resolves as server. Otherwise
+    ProductType decides; when it is unavailable we assume client, which both matches the
+    historical desktop-only behaviour and fails closed — a server briefly mislabelled as
+    a client reports the *earlier* client EOL rather than a false "supported".
     """
-    if build in _EOL_TABLE:
-        return _EOL_TABLE[build]
-    for min_build, entry in _EOL_RANGES:
-        if build >= min_build:
-            return entry
-    return None
+    if ("server", build) in _RELEASES and ("client", build) not in _RELEASES:
+        return "server"
+    if product_type in _SERVER_PRODUCT_TYPES:
+        return "server"
+    return "client"
+
+
+def _lookup_eol(
+    build: int,
+    product_type: int | None = None,
+    edition: str | None = None,
+) -> tuple[str, datetime] | _NewerThanKnown | None:
+    """Resolve a build to (friendly_name, eol_date), a sentinel, or None.
+
+    Returns ``(name, date)`` for a known release; ``_NEWER_THAN_KNOWN`` when the build is
+    newer than every known release on its channel (caller should WARN rather than assume
+    support); or ``None`` when it is below all known releases. Exact base-build hits win;
+    otherwise the nearest lower base on the same channel resolves it (post-GA cumulative
+    update tolerance). ``edition`` is accepted for a future SKU-aware policy but unused today.
+    """
+    channel = _channel_for(product_type, build)
+    known = _KNOWN_BUILDS[channel]  # always non-empty: both channels are populated
+    if (channel, build) in _RELEASES:
+        rel = _RELEASES[(channel, build)]
+        return (rel.name, rel.eol_date())
+    if build > known[-1]:
+        return _NEWER_THAN_KNOWN
+    base = max((b for b in known if b <= build), default=None)
+    if base is None:
+        return None
+    rel = _RELEASES[(channel, base)]
+    return (rel.name, rel.eol_date())
 
 _UPTIME_WARN_DAYS = 30
 
 _PS_OS = (
     "Get-CimInstance Win32_OperatingSystem "
-    "| Select-Object Caption, BuildNumber, Version "
+    "| Select-Object Caption, BuildNumber, Version, ProductType "
     "| ConvertTo-Json -Compress"
 )
 _PS_UPTIME = (
@@ -127,6 +197,10 @@ def _check_os_build() -> list[CheckResult]:
     except ValueError:
         build = 0
 
+    product_type = data.get("ProductType")
+    if not isinstance(product_type, int) or isinstance(product_type, bool):
+        product_type = None
+
     version_result = CheckResult(
         category=CATEGORY,
         check_name="OS Version",
@@ -138,8 +212,14 @@ def _check_os_build() -> list[CheckResult]:
     )
 
     now = _now()
-    eol_entry = _lookup_eol(build)
-    if eol_entry is not None:
+    eol_entry = _lookup_eol(build, product_type)
+    description = "Checks whether the installed Windows build is still supported by Microsoft."
+    confirm_command = (
+        "[System.Environment]::OSVersion.Version\n"
+        "(Get-ItemProperty 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion').DisplayVersion"
+    )
+
+    if isinstance(eol_entry, tuple):
         friendly_name, eol_date = eol_entry
         if now > eol_date:
             eol_result = CheckResult(
@@ -147,22 +227,21 @@ def _check_os_build() -> list[CheckResult]:
                 check_name="OS End-of-Support Status",
                 status=Status.FAIL,
                 severity=Severity.HIGH,
-                description="Checks whether the installed Windows build is still supported by Microsoft.",
+                description=description,
                 details=(
                     f"{friendly_name} reached end of support on "
                     f"{eol_date.strftime('%Y-%m-%d')}. "
                     f"This build no longer receives security updates."
                 ),
                 remediation=(
-                    "Upgrade to a supported build (Windows 10 22H2) or Windows 11 — "
-                    "the upgrade itself has no single command. Confirm the current "
-                    "build first, then run Windows Update or the Installation Assistant."
+                    "Upgrade to a currently supported Windows release — the upgrade "
+                    "itself has no single command. Confirm the current build first, "
+                    "then run Windows Update or the Installation Assistant."
                 ),
                 command=(
                     "# There is no in-place command for the upgrade — use Windows Update or the\n"
                     "# Windows Installation Assistant. Confirm the current build first:\n"
-                    "[System.Environment]::OSVersion.Version\n"
-                    "(Get-ItemProperty 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion').DisplayVersion"
+                    f"{confirm_command}"
                 ),
             )
         else:
@@ -172,7 +251,7 @@ def _check_os_build() -> list[CheckResult]:
                 check_name="OS End-of-Support Status",
                 status=Status.PASS,
                 severity=Severity.HIGH,
-                description="Checks whether the installed Windows build is still supported by Microsoft.",
+                description=description,
                 details=(
                     f"{friendly_name} is supported until "
                     f"{eol_date.strftime('%Y-%m-%d')} "
@@ -180,13 +259,31 @@ def _check_os_build() -> list[CheckResult]:
                 ),
                 remediation="",
             )
+    elif eol_entry is _NEWER_THAN_KNOWN:
+        eol_result = CheckResult(
+            category=CATEGORY,
+            check_name="OS End-of-Support Status",
+            status=Status.WARN,
+            severity=Severity.HIGH,
+            description=description,
+            details=(
+                f"Build {build_str} is newer than Apotrope's known Windows lifecycle "
+                f"table (last verified {_LAST_VERIFIED.strftime('%Y-%m-%d')}). Confirm "
+                "its support status on the Microsoft release-health page."
+            ),
+            remediation=(
+                "Update Apotrope, or confirm this build's support status on the "
+                "Microsoft release-health page."
+            ),
+            command=confirm_command,
+        )
     else:
         eol_result = CheckResult(
             category=CATEGORY,
             check_name="OS End-of-Support Status",
             status=Status.WARN,
             severity=Severity.HIGH,
-            description="Checks whether the installed Windows build is still supported by Microsoft.",
+            description=description,
             details=(
                 f"Build {build_str} is not in the known support table. "
                 "Verify this is a current supported release."
@@ -195,10 +292,7 @@ def _check_os_build() -> list[CheckResult]:
                 "Confirm the current build and verify it is a supported release on the "
                 "Microsoft support lifecycle page."
             ),
-            command=(
-                "[System.Environment]::OSVersion.Version\n"
-                "(Get-ItemProperty 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion').DisplayVersion"
-            ),
+            command=confirm_command,
         )
 
     return [version_result, eol_result]

--- a/tests/test_checks/test_os_info.py
+++ b/tests/test_checks/test_os_info.py
@@ -17,8 +17,12 @@ from apotrope.models import Status
 
 def _os_json(caption: str = "Microsoft Windows 11 Pro",
              build: str = "22631",
-             version: str = "10.0.22631") -> dict:
-    return {"Caption": caption, "BuildNumber": build, "Version": version}
+             version: str = "10.0.22631",
+             product_type: int | None = 1) -> dict:
+    data: dict = {"Caption": caption, "BuildNumber": build, "Version": version}
+    if product_type is not None:
+        data["ProductType"] = product_type
+    return data
 
 
 def _domain_json(part_of_domain: bool = False,
@@ -41,12 +45,26 @@ _REF_DATE = datetime(2026, 3, 17, tzinfo=timezone.utc)
 
 class TestCheckOsBuild:
     def test_supported_build_returns_pass(self):
-        """Build 22631 (Win11 23H2, EOL Nov 2026) should PASS on ref date."""
-        with patch("apotrope.checks.os_info.run_powershell_json", return_value=_os_json(build="22631")), \
+        """Build 26100 (Win11 24H2, Home/Pro EOL 2026-10-13) should PASS on ref date Mar 2026."""
+        with patch("apotrope.checks.os_info.run_powershell_json", return_value=_os_json(build="26100")), \
              patch("apotrope.checks.os_info._now", return_value=_REF_DATE):
             results = os_info._check_os_build()
         eol = next(r for r in results if r.check_name == "OS End-of-Support Status")
         assert eol.status == Status.PASS
+        assert "24H2" in eol.details
+
+    def test_win11_23h2_eol_under_home_pro_dates(self):
+        """Build 22631 (Win11 23H2) Home/Pro support ended 2025-11-11, so it FAILs on ref date Mar 2026.
+
+        Regression guard for the Fugu/Codex finding: the table previously held 23H2's
+        Enterprise date (2026-11-10), which wrongly reported a consumer box as supported.
+        """
+        with patch("apotrope.checks.os_info.run_powershell_json", return_value=_os_json(build="22631")), \
+             patch("apotrope.checks.os_info._now", return_value=_REF_DATE):
+            results = os_info._check_os_build()
+        eol = next(r for r in results if r.check_name == "OS End-of-Support Status")
+        assert eol.status == Status.FAIL
+        assert "23H2" in eol.details
 
     def test_eol_build_returns_fail(self):
         """Build 19045 (Win10 22H2, EOL Oct 2025) should FAIL on ref date Mar 2026."""
@@ -74,14 +92,101 @@ class TestCheckOsBuild:
         eol = next(r for r in results if r.check_name == "OS End-of-Support Status")
         assert eol.status == Status.WARN
 
-    def test_post_ga_cu_build_resolves_via_range(self):
-        """Build 26200 (post-24H2 CU) should resolve to Windows 11 24H2 and PASS."""
+    def test_25h2_build_resolves(self):
+        """Build 26200 is Windows 11 25H2 (an exact entry), not 24H2 via a range fallback."""
         with patch("apotrope.checks.os_info.run_powershell_json", return_value=_os_json(build="26200")), \
              patch("apotrope.checks.os_info._now", return_value=_REF_DATE):
             results = os_info._check_os_build()
         eol = next(r for r in results if r.check_name == "OS End-of-Support Status")
         assert eol.status == Status.PASS
+        assert "25H2" in eol.details
+        assert "24H2" not in eol.details
+
+    def test_intermediate_build_resolves_to_nearest_lower_base(self):
+        """A build between known bases (e.g. a post-GA CU 26150) resolves to its base release (24H2)."""
+        with patch("apotrope.checks.os_info.run_powershell_json", return_value=_os_json(build="26150")), \
+             patch("apotrope.checks.os_info._now", return_value=_REF_DATE):
+            results = os_info._check_os_build()
+        eol = next(r for r in results if r.check_name == "OS End-of-Support Status")
+        assert eol.status == Status.PASS
         assert "24H2" in eol.details
+
+    def test_26h1_build_resolves(self):
+        """Build 28000 is Windows 11 26H1."""
+        with patch("apotrope.checks.os_info.run_powershell_json", return_value=_os_json(build="28000")), \
+             patch("apotrope.checks.os_info._now", return_value=_REF_DATE):
+            results = os_info._check_os_build()
+        eol = next(r for r in results if r.check_name == "OS End-of-Support Status")
+        assert eol.status == Status.PASS
+        assert "26H1" in eol.details
+
+    def test_server_2025_resolves_distinct_from_client_24h2(self):
+        """Build 26100 is shared: ProductType 3 -> Windows Server 2025; ProductType 1 -> Windows 11 24H2.
+
+        Headline disambiguation test — without ProductType the server was mislabelled as
+        the Win11 client edition with the wrong (much earlier) support date.
+        """
+        with patch("apotrope.checks.os_info.run_powershell_json",
+                   return_value=_os_json(caption="Microsoft Windows Server 2025",
+                                         build="26100", product_type=3)), \
+             patch("apotrope.checks.os_info._now", return_value=_REF_DATE):
+            server = os_info._check_os_build()
+        server_eol = next(r for r in server if r.check_name == "OS End-of-Support Status")
+        assert "Server 2025" in server_eol.details
+        assert "24H2" not in server_eol.details
+
+        with patch("apotrope.checks.os_info.run_powershell_json",
+                   return_value=_os_json(build="26100", product_type=1)), \
+             patch("apotrope.checks.os_info._now", return_value=_REF_DATE):
+            client = os_info._check_os_build()
+        client_eol = next(r for r in client if r.check_name == "OS End-of-Support Status")
+        assert "24H2" in client_eol.details
+        assert "Server" not in client_eol.details
+
+    def test_unknown_future_build_warns(self):
+        """A build newer than the whole table must WARN, not silently inherit the newest release."""
+        with patch("apotrope.checks.os_info.run_powershell_json", return_value=_os_json(build="30000")), \
+             patch("apotrope.checks.os_info._now", return_value=_REF_DATE):
+            results = os_info._check_os_build()
+        eol = next(r for r in results if r.check_name == "OS End-of-Support Status")
+        assert eol.status == Status.WARN
+        assert "newer" in eol.details.lower()
+        assert "2026-06-26" in eol.details  # _LAST_VERIFIED stamp
+
+    def test_edition_date_correctness_pins_home_pro_policy(self):
+        """24H2 client between Home/Pro (2026-10-13) and Enterprise (2027-10-12) EOL must FAIL.
+
+        Pins the Home/Pro policy: if the table ever reverted to Enterprise dates this would
+        wrongly PASS.
+        """
+        between = datetime(2026, 12, 1, tzinfo=timezone.utc)
+        with patch("apotrope.checks.os_info.run_powershell_json",
+                   return_value=_os_json(build="26100", product_type=1)), \
+             patch("apotrope.checks.os_info._now", return_value=between):
+            results = os_info._check_os_build()
+        eol = next(r for r in results if r.check_name == "OS End-of-Support Status")
+        assert eol.status == Status.FAIL
+
+    def test_product_type_none_falls_back_to_client(self):
+        """Missing ProductType resolves the shared 26100 build to the client edition (24H2)."""
+        with patch("apotrope.checks.os_info.run_powershell_json",
+                   return_value=_os_json(build="26100", product_type=None)), \
+             patch("apotrope.checks.os_info._now", return_value=_REF_DATE):
+            results = os_info._check_os_build()
+        eol = next(r for r in results if r.check_name == "OS End-of-Support Status")
+        assert eol.status == Status.PASS
+        assert "24H2" in eol.details
+
+    def test_server_only_build_resolves_as_server_without_product_type(self):
+        """Build 20348 exists only as Windows Server 2022, so it resolves server-side even without ProductType."""
+        with patch("apotrope.checks.os_info.run_powershell_json",
+                   return_value=_os_json(caption="Microsoft Windows Server 2022",
+                                         build="20348", product_type=None)), \
+             patch("apotrope.checks.os_info._now", return_value=_REF_DATE):
+            results = os_info._check_os_build()
+        eol = next(r for r in results if r.check_name == "OS End-of-Support Status")
+        assert eol.status == Status.PASS
+        assert "Server 2022" in eol.details
 
     def test_os_version_result_is_info(self):
         with patch("apotrope.checks.os_info.run_powershell_json", return_value=_os_json()), \


### PR DESCRIPTION
## Summary

PR 1 of the post-v0.1.9 review remediation (Fugu-ultra finding #1, sharpened by the Codex pass). The OS End-of-Support check resolved lifecycle from **build number alone** and stored **Enterprise/Education** dates under a `# Uses Home/Pro dates` comment. On current machines this produced materially wrong support data.

## Bugs fixed

| Build | Release | Was reported | Correct (Home/Pro) | Effect |
|---|---|---|---|---|
| 22631 | Win11 23H2 | supported to 2026-11-10 | 2025-11-11 | **false "supported" → now FAIL** |
| 26100 | Win11 24H2 | 2027-10-12 (Enterprise) | 2026-10-13 | cutoff ~1yr too late |
| 26100 + ProductType 3 | **Server 2025** | mislabelled "Win11 24H2" | Windows Server 2025 (2034-11-14) | wrong name + date |
| 26200 / 28000 | 25H2 / 26H1 | mapped to "24H2" | exact entries | mislabelled |
| > table max | future build | inherited newest "supported" | **WARN** | latent false-negative closed |

## Approach

- Replaced the build-only `_EOL_TABLE`/`_EOL_RANGES` with a `(channel, build) → _Release` map keyed by `Win32_OperatingSystem.ProductType` (added to the existing `_PS_OS` query; graceful fallback to client when absent).
- **Client** rows carry **Home/Pro** dates (most conservative for a posture auditor; Enterprise date kept alongside, unused, so a future SKU-aware policy is a one-line change). **Server** rows carry **extended-support** end (when security updates stop).
- Added Win11 25H2, 26H1, Windows Server 2025; split the shared `14393`/`17763`/`26100` builds across client/server so a server is never labelled a client edition.
- Builds newer than the table now **WARN** with the `_LAST_VERIFIED` (2026-06-26) stamp instead of silently inheriting the newest known release.
- Dates reconciled against Microsoft release-health pages on 2026-06-26.

## Verification

- **Live 25H2 box (build 26200):** now reports `Windows 11 25H2 is supported until 2027-10-12 (472 days remaining)` — previously mislabelled "24H2".
- Tests: rewrote the test that codified the wrong `26200 → 24H2` behavior; added 25H2, 26H1, Server-2025-vs-client-24H2 disambiguation, future-build WARN, Home/Pro edition-policy pin, ProductType-none fallback, and nearest-lower-base coverage.
- **760 passed**, `os_info.py` 100% coverage, total 99.08% (≥95 gate); `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)