### PR TITLE
chore(packaging,ci): drop unused psutil, relocate PyInstaller workpath, add exe CI smoke test (findings #5, #6, #10)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,3 +34,38 @@ jobs:
         # Branch coverage is enabled in pyproject.toml ([tool.coverage.run]).
         # The threshold can only ratchet up — raise it as coverage improves.
         run: pytest tests/ -q --tb=short --cov --cov-report=term-missing --cov-fail-under=95
+
+  build-exe:
+    name: Build Windows exe (smoke test)
+    runs-on: windows-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install package, dev deps, and PyInstaller
+        run: pip install -e ".[dev]" pyinstaller
+
+      - name: Build apotrope.exe
+        # build_exe.py runs its own --dry-run probe and FAILS if the frozen exe
+        # bundles zero check modules, so this step is itself the smoke test for
+        # the most likely silent failure (collect-submodules finding nothing).
+        run: python build_exe.py --no-icon
+
+      - name: Verify exe --version
+        run: .\dist\apotrope.exe --version
+
+      - name: Verify exe --dry-run
+        run: .\dist\apotrope.exe --dry-run --no-color
+
+      - name: Upload exe artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: apotrope-exe
+          path: dist/apotrope.exe

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ MANIFEST
 # PyInstaller
 *.spec
 dist/
+.pyinstaller/
+build/pyinstaller/
 
 # Windows
 Thumbs.db

--- a/build_exe.py
+++ b/build_exe.py
@@ -5,7 +5,7 @@ Usage:
     python build_exe.py [--no-icon]
 
 The resulting exe is written to dist/apotrope.exe and bundles:
-  - All Python dependencies (rich, jinja2, psutil, ...)
+  - All Python dependencies (rich, jinja2, ...)
   - The Jinja2 HTML template (src/apotrope/templates/report.html.j2)
   - A Windows shield application icon (assets/icon.ico)
 
@@ -107,6 +107,11 @@ def build(use_icon: bool = True) -> int:
         print(f"[build] ERROR: entry point not found at {entry}")
         return 1
 
+    # Keep PyInstaller's intermediate work dir and generated spec OUT of the repo
+    # root: its default workpath is ./build, and a top-level build/ directory
+    # shadows the PyPA `build` package when running `python -m build` from the
+    # repo root. Nest both under .pyinstaller/ (gitignored) so the root stays clean.
+    work_dir = ROOT / ".pyinstaller"
     cmd = [
         sys.executable, "-m", "PyInstaller",
         "--onefile",
@@ -114,6 +119,8 @@ def build(use_icon: bool = True) -> int:
         "--add-data", f"{templates_src};templates",
         "--paths", str(ROOT / "src"),
         "--collect-submodules", "apotrope.checks",
+        "--workpath", str(work_dir),
+        "--specpath", str(work_dir),
         "--noconfirm",
         "--clean",
         str(entry),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
 dependencies = [
     "rich>=13.7",
     "jinja2>=3.1",
-    "psutil>=5.9",
 ]
 
 [project.urls]
@@ -38,6 +37,8 @@ Issues = "https://github.com/hexorcist404/apotrope/issues"
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
+    "build>=1.0",
+    "twine>=5.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+# Pinned convenience install (runtime + test). The authoritative dependency
+# source is pyproject.toml; CI uses `pip install -e ".[dev]"`. Release tools
+# (build, twine) live in the pyproject [dev] extra, not here.
+
 # Runtime dependencies (pinned for reproducibility)
 rich==13.9.4
 jinja2==3.1.6


### PR DESCRIPTION
## Summary

PR 4 of the post-v0.1.9 review remediation — packaging and CI hygiene (all LOW severity).

## Changes

**#6 — Dependency metadata.** Removed `psutil>=5.9` from runtime `dependencies` (declared but imported nowhere — confirmed across three search methods in the review). Added `build` + `twine` (used by `publish.yml`) to the `[dev]` extra, and noted in `requirements.txt` that `pyproject.toml` is the authoritative source. *(Did not add ruff/mypy/pip-audit — they aren't referenced by any CI workflow.)*

**#5 — `python -m build` shadowing.** `build_exe.py` now sets `--workpath`/`--specpath` to `.pyinstaller/` instead of PyInstaller's default `./build`. A top-level `build/` directory shadows the PyPA `build` package, which could break `python -m build` from the repo root. The root now stays clean and no stray `apotrope.spec` is written there.

**#10 — CI never built the exe.** Added a `build-exe` job on `windows-latest`: `pip install -e ".[dev]" pyinstaller` → `python build_exe.py --no-icon` (whose built-in `--dry-run` probe fails on an empty bundle) → `--version` / `--dry-run` → upload the exe artifact. Must run on windows-latest (`build_exe.py` uses the `;` `--add-data` separator). **Complements, does not replace,** the mandatory manual on-hardware check before a release (CI can't validate console color/glyph rendering).

## Verification (built locally)

- `python build_exe.py --no-icon` → `dist/apotrope.exe` (12.4 MB), **14 check modules bundled**, internal probe passed.
- `dist\apotrope.exe --version` → `apotrope 0.1.9`.
- Work dir + spec land in `.pyinstaller/`; the top-level `build/` mtime was **unchanged** (build_exe no longer touches it).
- `python -m build --wheel` succeeds from the repo root.
- 752 tests pass; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)