### PR TITLE
fix(antivirus): distinguish unknown/passive Defender from disabled; gate SecurityCenter2 on SKU (finding #3)

### DIFF
--- a/src/apotrope/checks/antivirus.py
+++ b/src/apotrope/checks/antivirus.py
@@ -6,7 +6,7 @@ import logging
 
 from apotrope.exceptions import ApotropeError
 from apotrope.models import CheckResult, Severity, Status
-from apotrope.utils import run_powershell_json
+from apotrope.utils import get_wmi_object, run_powershell_json
 
 log = logging.getLogger(__name__)
 
@@ -14,15 +14,19 @@ CATEGORY = "Antivirus"
 
 _SIGNATURE_WARN_DAYS = 7
 
-# Try Defender first; catch handles Server SKUs where Get-MpComputerStatus is absent.
+# Query Windows Defender via Get-MpComputerStatus. The catch fires when the cmdlet is
+# unavailable — Server Core without the Defender module, the module failing to load, or
+# access denied — and emits a distinct {"_QueryError":true} marker, so the Python layer
+# reports "status unknown" instead of mistaking an unreadable provider for a genuinely
+# disabled Defender. AMRunningMode further distinguishes passive mode (a third-party AV
+# is the active provider) from Defender actually being off.
 _PS_DEFENDER = (
     "try { "
     "Get-MpComputerStatus | Select-Object "
     "AMServiceEnabled, RealTimeProtectionEnabled, AntivirusEnabled, "
-    "IsTamperProtected, AntivirusSignatureAge "
+    "IsTamperProtected, AntivirusSignatureAge, AMRunningMode "
     "| ConvertTo-Json -Compress "
-    "} catch { '{\"AMServiceEnabled\":false,\"RealTimeProtectionEnabled\":false,"
-    "\"AntivirusEnabled\":false,\"IsTamperProtected\":false,\"AntivirusSignatureAge\":999}' }"
+    "} catch { '{\"_QueryError\":true}' }"
 )
 
 # SecurityCenter2 lists all registered AV products (requires desktop SKU).
@@ -48,7 +52,13 @@ def run() -> list[CheckResult]:
 
 
 def _check_defender() -> list[CheckResult]:
-    """Check Windows Defender via Get-MpComputerStatus."""
+    """Check Windows Defender via Get-MpComputerStatus.
+
+    Distinguishes three states the build previously conflated into a CRITICAL fail:
+    the provider being unreadable (status unknown), Defender running passively behind
+    a third-party AV (expected, not a finding), and Defender being the active AV (the
+    real-time-protection / signature / tamper checks).
+    """
     try:
         data = run_powershell_json(_PS_DEFENDER)
     except ApotropeError as exc:
@@ -56,6 +66,39 @@ def _check_defender() -> list[CheckResult]:
 
     if isinstance(data, list):
         data = data[0] if data else {}
+
+    if not data or data.get("_QueryError"):
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="Windows Defender",
+            status=Status.INFO,
+            severity=Severity.INFO,
+            description="Reports Windows Defender real-time protection, signatures, and tamper protection.",
+            details=(
+                "Windows Defender status could not be determined — Get-MpComputerStatus "
+                "is unavailable on this system (e.g. Server Core without the Defender "
+                "module, the module failed to load, or access was denied). This is not "
+                "the same as Defender being disabled; see Registered AV Products below "
+                "for whether another antivirus is active."
+            ),
+            remediation="",
+        )]
+
+    running_mode = str(data.get("AMRunningMode") or "").strip()
+    if "passive" in running_mode.lower():
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="Windows Defender",
+            status=Status.INFO,
+            severity=Severity.INFO,
+            description="Reports Windows Defender real-time protection, signatures, and tamper protection.",
+            details=(
+                f"Microsoft Defender is in passive mode ({running_mode}); a third-party "
+                "antivirus is the active provider, so Defender's own real-time protection "
+                "is expected to be off. See Registered AV Products for the active product."
+            ),
+            remediation="",
+        )]
 
     am_enabled = bool(data.get("AMServiceEnabled", False))
     rtp_enabled = bool(data.get("RealTimeProtectionEnabled", False))
@@ -135,6 +178,21 @@ def _check_defender() -> list[CheckResult]:
     return results
 
 
