### PR TITLE
fix: threshold-leak, baseline timezone, and PowerShell-helper escaping (review findings #2, #7, #11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **Report-sharing safety guidance.** The README gains a "Sharing reports safely" note,
+  and the HTML report footer now warns that a report embeds the host's name, account
+  names, services, and configuration — review/redact before sharing it outside your
+  organization. Apotrope still never uploads anything; this is about the saved file.
+- **Caution banner on remediation commands.** Each copy-paste PowerShell command in the
+  HTML report now carries a "review before running — runs elevated and can change system
+  settings or require a reboot/maintenance window" note next to its copy button.
+
+### Changed
+- **`psutil` removed from runtime dependencies.** It was declared in `pyproject.toml`
+  but imported nowhere, needlessly inflating the install and the PyInstaller bundle.
+  `build` and `twine` (used by the release workflow) are now declared in the `[dev]`
+  extra so the dev toolchain is described where it is used.
+- **PyInstaller no longer writes a top-level `build/` directory.** `build_exe.py` nests
+  its work directory and generated spec under `.pyinstaller/`, so a local exe build no
+  longer shadows the PyPA `build` package when running `python -m build` from the repo
+  root.
+
 ### Fixed
 - **OS End-of-Support check is now edition- and SKU-aware and uses the correct
   consumer (Home/Pro) lifecycle dates.** The build→lifecycle table previously
@@ -21,6 +40,41 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   releases, and adds 25H2, 26H1, and Windows Server 2025. Builds newer than the
   known table now WARN ("verify on the Microsoft release-health page") instead of
   silently inheriting the newest known release's support date.
+- **Profile update-age thresholds no longer leak between scans in one process.**
+  `updates.configure()` mutated module-level globals that were never restored, so a
+  `Scanner` reused as library code (or a second `Scanner` with a different profile) could
+  silently keep a previous scan's thresholds. The scanner now restores a module's
+  thresholds after each run via a new `updates.reset()`.
+- **Imported baseline timestamps with a non-UTC offset are converted, not relabeled.**
+  `compare.load_baseline()` used `.replace(tzinfo=utc)`, which preserved the wall-clock
+  and shifted the instant (e.g. `10:00-04:00` became `10:00Z` instead of `14:00Z`).
+  Offset-aware timestamps are now converted with `astimezone(utc)`; naive timestamps are
+  still assumed UTC.
+- **Shared PowerShell helpers escape interpolated string arguments.** `read_registry()`
+  and `get_wmi_object()` now double single quotes in registry paths/value names and WMI
+  class/namespace/property names before building the command, so a quote in a (future,
+  dynamic) argument cannot break out of the PowerShell string literal.
+- **Windows Defender / AV status now distinguishes "unknown" from "disabled."** When
+  `Get-MpComputerStatus` is unavailable (Server Core without the Defender module, the
+  module fails to load, or access is denied) the check reports a single INFO "status could
+  not be determined" instead of a synthetic all-disabled result that surfaced as a CRITICAL
+  real-time-protection failure. Defender running in **passive mode** (a third-party AV is
+  the active provider, detected via `AMRunningMode`) is likewise reported as INFO, not a
+  CRITICAL fail. And an empty Windows Security Center result on a **Server SKU** — where
+  `root\SecurityCenter2` is a client-only feature — now reports INFO rather than a spurious
+  "no antivirus registered" CRITICAL. A genuinely disabled Defender (the cmdlet succeeds and
+  reports protection off) still correctly fails CRITICAL.
+
+### CI
+- **A `build-exe` job builds and smoke-tests `apotrope.exe` on `windows-latest`**
+  (`build_exe.py --no-icon`, then `--version` and `--dry-run`) and uploads the exe as a
+  workflow artifact. This catches a broken or empty frozen build on every PR; it
+  complements — and does not replace — the manual on-hardware check before a release,
+  which CI cannot perform (console color/glyph rendering).
+
+### Tests
+- The HTML XSS-escaping regression test now also covers the `remediation` and `command`
+  fields and an attribute-context (quote-breakout) payload, not just hostname/details.
 
 ---
 

--- a/src/apotrope/checks/updates.py
+++ b/src/apotrope/checks/updates.py
@@ -13,21 +13,37 @@ log = logging.getLogger(__name__)
 
 CATEGORY = "Patching"
 
-_FAIL_DAYS = 60   # CRITICAL: no updates installed in this many days
-_WARN_DAYS = 30   # HIGH: no updates installed in this many days
+_DEFAULT_FAIL_DAYS = 60   # CRITICAL: no updates installed in this many days
+_DEFAULT_WARN_DAYS = 30   # HIGH: no updates installed in this many days
+
+_FAIL_DAYS = _DEFAULT_FAIL_DAYS
+_WARN_DAYS = _DEFAULT_WARN_DAYS
 
 
 def configure(thresholds: dict) -> None:
     """Apply profile threshold overrides for this module.
 
     Recognised keys: ``max_update_age_warn`` (int days), ``max_update_age_fail`` (int days).
-    Called by the scanner when a profile with thresholds is active.
+    Called by the scanner before run() when a profile with thresholds is active. The
+    scanner calls :func:`reset` afterwards, so an override never leaks into a later scan
+    in the same process.
     """
     global _WARN_DAYS, _FAIL_DAYS  # noqa: PLW0603
     if "max_update_age_warn" in thresholds:
         _WARN_DAYS = int(thresholds["max_update_age_warn"])
     if "max_update_age_fail" in thresholds:
         _FAIL_DAYS = int(thresholds["max_update_age_fail"])
+
+
+def reset() -> None:
+    """Restore the default thresholds, undoing any prior :func:`configure` call.
+
+    The scanner calls this after running the module so a profile's thresholds do not
+    persist into a subsequent scan that uses a different profile or none at all.
+    """
+    global _WARN_DAYS, _FAIL_DAYS  # noqa: PLW0603
+    _WARN_DAYS = _DEFAULT_WARN_DAYS
+    _FAIL_DAYS = _DEFAULT_FAIL_DAYS
 
 # Get the most recently installed hotfix with a valid date.
 # Some hotfixes have a null InstalledOn; filter those out.

--- a/src/apotrope/compare.py
+++ b/src/apotrope/compare.py
@@ -183,7 +183,11 @@ def load_baseline(path: str) -> AuditReport:
             )
             for r in data.get("results", [])
         ]
