### PR TITLE
docs(site): add comparison-page links to top nav

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -136,13 +136,14 @@
                text-transform:uppercase; color:var(--bright); }
   .nav-links { display:flex; align-items:center; gap:26px; }
   .nav-links a { font-family:"IBM Plex Mono",monospace; font-size:12px; letter-spacing:0.12em; color:var(--muted);
-                 text-transform:uppercase; transition:color .15s; }
+                 text-transform:uppercase; transition:color .15s; white-space:nowrap; }
   .nav-links a:hover, .nav-links a.active { color:var(--bright); }
   .nav-links a.active { color:var(--accent); }
   .nav-cta { font-family:"IBM Plex Mono",monospace; font-size:12px; letter-spacing:0.08em; font-weight:600;
              color:var(--void); background:var(--accent); padding:8px 15px; border-radius:2px;
              box-shadow:0 0 16px rgba(43,255,136,0.3); transition:transform .12s; white-space:nowrap; }
   .nav-cta:hover { transform:translateY(-1px); }
+  @media (max-width:1140px){ .nav-links .nav-compare { display:none; } }
   @media (max-width:760px){ .nav-links { display:none; } }
 
   /* ── Hero ────────────────────────────────────────────────────────────────── */
@@ -313,6 +314,8 @@
         <a href="#checks">Checks</a>
         <a href="#scoring">Scoring</a>
         <a href="#report">Report</a>
+        <a class="nav-compare" href="/lynis-for-windows/">vs Lynis</a>
+        <a class="nav-compare" href="/vs-cis-cat/">vs CIS-CAT</a>
         <a href="#start">Get Started</a>
         <a href="#faq">FAQ</a>
         <a href="https://github.com/hexorcist404/apotrope">GitHub ↗</a>


### PR DESCRIPTION
## Summary

Closes out Task 4 of the v0.1.9 work order: adds **vs Lynis** and **vs CIS-CAT** links to the homepage top nav, between Report and Get Started — the same position the comparison pages themselves use for their cross-links.

## Why the label is "vs Lynis" (not "Lynis for Windows")

Measured with the site served locally: with all nine links on one line, the "Lynis for Windows" label pushes the nav row to 1158px — wider than the 1140px `.wrap` cap, i.e. it overflows at **every** viewport. "vs Lynis" is parallel with "vs CIS-CAT", accurate to the page, and brings the row to 1055px (fits with slack above 1140px viewports).

## Responsive behavior (verified headless at 10 widths: 1920→390)

- **>1140px:** both links render, single line, no overflow (screenshot-verified at 1920/1440/1280/1141).
- **761–1140px:** the two links hide via a new `.nav-compare` media query; the nav renders exactly as it did before this PR. The comparison pages stay reachable through the existing FAQ-block and footer links.
- **≤760px:** whole `.nav-links` row hidden (pre-existing template behavior) — brand + Download only.
- `white-space:nowrap` added to `.nav-links a` (the CTA already had it) so labels can't wrap to two lines when flex space runs out.

## Work-order verification (all green)

- `pytest tests/ -q` → **779 passed**
- 14 category modules in `src/apotrope/checks/`; "50+" phrasing consistent across README, site, llms.txt
- Live JSON-LD: `SoftwareApplication` v0.1.9 + `FAQPage` (5 questions) both parse and are well-formed
- All 7 live URLs return 200 (`/`, `/report.html`, both comparison pages, robots/sitemap/llms.txt)


🤖 Generated with [Claude Code](https://claude.com/claude-code)