### PR TITLE
docs(report): share-safely guidance + remediation-command caution (findings #9, #12, #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,17 @@ permanently change your policy. **No scripts are written to disk.** Each command
 read-only query passed directly to the PowerShell process; the bypass applies only to
 that subprocess and does not change the machine's policy setting.
 
+### Sharing reports safely
+
+Generated reports (`--html` / `--json`) are written **only to your machine** — Apotrope
+never uploads them. But because a report's job is to inventory your security posture, it
+embeds machine-identifying and configuration detail: hostname, domain/workgroup, local
+administrator account names, listening ports and the processes behind them, service
+executable paths, and startup/scheduled-task names. Treat a saved report like any other
+sensitive configuration export — **review and redact it before sending it outside your
+organization** (a vendor, a support ticket, a chat). The HTML report repeats this reminder
+in its footer.
+
 ---
 
 ## Usage

--- a/src/apotrope/templates/report.html.j2
+++ b/src/apotrope/templates/report.html.j2
@@ -333,6 +333,8 @@
   .code .copy:hover { color:var(--accent); border-color:var(--accent); }
   .code-cmd { font-family:"IBM Plex Mono","Cascadia Code","Consolas",monospace; font-size:12.5px;
               color:var(--green); white-space:pre-wrap; word-break:break-word; padding:11px 13px; margin:0; }
+  .code-warn { font-size:10.5px; line-height:1.5; color:#ffb23d; padding:6px 13px; margin:0;
+               background:rgba(255,178,61,0.06); border-top:1px solid rgba(255,178,61,0.18); }
   .cis { display:inline-flex; align-items:center; gap:6px; font-size:11px; letter-spacing:0.06em;
          color:var(--cyan); border:1px solid rgba(68,224,230,0.28); background:rgba(68,224,230,0.05);
          padding:3px 9px; border-radius:2px; }
@@ -344,6 +346,7 @@
           display:flex; justify-content:space-between; align-items:center; gap:20px; flex-wrap:wrap;
           font-size:11.5px; color:var(--muted); letter-spacing:0.05em; }
   .foot .auth { color:var(--faint); }
+  .foot .share-warn { flex-basis:100%; order:9; color:#ffb23d; opacity:0.92; font-size:11px; }
   .foot a { color:var(--muted); border-bottom:1px dashed transparent; }
   .foot a:hover { color:var(--accent); border-bottom-color:var(--accent); }
 
@@ -553,6 +556,7 @@
                     <button class="copy" type="button">copy</button>
                   </div>
                   <pre class="code-cmd">{{ f.command }}</pre>
+                  <div class="code-warn">⚠ Review before running — these commands run elevated and can change system settings, or require a reboot or maintenance window.</div>
                 </div>
                 {% endif %}
               </div></div>
@@ -569,6 +573,7 @@
     <div class="foot">
       <span class="auth">For authorized security assessment use only · <strong style="color:var(--green);font-weight:600;text-shadow:0 0 9px rgba(43,255,136,0.45)">No data left this machine</strong> · CIS Benchmark {{ cis_version }}{% if cis_caveat %} · <span class="cis-caveat" style="color:#ffb23d">{{ cis_caveat }}</span>{% endif %}</span>
       <span>apotrope.sh · <a href="https://github.com/hexorcist404/apotrope">github.com/hexorcist404/apotrope</a> · MIT</span>
+      <span class="share-warn">⚠ This report contains this machine's hostname, account names, services, and configuration. Review and redact before sharing it outside your organization.</span>
     </div>
 
   </div>

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -209,30 +209,39 @@ class TestGenerateHtmlReport:
         assert "<!DOCTYPE html>" in html
 
     def test_html_special_chars_escaped(self):
-        """Regression: autoescape=True must escape user-controlled fields.
+        """Regression: autoescape=True must escape user-controlled fields everywhere.
 
         select_autoescape(["html"]) silently returned False for .j2 templates
-        because it checks the last extension (.j2, not .html). Verify that a
-        future change cannot re-introduce raw output.
+        because it checks the last extension (.j2, not .html). Verify a future
+        change cannot re-introduce raw output — in details, remediation, OR the
+        command field, including attribute-context (the data-text search index)
+        injection via a quote breakout.
         """
-        xss_payload = '<script>alert(1)</script>'
+        xss = '<script>alert(1)</script>'
+        attr_breakout = '"><img src=x onerror=alert(2)>'
         report = AuditReport(
-            hostname=f"HOST-{xss_payload}",
+            hostname=f"HOST-{xss}",
             os_version="10.0.22631",
             scan_timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
             scan_duration=1.0,
             results=[
                 CheckResult(
                     "Security", "XSS Check", Status.FAIL, Severity.HIGH,
-                    "desc", f"Details: {xss_payload}", "Remediate",
+                    "desc", f"Details: {xss} {attr_breakout}",
+                    f"Remediate {xss}", f"Set-Item {xss} {attr_breakout}",
                 ),
             ],
             score=50,
             is_admin=False,
         )
         html = self._generate(report)
+        # No raw executable markup survives in any field or in attribute context
         assert "<script>alert(1)</script>" not in html
+        assert "<img src=x" not in html
+        assert '"><img' not in html
+        # Escaped forms are present, proving the payloads were rendered (and escaped)
         assert "&lt;script&gt;" in html
+        assert "&lt;img" in html
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PR 5 of the post-v0.1.9 review remediation — documentation/safety guidance (all LOW). **No behavior change:** the scanner stays read-only, the report stays self-contained and XSS-safe.

## Changes

**#9 — reports embed local inventory.** Added a "Sharing reports safely" note to the README and a footer warning in the HTML report: a report embeds the host's name, account names, services, and configuration, so it should be reviewed/redacted before leaving the organization. (Apotrope still never uploads anything — this is about the saved file.)

**#12 — remediation commands are one-click copyable.** Added a caution line next to each command's copy button: the commands run elevated and can change system settings or require a reboot/maintenance window. The read-only property is unchanged.

**#8 — XSS test coverage gap.** Kept the duplicated `f.command` in the `data-text` search attribute (it powers client-side command search — removing it would break search). Extended the existing escaping regression test to also cover the `remediation` and `command` fields and an attribute-context quote-breakout payload, proving `autoescape` neutralizes them in every field and context.

## Verification

- Rendered a report and confirmed both new elements appear: the per-command `code-warn` caution and the footer `share-warn` notice.
- **752 tests pass** (including the extended XSS test); `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)