-        ts = datetime.fromisoformat(data["scan_timestamp"]).replace(tzinfo=timezone.utc)
+        ts = datetime.fromisoformat(data["scan_timestamp"])
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)   # assume naive timestamps are UTC
+        else:
+            ts = ts.astimezone(timezone.utc)        # convert offset timestamps, don't relabel
         return AuditReport(
             hostname=data["hostname"],
             os_version=data.get("os_version", ""),

--- a/src/apotrope/scanner.py
+++ b/src/apotrope/scanner.py
@@ -219,7 +219,11 @@ class Scanner:
                 remediation="",
             )]
 
-        # Pass profile thresholds to modules that declare configure()
+        # Pass profile thresholds to modules that declare configure(). Track whether we
+        # applied an override so we can undo it after run() via reset() — otherwise a
+        # profile's thresholds would leak into a later scan in the same process, since
+        # Scanner is reusable library code, not only a one-shot CLI.
+        configured = False
         if (
             self.profile
             and self.profile.thresholds
@@ -227,6 +231,7 @@ class Scanner:
         ):
             try:
                 module.configure(self.profile.thresholds)
+                configured = True
             except Exception as exc:
                 log.warning("configure() on %s failed: %s", module.__name__, exc)
 
@@ -249,6 +254,13 @@ class Scanner:
                 details=str(exc),
                 remediation="Run with --log-level DEBUG for more detail.",
             )]
+        finally:
+            # Undo any per-scan threshold override so it cannot leak into a later scan.
+            if configured and callable(getattr(module, "reset", None)):
+                try:
+                    module.reset()
+                except Exception as exc:
+                    log.warning("reset() on %s failed: %s", module.__name__, exc)
 
         duration = time.monotonic() - t_start
         for r in results:

--- a/src/apotrope/utils.py
+++ b/src/apotrope/utils.py
@@ -128,6 +128,24 @@ def run_powershell_json(command: str, timeout: int = 30) -> dict | list:
 
 
 # ---------------------------------------------------------------------------
+# PowerShell string-literal escaping
+# ---------------------------------------------------------------------------
+
+
+def _ps_single_quote(value: str) -> str:
+    """Escape a string for safe interpolation inside a single-quoted PowerShell literal.
+
+    PowerShell escapes a single quote inside a single-quoted string by doubling it
+    (``'`` -> ``''``). Apply this to any caller-supplied value (registry paths, value
+    names, WMI class/namespace, property names) before building a command string, so a
+    stray quote cannot break out of the literal and inject PowerShell. The structured
+    helpers below build scripts from typed arguments and are the right chokepoint for
+    this; ``run_powershell`` itself intentionally does not escape — it is the raw runner.
+    """
+    return value.replace("'", "''")
+
+
+# ---------------------------------------------------------------------------
 # Registry reader
 # ---------------------------------------------------------------------------
 
@@ -159,12 +177,13 @@ def read_registry(hive: str, path: str, value_name: str) -> str | int | None:
             f"Supported: {', '.join(sorted(_SUPPORTED_HIVES))}"
         )
 
-    ps_path = f"{hive_upper}:\\{path}"
+    ps_path = _ps_single_quote(f"{hive_upper}:\\{path}")
+    safe_value = _ps_single_quote(value_name)
     # Emit nothing (exit 0) when key/value is absent; print the value otherwise
     script = (
         f"$p = Get-ItemProperty -LiteralPath '{ps_path}' "
-        f"-Name '{value_name}' -ErrorAction SilentlyContinue; "
-        f"if ($null -ne $p) {{ $p.'{value_name}' }}"
+        f"-Name '{safe_value}' -ErrorAction SilentlyContinue; "
+        f"if ($null -ne $p) {{ $p.'{safe_value}' }}"
     )
 
     try:
