### PR TITLE
docs+ci: pre-launch trust & positioning (HWS comparison, Verify Your Download, attested CI releases)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,3 +66,8 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # PEP 740 attestations are already the default for Trusted
+          # Publishing, but pin it explicitly: PyPI provenance is part of our
+          # trust story and must not silently change with an upstream default.
+          attestations: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,173 @@
+name: Release (Windows exe)
+
+# On v* tag push: runs tests on Windows, builds apotrope.exe on a clean
+# GitHub-hosted runner, attests its build provenance (Sigstore, via GitHub
+# OIDC), generates SHA256SUMS, and creates a DRAFT GitHub release with both
+# attached. The maintainer then downloads the exe FROM THE DRAFT, verifies
+# console rendering (colors/glyphs) on a live machine — the mandatory
+# pre-release gate — and publishes the draft by hand.
+#
+# INVARIANT: the published asset must remain the CI-built exe, byte for byte.
+# Never replace it with a locally built exe — the attestation is bound to the
+# CI build's SHA-256 digest, and `gh attestation verify` would fail for every
+# user who follows the README. The workflow enforces this on its side too: it
+# refuses to touch a release once it has been published (draft-only refresh).
+#
+# workflow_dispatch is a dry-run: build + smoke test + artifact upload only
+# (no attestation, no release).
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  build-attest-draft:
+    name: Build, attest, draft release
+    runs-on: windows-latest
+    permissions:
+      contents: write      # create the draft release + upload assets
+      id-token: write      # OIDC identity used to Sigstore-sign the attestation
+      attestations: write  # persist the attestation to the repo's store
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install package, dev deps, and PyInstaller
+        run: pip install -e ".[dev]" pyinstaller
+
+      - name: Run tests
+        # Same rationale as publish.yml's gate: test.yml does NOT run on tags.
+        # Deliberately duplicated here on Windows — the OS this exe ships for.
+        run: pytest tests/ -q --tb=short --cov --cov-fail-under=95
+
+      - name: Ensure release icon is present
+        # assets/icon.ico is committed. build_exe.py silently builds WITHOUT
+        # an icon if it is missing (Pillow is not installed here to regenerate
+        # it). Fail loudly rather than ship an iconless release exe.
+        shell: bash
+        run: test -f assets/icon.ico
+
+      - name: Build apotrope.exe (with icon)
+        # No --no-icon: unlike the CI smoke build in test.yml, the released
+        # exe embeds assets/icon.ico. build_exe.py already runs its own
+        # --dry-run probe and fails if zero check modules were bundled.
+        run: python build_exe.py
+
+      - name: Smoke-test exe (--version)
+        # Separate steps so a non-zero exit from either command fails the job;
+        # pwsh only checks the exit code of a step's final native command.
+        run: .\dist\apotrope.exe --version
+
+      - name: Smoke-test exe (--dry-run)
+        run: .\dist\apotrope.exe --dry-run --no-color
+
+      - name: Check exe version matches tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          want="${GITHUB_REF_NAME#v}"
+          # tr strips the \r a Windows exe emits; exact token match (not
+          # substring) so tag v0.1.1 can never pass against version 0.1.10.
+          got="$(./dist/apotrope.exe --version | tr -d '\r')"
+          got_ver="${got##* }"
+          echo "tag version: $want / exe reports: $got"
+          if [ "$got_ver" != "$want" ]; then
+            echo "::error::exe --version ('$got') does not report exactly '$want'." \
+                 "Did you forget to bump version in pyproject.toml before tagging?"
+            exit 1
+          fi
+
+      - name: Generate SHA256SUMS
+        shell: bash
+        run: |
+          cd dist
+          sha256sum apotrope.exe > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Attest build provenance
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/attest-build-provenance@v4
+        with:
+          # Attest the checksums file too, so it has the same trust anchor as
+          # the exe rather than only the release page it ships from.
+          subject-path: |
+            dist/apotrope.exe
+            dist/SHA256SUMS
+
+      - name: Upload workflow artifact (dry-run inspection)
+        uses: actions/upload-artifact@v4
+        with:
+          name: apotrope-release
+          path: |
+            dist/apotrope.exe
+            dist/SHA256SUMS
+
+      - name: Create draft release
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="$GITHUB_REF_NAME"
+          sha="$(cut -d' ' -f1 dist/SHA256SUMS)"
+
+          cat > release_notes.md <<EOF
+          ## Verify your download
+
+          \`\`\`
+          SHA-256 (apotrope.exe): $sha
+          \`\`\`
+
+          Provenance (proves this exe was built by CI in this repo):
+
+          \`\`\`
+          gh attestation verify apotrope.exe --repo $GITHUB_REPOSITORY
+          \`\`\`
+
+          Hash check — PowerShell: \`Get-FileHash .\apotrope.exe -Algorithm SHA256\`
+          or cmd.exe: \`certutil -hashfile apotrope.exe SHA256\` — compare
+          against SHA256SUMS attached below (hex case differs between tools;
+          the comparison is case-insensitive).
+          EOF
+
+          if gh release view "$tag" >/dev/null 2>&1; then
+            isdraft="$(gh release view "$tag" --json isDraft --jq .isDraft)"
+            if [ "$isdraft" != "true" ]; then
+              echo "::error::Release $tag is already PUBLISHED. Refusing to overwrite" \
+                   "published assets: users may have recorded their hashes, and the" \
+                   "attestation trust story depends on release assets never changing" \
+                   "after publication. If a rebuild is truly required, delete the" \
+                   "release and tag deliberately and re-push."
+              exit 1
+            fi
+            echo "Draft release for $tag already exists — refreshing assets and notes."
+            gh release upload "$tag" dist/apotrope.exe dist/SHA256SUMS --clobber
+            # Keep the body's stated hash in sync with the refreshed assets.
+            # gh release edit has no --generate-notes; re-add auto-generated
+            # notes from the UI before publishing if wanted.
+            gh release edit "$tag" --notes-file release_notes.md
+          else
+            gh release create "$tag" \
+              --draft \
+              --verify-tag \
+              --title "apotrope $tag" \
+              --notes-file release_notes.md \
+              --generate-notes \
+              dist/apotrope.exe dist/SHA256SUMS
+          fi
+
+          {
+            echo "## Maintainer gate — before publishing the draft"
+            echo "- [ ] Download apotrope.exe FROM THE DRAFT (do not rebuild locally)"
+            echo "- [ ] Verify console rendering (colors/glyphs) on a live machine"
+            echo "- [ ] gh attestation verify apotrope.exe --repo $GITHUB_REPOSITORY"
+            echo "- [ ] Publish the draft in the Releases UI"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   "no antivirus registered" CRITICAL. A genuinely disabled Defender (the cmdlet succeeds and
   reports protection off) still correctly fails CRITICAL.
 
+### Docs
+- **README: Harden Windows Security (HotCakeX) joins the comparison table,** which
+  also gains an Automation row, plus a new FAQ section ("How is this different from
+  Harden Windows Security?", download verification, CIS affiliation) and a "Verify
+  Your Download" section documenting build-provenance attestations, SHA-256
+  checking, and the PyPI trusted-publishing channel as the exe-free alternative.
+- **SECURITY.md explains why PowerShell subprocesses use `-ExecutionPolicy Bypass`**
+  (read-only queries, nothing written to disk, machine policy unchanged),
+  cross-referencing the README's "How Apotrope queries your system" section.
+
 ### CI
+- **Version-tag releases are now built, attested, and drafted by CI.** A new
+  `release.yml` builds `apotrope.exe` on `windows-latest` for every `v*` tag, runs
+  the test suite, generates `SHA256SUMS`, attaches a GitHub build-provenance
+  attestation (`actions/attest-build-provenance`, verifiable with
+  `gh attestation verify`), and creates a **draft** GitHub release with both files
+  attached. The maintainer performs the on-hardware rendering check against the exe
+  downloaded from the draft, then publishes it — the published exe is always the
+  CI-built artifact, never a local build, and the workflow refuses to modify a
+  release once it has been published.
+- **PyPI attestations pinned on.** `publish.yml` now passes `attestations: true`
+  explicitly (PEP 740 provenance was already the Trusted Publishing default; now it
+  cannot silently change with an upstream default).
 - **A `build-exe` job builds and smoke-tests `apotrope.exe` on `windows-latest`**
   (`build_exe.py --no-icon`, then `--version` and `--dry-run`) and uploads the exe as a
   workflow artifact. This catches a broken or empty frozen build on every PR; it

--- a/README.md
+++ b/README.md
@@ -32,17 +32,18 @@ of checks (BitLocker, some policy reads) just come back limited.
 
 ### How Apotrope compares
 
-| | Apotrope | CIS-CAT Lite | HardeningKitty | Lynis |
-|---|---|---|---|---|
-| Platform | Windows 10/11 | Windows (+others) | Windows | Linux/macOS/BSD |
-| Install | Single `.exe` or `pip` | Java app | PowerShell module | Shell script |
-| Account / signup | None | Yes¹ | None | None |
-| Mode | Read-only audit | Read-only audit | Audit **and** apply¹ | Read-only audit |
-| CIS mapping | CIS Win11 v5.0.0 / Win10 v4.0.0 | CIS (authoritative) | CIS / Microsoft / BSI¹ | CIS / various |
-| Output | Score + HTML + JSON | Scored HTML | CSV¹ | Terminal + log |
-| License | MIT | Free tier / paid Pro | MIT¹ | GPLv3 |
+| | Apotrope | CIS-CAT Lite | HardeningKitty | Harden Windows Security (HotCakeX) | Lynis |
+|---|---|---|---|---|---|
+| Platform | Windows 10/11 | Windows (+others) | Windows | Windows¹ | Linux/macOS/BSD |
+| Install | Single `.exe` or `pip` | Java app | PowerShell module | Microsoft Store (MSIX)¹ | Shell script |
+| Account / signup | None | Yes¹ | None | None¹ | None |
+| Mode | Read-only audit | Read-only audit | Audit **and** apply¹ | Applies hardening; verifies its own baseline¹ | Read-only audit |
+| CIS mapping | CIS Win11 v5.0.0 / Win10 v4.0.0 | CIS (authoritative) | CIS / Microsoft / BSI¹ | Own baseline (not CIS)¹ | CIS / various |
+| Automation | JSON, exit codes, baseline diff, TOML profiles | Scripted runs¹ | PowerShell-native¹ | GUI + headless CLI (JSON, exit codes)¹ | CLI + log |
+| Output | Score + HTML + JSON | Scored HTML | CSV¹ | GUI score; CLI JSON export¹ | Terminal + log |
+| License | MIT | Free tier / paid Pro | MIT¹ | MIT | GPLv3 |
 
-¹ Verify current details with each project before relying on them. Lynis is listed for context; it does not run on Windows.
+¹ Verify current details with each project before relying on them. Lynis is listed for context; it does not run on Windows. Harden Windows Security does a different job — it **applies** a hardened baseline (and is excellent at it) rather than auditing against an external benchmark; see the [FAQ](#faq).
 
 ---
 
@@ -81,6 +82,59 @@ Then open `report.html` in your browser.
 
 Every issue is shown with a copy-paste-ready PowerShell command by default —
 no extra flags needed.
+
+---
+
+## Verify Your Download
+
+`apotrope.exe` is not yet Authenticode-signed (no code-signing certificate yet —
+expect a SmartScreen warning on first run). Instead of asking you to trust a
+bare binary, releases are verifiable two ways.
+
+**1. Verify build provenance** — releases **from v0.1.10 onward** are built on
+GitHub-hosted CI and attested at build time. Requires the
+[GitHub CLI](https://cli.github.com/), logged in with any GitHub account:
+
+```powershell
+gh attestation verify .\apotrope.exe --repo hexorcist404/apotrope
+```
+
+A successful result proves the file was built by a GitHub Actions workflow in
+this repository and hasn't been altered since — not built on someone's laptop,
+not modified in transit. The output shows exactly which workflow, commit, and
+tag produced the file: check that it names `release.yml` and the tag you
+downloaded. (This proves *origin*, not correctness — the source is right here
+for that.)
+
+**2. Verify the SHA-256 hash** against the release notes and the `SHA256SUMS`
+file attached to releases from v0.1.10 onward:
+
+```powershell
+Get-FileHash .\apotrope.exe -Algorithm SHA256
+```
+
+or in Command Prompt:
+
+```bat
+certutil -hashfile apotrope.exe SHA256
+```
+
+(Hex case differs between tools; the comparison is case-insensitive.) Honest
+caveat: the hash is published on the same release page as the exe, so this
+step catches download corruption and tampered mirrors — not a compromised
+repository. Step 1 is the authenticity check; this is the quick integrity
+check.
+
+**Prefer not to run a downloaded exe at all?** `pip install apotrope` gets the
+same tool from PyPI, where every release is published straight from CI via
+[trusted publishing](https://docs.pypi.org/trusted-publishers/) (OpenID
+Connect, no long-lived tokens) with [PEP 740](https://peps.python.org/pep-0740/)
+attestations — visible on the PyPI project page; pip itself doesn't verify
+attestations at install time yet.
+
+> **Note:** v0.1.9 and older were built and attached by hand, before CI-built
+> releases existed. They cannot carry build-provenance attestations — verify
+> them by hash instead (v0.1.9's SHA-256 is published in its release notes).
 
 ---
 
@@ -133,11 +187,12 @@ apotrope
 ### How Apotrope queries your system
 
 Apotrope uses PowerShell subprocesses with `-ExecutionPolicy Bypass` to read system
-configuration. This flag is required so the tool can run on machines with any execution
-policy setting — including the default `Restricted` policy — without requiring you to
-permanently change your policy. **No scripts are written to disk.** Each command is a
-read-only query passed directly to the PowerShell process; the bypass applies only to
-that subprocess and does not change the machine's policy setting.
+configuration. This flag is required so the tool can run under any locally configured
+execution policy — including the default `Restricted` — without requiring you to
+change your policy. (An execution policy enforced through Group Policy takes
+precedence and is not overridden.) **No scripts are written to disk.** Each command is
+a read-only query passed directly to the PowerShell process; the bypass applies only
+to that subprocess and does not change the machine's policy setting.
 
 ### Sharing reports safely
 
@@ -402,6 +457,31 @@ def run() -> list[CheckResult]:
 ```
 
 The scanner auto-discovers all modules in `checks/` — no registration needed.