+def _is_server_sku() -> bool:
+    """Return True if this looks like a server SKU (ProductType 2 or 3).
+
+    Windows Security Center (root\\SecurityCenter2) is a client-only feature, so an
+    empty result there is expected on servers and must not be reported as "no AV". When
+    ProductType is unreadable this returns False, falling back to the stricter client
+    behaviour (better a false CRITICAL prompting investigation than a silent miss).
+    """
+    rows = get_wmi_object("Win32_OperatingSystem", properties=["ProductType"])
+    if not rows:
+        return False
+    product_type = rows[0].get("ProductType")
+    return isinstance(product_type, int) and product_type in (2, 3)
+
+
 def _check_security_center() -> list[CheckResult]:
     """List antivirus products registered with Windows Security Center."""
     try:
@@ -145,6 +203,21 @@ def _check_security_center() -> list[CheckResult]:
     products = data if isinstance(data, list) else ([data] if data else [])
 
     if not products:
+        if _is_server_sku():
+            return [CheckResult(
+                category=CATEGORY,
+                check_name="Registered AV Products",
+                status=Status.INFO,
+                severity=Severity.INFO,
+                description="Lists antivirus products registered with Windows Security Center.",
+                details=(
+                    "Windows Security Center (root\\SecurityCenter2) is a client-only "
+                    "feature and is not present on Server SKUs, so registered antivirus "
+                    "products cannot be enumerated here. Check the Windows Defender status "
+                    "above for this machine's protection state."
+                ),
+                remediation="",
+            )]
         return [CheckResult(
             category=CATEGORY,
             check_name="Registered AV Products",

--- a/tests/test_checks/test_antivirus.py
+++ b/tests/test_checks/test_antivirus.py
@@ -14,13 +14,14 @@ from apotrope.models import Status, Severity
 # Shared mock data
 # ---------------------------------------------------------------------------
 
-def _defender(am=True, rtp=True, av=True, tamper=True, sig_age=1) -> dict:
+def _defender(am=True, rtp=True, av=True, tamper=True, sig_age=1, running_mode="Normal") -> dict:
     return {
         "AMServiceEnabled": am,
         "RealTimeProtectionEnabled": rtp,
         "AntivirusEnabled": av,
         "IsTamperProtected": tamper,
         "AntivirusSignatureAge": sig_age,
+        "AMRunningMode": running_mode,
     }
 
 
@@ -107,13 +108,41 @@ class TestCheckDefender:
         sig = next(r for r in results if "Signature" in r.check_name)
         assert sig.status == Status.PASS
 
-    def test_all_fields_false_rtp_is_still_critical_fail(self):
+    def test_genuinely_disabled_rtp_is_still_critical_fail(self):
+        """Real data (cmdlet succeeded) reporting RTP off is a genuine CRITICAL fail —
+        distinct from the unavailable-provider case below."""
         with patch("apotrope.checks.antivirus.run_powershell_json",
                    return_value=_defender(am=False, rtp=False, av=False, tamper=False, sig_age=999)):
             results = antivirus._check_defender()
+        assert len(results) == 3
         rtp = next(r for r in results if "Real-Time" in r.check_name)
         assert rtp.status == Status.FAIL
         assert rtp.severity == Severity.CRITICAL
+
+    def test_unavailable_provider_returns_single_info(self):
+        """A {"_QueryError": true} marker (cmdlet unavailable) must report unknown, not FAIL."""
+        with patch("apotrope.checks.antivirus.run_powershell_json",
+                   return_value={"_QueryError": True}):
+            results = antivirus._check_defender()
+        assert len(results) == 1
+        assert results[0].status == Status.INFO
+        assert "could not be determined" in results[0].details.lower()
+
+    def test_passive_mode_returns_single_info(self):
+        """Passive Defender (a third-party AV is the active provider) is expected, not a CRITICAL fail."""
+        with patch("apotrope.checks.antivirus.run_powershell_json",
+                   return_value=_defender(rtp=False, running_mode="Passive")):
+            results = antivirus._check_defender()
+        assert len(results) == 1
+        assert results[0].status == Status.INFO
+        assert "passive" in results[0].details.lower()
+
+    def test_empty_response_treated_as_unavailable(self):
+        """Empty output (no JSON at all) is unknown, not a disabled Defender."""
+        with patch("apotrope.checks.antivirus.run_powershell_json", return_value=[]):
+            results = antivirus._check_defender()
+        assert len(results) == 1
+        assert results[0].status == Status.INFO
 
 
 # ---------------------------------------------------------------------------
@@ -142,12 +171,22 @@ class TestCheckSecurityCenter:
         assert "Windows Defender" in results[0].details
         assert "Malwarebytes" in results[0].details
 
-    def test_no_av_registered_returns_critical_fail(self):
-        with patch("apotrope.checks.antivirus.run_powershell_json", return_value=[]):
+    def test_no_av_registered_on_client_returns_critical_fail(self):
+        with patch("apotrope.checks.antivirus.run_powershell_json", return_value=[]), \
+             patch("apotrope.checks.antivirus._is_server_sku", return_value=False):
             results = antivirus._check_security_center()
         assert results[0].status == Status.FAIL
         assert results[0].severity == Severity.CRITICAL
         assert results[0].remediation != ""
+
+    def test_no_av_on_server_sku_returns_info_not_fail(self):
+        """Empty SecurityCenter2 on a Server SKU is expected (it's a client-only feature),
+        so it must report INFO, not a spurious 'no AV registered' CRITICAL."""
+        with patch("apotrope.checks.antivirus.run_powershell_json", return_value=[]), \
+             patch("apotrope.checks.antivirus._is_server_sku", return_value=True):
+            results = antivirus._check_security_center()
+        assert results[0].status == Status.INFO
+        assert results[0].severity == Severity.INFO
 
     def test_ps_error_returns_error(self):
         with patch("apotrope.checks.antivirus.run_powershell_json",
@@ -160,6 +199,32 @@ class TestCheckSecurityCenter:
         with patch("apotrope.checks.antivirus.run_powershell_json", return_value=single):
             results = antivirus._check_security_center()
         assert results[0].status == Status.INFO
+
+
+# ---------------------------------------------------------------------------
+# _is_server_sku
+# ---------------------------------------------------------------------------
+
+class TestIsServerSku:
+    def test_server_product_type_is_server(self):
+        with patch("apotrope.checks.antivirus.get_wmi_object", return_value=[{"ProductType": 3}]):
+            assert antivirus._is_server_sku() is True
+
+    def test_domain_controller_is_server(self):
+        with patch("apotrope.checks.antivirus.get_wmi_object", return_value=[{"ProductType": 2}]):
+            assert antivirus._is_server_sku() is True
+
+    def test_workstation_is_not_server(self):
+        with patch("apotrope.checks.antivirus.get_wmi_object", return_value=[{"ProductType": 1}]):
+            assert antivirus._is_server_sku() is False
+
+    def test_unreadable_product_type_is_not_server(self):
+        with patch("apotrope.checks.antivirus.get_wmi_object", return_value=[]):
+            assert antivirus._is_server_sku() is False
+
+    def test_non_int_product_type_is_not_server(self):
+        with patch("apotrope.checks.antivirus.get_wmi_object", return_value=[{"ProductType": None}]):
+            assert antivirus._is_server_sku() is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PR 3 (the follow-up) of the post-v0.1.9 review remediation. The Defender/AV check conflated several materially different states into a CRITICAL real-time-protection failure. This separates them so a posture auditor reports *unknown* as unknown, not as *bad*.

## Problem

- `_PS_DEFENDER`'s `catch` (fired when `Get-MpComputerStatus` is unavailable — Server Core without the Defender module, module load failure, access denied) returned a synthetic all-`false` + `AntivirusSignatureAge:999` object, **indistinguishable** from a genuinely disabled Defender → surfaced as CRITICAL FAIL.
- `_check_security_center` returned CRITICAL "no antivirus registered" when `root\SecurityCenter2` was empty — but SecurityCenter2 is a **client-only** feature, so that's a false positive on Server SKUs.

## Fix — three distinct Defender states

| State | Before | After |
|---|---|---|
| Provider unreadable (cmdlet unavailable) | CRITICAL FAIL (false) | single **INFO** "status could not be determined" (distinct `{"_QueryError":true}` marker) |
| Defender **passive** (3rd-party AV active, via `AMRunningMode`) | CRITICAL FAIL (false) | **INFO** "passive mode — another AV is the active provider" |
| Defender active, RTP genuinely off | CRITICAL FAIL | **CRITICAL FAIL** (unchanged — correct) |

`_check_security_center` now gates the empty result on `Win32_OperatingSystem.ProductType`: a Server SKU reports **INFO** ("SecurityCenter2 is client-only"); a client/undetectable SKU keeps the strict CRITICAL (fail-closed). The misleading `# catch handles Server SKUs` comment is corrected.

## Verification

- New tests: unavailable-marker → INFO, passive-mode → INFO, empty-response → INFO, genuinely-disabled → still CRITICAL; `_is_server_sku` truth table; SecurityCenter2 client-FAIL vs server-INFO.
- Live on a Win11 client: 3 Defender PASS + registered-AV INFO (active path unchanged).
- **761 tests pass**, `antivirus.py` 100% coverage, total 99.07%; `ruff` + `mypy` clean.


🤖 Generated with [Claude Code](https://claude.com/claude-code)