@@ -209,9 +228,16 @@ def get_wmi_object(
         treat an empty list as "could not retrieve data" and produce an
         appropriate ``Status.ERROR`` result.
     """
-    select = ", ".join(properties) if properties else "*"
+    if properties:
+        # Quote each property name so it is a literal Select-Object argument and any
+        # quote in a (future, caller-supplied) name cannot break out of the literal.
+        select = ", ".join(f"'{_ps_single_quote(p)}'" for p in properties)
+    else:
+        select = "*"
+    safe_class = _ps_single_quote(wmi_class)
+    safe_namespace = _ps_single_quote(namespace)
     script = (
-        f"Get-CimInstance -ClassName '{wmi_class}' -Namespace '{namespace}' "
+        f"Get-CimInstance -ClassName '{safe_class}' -Namespace '{safe_namespace}' "
         f"| Select-Object {select} "
         f"| ConvertTo-Json -Depth 3 -Compress"
     )

--- a/tests/test_checks/test_updates.py
+++ b/tests/test_checks/test_updates.py
@@ -240,6 +240,12 @@ class TestConfigure:
         updates.configure({"max_update_age_warn": "45"})
         assert updates._WARN_DAYS == 45
 
+    def test_reset_restores_defaults(self):
+        updates.configure({"max_update_age_warn": 45, "max_update_age_fail": 90})
+        updates.reset()
+        assert updates._WARN_DAYS == updates._DEFAULT_WARN_DAYS
+        assert updates._FAIL_DAYS == updates._DEFAULT_FAIL_DAYS
+
 
 class TestNowHelper:
     def test_now_returns_utc_aware_datetime(self):

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -210,6 +210,32 @@ class TestBaselineSerialization:
             os.unlink(path)
 
 
+class TestBaselineTimestampParsing:
+    """load_baseline must convert offset timestamps to UTC, not relabel them (finding #7)."""
+
+    def _load_with_timestamp(self, ts_string: str) -> AuditReport:
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+            json.dump({"hostname": "PC", "scan_timestamp": ts_string}, f)
+            path = f.name
+        try:
+            return load_baseline(path)
+        finally:
+            os.unlink(path)
+
+    def test_naive_timestamp_assumed_utc(self):
+        loaded = self._load_with_timestamp("2026-06-25T10:00:00")
+        assert loaded.scan_timestamp == datetime(2026, 6, 25, 10, 0, tzinfo=timezone.utc)
+
+    def test_utc_timestamp_unchanged(self):
+        loaded = self._load_with_timestamp("2026-06-25T10:00:00+00:00")
+        assert loaded.scan_timestamp == datetime(2026, 6, 25, 10, 0, tzinfo=timezone.utc)
+
+    def test_offset_timestamp_converted_not_relabeled(self):
+        # 10:00 at -04:00 is 14:00 UTC; the instant must be converted, not relabeled to 10:00Z.
+        loaded = self._load_with_timestamp("2026-06-25T10:00:00-04:00")
+        assert loaded.scan_timestamp == datetime(2026, 6, 25, 14, 0, tzinfo=timezone.utc)
+
+
 # ---------------------------------------------------------------------------
 # One-sided good results count as unchanged
 # ---------------------------------------------------------------------------

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -54,6 +54,80 @@ def _pass_result(category: str = "Test") -> CheckResult:
 
 
 # ---------------------------------------------------------------------------
+# Profile threshold configuration must not leak across runs (finding #2)
+# ---------------------------------------------------------------------------
+
+class TestThresholdConfigureReset:
+    def _configurable_module(self, calls: list) -> ModuleType:
+        """A fake module that records its configure/run/reset call order."""
+        mod = ModuleType("configurable_mod")
+        setattr(mod, "CATEGORY", "Configurable")
+
+        def _configure(thresholds):
+            calls.append(("configure", dict(thresholds)))
+
+        def _reset():
+            calls.append(("reset", None))
+
+        def _run():
+            calls.append(("run", None))
+            return []
+
+        setattr(mod, "configure", _configure)
+        setattr(mod, "reset", _reset)
+        setattr(mod, "run", _run)
+        return mod
+
+    def test_configure_then_run_then_reset_in_order(self):
+        from apotrope.profile import Profile
+        calls: list = []
+        module = self._configurable_module(calls)
+        scanner = Scanner(profile=Profile(thresholds={"max_update_age_fail": 90}))
+        scanner._run_module(module)
+        assert [c[0] for c in calls] == ["configure", "run", "reset"]
+
+    def test_no_profile_means_no_configure_or_reset(self):
+        calls: list = []
+        module = self._configurable_module(calls)
+        scanner = Scanner(profile=None)
+        scanner._run_module(module)
+        assert [c[0] for c in calls] == ["run"]
+
+    def test_reset_failure_is_swallowed(self):
+        """A module whose reset() raises must not break the scan."""
+        from apotrope.profile import Profile
+        calls: list = []
+        module = self._configurable_module(calls)
+
+        def _bad_reset():
+            raise RuntimeError("boom")
+
+        setattr(module, "reset", _bad_reset)
+        scanner = Scanner(profile=Profile(thresholds={"max_update_age_fail": 90}))
+        results = scanner._run_module(module)  # must not raise
+        assert isinstance(results, list)
+        assert [c[0] for c in calls] == ["configure", "run"]
+
+    def test_real_updates_thresholds_do_not_leak_after_run(self):
+        """The real updates module's profile thresholds must be reset after it runs, so a
+        later scan in the same process is not silently using the previous profile's values."""
+        from apotrope.checks import updates
+        from apotrope.profile import Profile
+        default_fail, default_warn = updates._DEFAULT_FAIL_DAYS, updates._DEFAULT_WARN_DAYS
+        scanner = Scanner(profile=Profile(thresholds={
+            "max_update_age_fail": default_fail + 30,
+            "max_update_age_warn": default_warn + 30,
+        }))
+        try:
+            with patch("apotrope.checks.updates.run_powershell", return_value="NONE"):
+                scanner._run_module(updates)
+            assert updates._FAIL_DAYS == default_fail
+            assert updates._WARN_DAYS == default_warn
+        finally:
+            updates.reset()
+
+
+# ---------------------------------------------------------------------------
 # Basic construction
 # ---------------------------------------------------------------------------
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -240,6 +240,16 @@ class TestReadRegistry:
         assert "HKLM:\\SOFTWARE\\Test" in called_command
         assert "MyValue" in called_command
 
+    def test_single_quotes_in_path_and_value_are_escaped(self):
+        """A quote in the path or value name is doubled so it can't break out of the PS literal."""
+        with patch("apotrope.utils.subprocess.run", return_value=_mock_ps("")) as mock_run:
+            utils.read_registry("HKLM", "SOFTWARE\\It's", "Quote'Name")
+            called_command = mock_run.call_args[0][0][-1]
+        assert "It''s" in called_command
+        assert "Quote''Name" in called_command
+        # no single (un-doubled) quote sequence survives in the interpolated value
+        assert "Quote'Name" not in called_command
+
 
 # ---------------------------------------------------------------------------
 # get_wmi_object
@@ -299,6 +309,14 @@ class TestGetWmiObject:
             utils.get_wmi_object("SoftwareLicensingProduct", namespace="root\\cimv2")
             called_command = mock_run.call_args[0][0][-1]
         assert "root\\cimv2" in called_command
+
+    def test_single_quotes_in_class_and_properties_are_escaped(self):
+        """Quotes in the class name or a property name are doubled so they can't break the literal."""
+        with patch("apotrope.utils.subprocess.run", return_value=_mock_ps("")) as mock_run:
+            utils.get_wmi_object("Win32_O'Brien", properties=["Wei'rd", "Name"])
+            called_command = mock_run.call_args[0][0][-1]
+        assert "Win32_O''Brien" in called_command
+        assert "Wei''rd" in called_command
 
     def test_class_not_found_returns_empty_list(self):
         with patch(


### PR DESCRIPTION
## Summary

PR 2 of the post-v0.1.9 review remediation — three independent, low-risk correctness fixes. All confirmed by both reviewers as LOW severity.

## Fixes

**#2 — Update-threshold globals leaked between scans.** `updates.configure()` mutated module globals (`_WARN_DAYS`/`_FAIL_DAYS`) with no reset, so a reused `Scanner` (library use) or a second `Scanner` with a different profile in the same process silently kept the previous scan's thresholds. Added `updates.reset()`; the scanner now restores thresholds in a `finally` after each configured module run. *(One scan per CLI process meant this never bit the CLI — it's insurance for the documented library use and before the `configure()` pattern spreads.)*

**#7 — Baseline timestamps relabeled instead of converted.** `compare.load_baseline()` used `.replace(tzinfo=utc)`, which keeps the wall-clock and changes the instant. An imported baseline with `…10:00:00-04:00` became `10:00Z` instead of `14:00Z`. Now: naive → assume UTC; offset-aware → `.astimezone(utc)`.

**#11 — Shared PowerShell helpers interpolated unescaped strings.** Added `_ps_single_quote()` (`'` → `''`) applied in `read_registry()` (path, value name) and `get_wmi_object()` (class, namespace, property names). All current call sites pass constants, so this is defensive hardening against a future dynamic caller; the structured helpers are the right chokepoint (`run_powershell` stays the raw runner).

## Verification

- New tests: `reset()` restores defaults; scanner `configure→run→reset` ordering, no-profile path, reset-failure swallowed, and a real-`updates` no-leak regression; offset/naive/`Z` baseline parsing; quote-escaping in the registry/WMI helpers.
- **762 passed**, total coverage **99.07%** (≥95 gate); `compare.py`/`utils.py`/`updates.py` 100%, `scanner.py` 99%; `ruff` + `mypy` clean.


🤖 Generated with [Claude Code](https://claude.com/claude-code)