+
+---
+
+## FAQ
+
+### How is this different from Harden Windows Security (HotCakeX)?
+
+Different job. [Harden Windows Security](https://github.com/HotCakeX/Harden-Windows-Security)
+changes your machine to a hardened baseline — it's excellent at that. Apotrope
+never changes anything; it's a read-only assessor that scores any box against
+CIS Benchmarks. Audit with Apotrope, harden with Harden Windows Security or
+Group Policy, then re-audit. They compose.
+
+### How do I verify that my download is legitimate?
+
+See [Verify Your Download](#verify-your-download): check the SHA-256 published
+with the release, and — from v0.1.10 onward — verify CI build provenance with
+`gh attestation verify`. Or skip the exe entirely with `pip install apotrope`.
+
+### Is Apotrope affiliated with CIS?
+
+No. Apotrope independently references CIS Benchmark control IDs for
+informational purposes. It is not affiliated with, endorsed by, or sponsored by
+CIS. For the official benchmarks and tooling, see
+[cisecurity.org](https://www.cisecurity.org).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,12 @@
 
 Apotrope is a **read-only** security auditing tool. It does not modify system configurations, write to the registry, or change any settings on the machines it scans. All operations are observational only.
 
+## Why Apotrope Runs PowerShell with `-ExecutionPolicy Bypass`
+
+Apotrope reads system configuration through short-lived PowerShell subprocesses started with `-ExecutionPolicy Bypass`. The flag exists so the tool runs under any *locally configured* execution policy — including the default `Restricted` — without asking you to change it. An execution policy enforced through Group Policy (the `MachinePolicy`/`UserPolicy` scopes) still takes precedence: the flag doesn't and can't override it, and on such machines some queries may come back limited. The flag applies only to each read-only subprocess: no scripts are written to disk, and the machine's execution-policy setting is never modified. The README section ["How Apotrope queries your system"](README.md#how-apotrope-queries-your-system) has the detail.
+
+If you find an Apotrope query that is *not* read-only, that is a reportable vulnerability — see below.
+
 ## Supported Versions
 
 | Version  | Supported          |


### PR DESCRIPTION
## Summary

Handoff tasks 1–3 (P0)

- **README**: "Harden Windows Security" column + new Automation row in the comparison table; new **FAQ** (HWS "different job — they compose" framing, download verification, CIS affiliation); new **Verify Your Download** section (attestations, SHA-256, pip/PyPI channel).
- **SECURITY.md**: why `-ExecutionPolicy Bypass` is used (read-only subprocess queries, nothing on disk, machine policy unchanged) — pre-empting the predictable objection.
- **CI**: new `release.yml` — on `v*` tag: test on windows-latest → build exe with icon → smoke + exact version-vs-tag gate → `SHA256SUMS` → `actions/attest-build-provenance` (exe + sums) → **draft** release via `gh` CLI only (no third-party release actions). Maintainer verifies rendering against the exe downloaded *from the draft*, then publishes. The workflow refuses to modify a published release. `publish.yml` pins `attestations: true`.

## Release process change

From v0.1.10 onward the released exe is always the CI-built artifact. Never hand-attach a locally built exe again — the attestation is bound to the CI build's digest, and a mismatch reads as tampering.

## Review

Adversarially reviewed pre-commit by a 4-lens multi-agent pass (HN skeptic, HWS community member, claims-checker, CI-tech; 26 agents, refutation vote per finding). 9 confirmed findings all fixed, incl.: present-tense v0.1.10 claims, `gh attestation verify` overclaim, SHA256SUMS same-trust-domain caveat, GPO execution-policy precedence, the HWS automation cell, pip/PEP-740 nuance, draft-only release guard, exact version gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)