### PR TITLE
Pre-HN fixes: working report expand/collapse, clickable summary counters, COMPARE nav dropdown

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -143,7 +143,24 @@
              color:var(--void); background:var(--accent); padding:8px 15px; border-radius:2px;
              box-shadow:0 0 16px rgba(43,255,136,0.3); transition:transform .12s; white-space:nowrap; }
   .nav-cta:hover { transform:translateY(-1px); }
-  @media (max-width:1140px){ .nav-links .nav-compare { display:none; } }
+  /* Compare dropdown — CSS-only (hover + focus-within) so the JS-free vs
+     pages get the identical nav. Full nav height = no hover dead-zone. */
+  .nav-drop { position:relative; display:flex; align-items:center; height:62px; }
+  .nav-drop-btn { display:flex; align-items:center; gap:6px; font-family:"IBM Plex Mono",monospace;
+                  font-size:12px; letter-spacing:0.12em; color:var(--muted); text-transform:uppercase;
+                  background:none; border:none; cursor:pointer; padding:0; transition:color .15s; white-space:nowrap; }
+  .nav-drop-btn .dcaret { font-size:9px; transition:transform .15s; }
+  .nav-drop:hover .nav-drop-btn, .nav-drop:focus-within .nav-drop-btn { color:var(--bright); }
+  .nav-drop:hover .dcaret, .nav-drop:focus-within .dcaret { transform:rotate(180deg); }
+  .nav-drop-menu { display:none; position:absolute; top:100%; left:50%; transform:translateX(-50%);
+                   background:rgba(8,13,17,0.97); border:1px solid var(--line); border-radius:3px;
+                   padding:7px 0; min-width:190px; box-shadow:0 16px 34px rgba(0,0,0,0.55); }
+  .nav-drop:hover .nav-drop-menu, .nav-drop:focus-within .nav-drop-menu { display:block; }
+  .nav-drop-menu a { display:block; padding:9px 18px; }
+  .nav-drop-menu a:hover { background:rgba(43,255,136,0.05); }
+  /* measured fit: full nav needs ~1000px; below that, drop Compare first
+     (the vs pages stay reachable from the in-page comparison links) */
+  @media (max-width:1020px){ .nav-links .nav-drop { display:none; } }
   @media (max-width:760px){ .nav-links { display:none; } }
 
   /* ── Hero ────────────────────────────────────────────────────────────────── */
@@ -314,9 +331,14 @@
         <a href="#checks">Checks</a>
         <a href="#scoring">Scoring</a>
         <a href="#report">Report</a>
-        <a class="nav-compare" href="/lynis-for-windows/">vs Lynis</a>
-        <a class="nav-compare" href="/vs-cis-cat/">vs CIS-CAT</a>
-        <a class="nav-compare" href="/vs-harden-windows-security/" title="Apotrope vs Harden Windows Security">vs HWS</a>
+        <div class="nav-drop">
+          <button class="nav-drop-btn" type="button" aria-haspopup="true">Compare <span class="dcaret">▾</span></button>
+          <div class="nav-drop-menu">
+            <a href="/lynis-for-windows/">vs Lynis</a>
+            <a href="/vs-cis-cat/">vs CIS-CAT</a>
+            <a href="/vs-harden-windows-security/" title="Apotrope vs Harden Windows Security">vs HWS</a>
+          </div>
+        </div>
         <a href="#start">Get Started</a>
         <a href="#faq">FAQ</a>
         <a href="https://github.com/hexorcist404/apotrope">GitHub ↗</a>

--- a/docs/lynis-for-windows/index.html
+++ b/docs/lynis-for-windows/index.html
@@ -59,8 +59,14 @@
         <a href="/#checks">Checks</a>
         <a href="/#scoring">Scoring</a>
         <a href="/#report">Report</a>
-        <a href="/vs-cis-cat/">vs CIS-CAT</a>
-        <a href="/vs-harden-windows-security/">vs Harden Windows Security</a>
+        <div class="nav-drop">
+          <button class="nav-drop-btn" type="button" aria-haspopup="true">Compare <span class="dcaret">▾</span></button>
+          <div class="nav-drop-menu">
+            <a href="/lynis-for-windows/">vs Lynis</a>
+            <a href="/vs-cis-cat/">vs CIS-CAT</a>
+            <a href="/vs-harden-windows-security/" title="Apotrope vs Harden Windows Security">vs HWS</a>
+          </div>
+        </div>
         <a href="/#faq">FAQ</a>
         <a href="https://github.com/hexorcist404/apotrope">GitHub ↗</a>
       </div>

--- a/docs/pages.css
+++ b/docs/pages.css
@@ -48,6 +48,23 @@ nav .wrap { display:flex; align-items:center; justify-content:space-between; hei
            color:var(--void); background:var(--accent); padding:8px 15px; border-radius:2px;
            box-shadow:0 0 16px rgba(43,255,136,0.3); transition:transform .12s; white-space:nowrap; }
 .nav-cta:hover { transform:translateY(-1px); }
+/* Compare dropdown — CSS-only (hover + focus-within), mirrors the homepage.
+   Full nav height = no hover dead-zone between button and menu. */
+.nav-drop { position:relative; display:flex; align-items:center; height:62px; }
+.nav-drop-btn { display:flex; align-items:center; gap:6px; font-family:"IBM Plex Mono",monospace;
+                font-size:12px; letter-spacing:0.12em; color:var(--muted); text-transform:uppercase;
+                background:none; border:none; cursor:pointer; padding:0; transition:color .15s; white-space:nowrap; }
+.nav-drop-btn .dcaret { font-size:9px; transition:transform .15s; }
+.nav-drop:hover .nav-drop-btn, .nav-drop:focus-within .nav-drop-btn { color:var(--bright); }
+.nav-drop:hover .dcaret, .nav-drop:focus-within .dcaret { transform:rotate(180deg); }
+.nav-drop-menu { display:none; position:absolute; top:100%; left:50%; transform:translateX(-50%);
+                 background:rgba(8,13,17,0.97); border:1px solid var(--line); border-radius:3px;
+                 padding:7px 0; min-width:190px; box-shadow:0 16px 34px rgba(0,0,0,0.55); }
+.nav-drop:hover .nav-drop-menu, .nav-drop:focus-within .nav-drop-menu { display:block; }
+.nav-drop-menu a { display:block; padding:9px 18px; }
+.nav-drop-menu a:hover { background:rgba(43,255,136,0.05); }
+/* measured fit: the vs-page nav needs ~870px; below that, drop Compare first */
+@media (max-width:880px){ .nav-links .nav-drop { display:none; } }
 @media (max-width:760px){ .nav-links { display:none; } }
 
 /* ── Page content ── */

--- a/docs/report.html
+++ b/docs/report.html
@@ -219,6 +219,8 @@
   .pill-fail { color:var(--red);   border-color:rgba(255,81,71,0.3);  background:rgba(255,81,71,0.07); }
   .pill-warn { color:var(--amber); border-color:rgba(255,178,61,0.3); background:rgba(255,178,61,0.06); }
   .pill-info { color:var(--cyan);  border-color:rgba(68,224,230,0.28);background:rgba(68,224,230,0.05); }
+  button.pill { transition:filter .15s, text-shadow .15s; }
+  button.pill:hover, button.pill:focus-visible { filter:brightness(1.4); text-shadow:0 0 9px currentColor; }
 
   /* donut */
   .donut-row { display:flex; align-items:center; gap:18px; }
@@ -316,6 +318,9 @@
 
   .fbody { padding:2px 16px 18px 59px; display:grid; gap:13px;
            border-top:1px solid var(--line-soft); background:rgba(0,0,0,0.18); }
+  /* display:grid above beats the UA's [hidden]{display:none} — collapse needs
+     an explicit author rule or the toggle can never hide the body */
+  .fbody[hidden] { display:none; }
   .fbody .fld { display:grid; grid-template-columns: 82px 1fr; gap:14px; align-items:start; }
   .fbody .fld .k { font-size:10.5px; letter-spacing:0.14em; text-transform:uppercase; color:var(--faint); padding-top:2px; }
   .fbody .fld .vv { font-size:13px; color:var(--text); line-height:1.65; }
@@ -425,10 +430,10 @@
           <div class="summary-head">
             <span class="kicker">Executive Summary</span>
             <div class="pills">
-              <span class="pill pill-pass"><span class="n">34</span> passed</span>
-              <span class="pill pill-fail"><span class="n">3</span> failed</span>
-              <span class="pill pill-warn"><span class="n">3</span> warnings</span>
-              <span class="pill pill-info"><span class="n">13</span> info</span>
+              <button class="pill pill-pass" data-k="PASS" title="Show the passed checks"><span class="n">34</span> passed</button>
+              <button class="pill pill-fail" data-k="FAIL" title="Show the failed checks"><span class="n">3</span> failed</button>
+              <button class="pill pill-warn" data-k="WARN" title="Show the warnings"><span class="n">3</span> warnings</button>
+              <button class="pill pill-info" data-k="INFO" title="Show the info results"><span class="n">13</span> info</button>
             </div>
           </div>
           <div class="summary-body">The security posture of <b>WORKSTATION-07</b> has been assessed as <b>Fair</b> with an overall score of <b>75/100 (C)</b> across 53 security checks. <span class="hl-high">1 high-severity finding should be addressed promptly.</span> Of the checks performed, 3 checks failed and 3 checks issued warnings. The primary areas of concern are <b>Accounts</b>, <b>Hardening</b> and <b>Encryption</b>. Remediation should be prioritized by severity, addressing critical and high-severity findings first.</div>
@@ -742,7 +747,7 @@
       <div class="findings">
         
         <div class="frow" data-status="FAIL" data-text="password policy — minimum length accounts minimum password length: 0 characters. cis 1.1.4 net accounts /minpwlen:14">
-          <button class="fhead">
+          <button class="fhead is-open">
             <span class="ficon" style="color:#ff5147">✗</span>
             <span class="fsev" style="color:#ff5147;border:1px solid #ff5147;background:transparent">HIGH</span>
             <span class="fname">
@@ -754,7 +759,7 @@
               <span class="chev">▶</span>
             </span>
           </button>
-          <div class="fbody" hidden>
+          <div class="fbody">
             <div class="fld"><span class="k">Checks</span><span class="vv">Minimum password length must be ≥8 (WARN if &lt;12).</span></div>
             <div class="fld"><span class="k">Found</span><span class="vv">Minimum password length: 0 characters.</span></div>
             
@@ -781,7 +786,7 @@
 # password policy -&gt; password must meet complexity requirements -&gt; enabled.
 # verify the current setting:
 secedit /export /cfg &#34;$env:temp\secpol.cfg&#34; | out-null; select-string -path &#34;$env:temp\secpol.cfg&#34; -pattern &#39;passwordcomplexity&#39;">
-          <button class="fhead">
+          <button class="fhead is-open">
             <span class="ficon" style="color:#ff5147">✗</span>
             <span class="fsev" style="color:#ffb23d;border:1px solid #ffb23d;background:transparent">MEDIUM</span>
             <span class="fname">
@@ -793,7 +798,7 @@ secedit /export /cfg &#34;$env:temp\secpol.cfg&#34; | out-null; select-string -p
               <span class="chev">▶</span>
             </span>
           </button>
-          <div class="fbody" hidden>
+          <div class="fbody">
             <div class="fld"><span class="k">Checks</span><span class="vv">Checks whether password complexity requirements are enforced.</span></div>
             <div class="fld"><span class="k">Found</span><span class="vv">Password complexity requirement: disabled.</span></div>
             
@@ -1024,7 +1029,7 @@ secedit /export /cfg &#34;$env:TEMP\secpol.cfg&#34; | Out-Null; Select-String -P
       <div class="findings">
         
         <div class="frow" data-status="FAIL" data-text="bitlocker — g: encryption drive: g: | type: 1 | status: unknown | encrypted: 0% | protection: off cis 18.10.10 enable-bitlocker -mountpoint &#39;g:&#39; -encryptionmethod xtsaes256 -usedspaceonly -tpmprotector">
-          <button class="fhead">
+          <button class="fhead is-open">
             <span class="ficon" style="color:#ff5147">✗</span>
             <span class="fsev" style="color:#ffb23d;border:1px solid #ffb23d;background:transparent">MEDIUM</span>
             <span class="fname">
@@ -1036,7 +1041,7 @@ secedit /export /cfg &#34;$env:TEMP\secpol.cfg&#34; | Out-Null; Select-String -P
               <span class="chev">▶</span>
             </span>
           </button>
-          <div class="fbody" hidden>
+          <div class="fbody">
             <div class="fld"><span class="k">Checks</span><span class="vv">Checks BitLocker encryption status for drive G:.</span></div>
             <div class="fld"><span class="k">Found</span><span class="vv">Drive: G: | Type: 1 | Status: Unknown | Encrypted: 0% | Protection: Off</span></div>
             
@@ -1330,7 +1335,7 @@ secedit /export /cfg &#34;$env:TEMP\secpol.cfg&#34; | Out-Null; Select-String -P
       <div class="findings">
         
         <div class="frow" data-status="WARN" data-text="autoplay disabled hardening autoplay is partially disabled (nodrivetypeautorun = 158). some drive types may still trigger autoplay. cis 18.10.8.3 set-itemproperty -path &#39;hklm:\software\microsoft\windows\currentversion\policies\explorer&#39; -name nodrivetypeautorun -value 255 -type dword -force">
-          <button class="fhead">
+          <button class="fhead is-open">
             <span class="ficon" style="color:#ffb23d">!</span>
             <span class="fsev" style="color:#ffb23d;border:1px solid #ffb23d;background:transparent">MEDIUM</span>
             <span class="fname">
@@ -1342,7 +1347,7 @@ secedit /export /cfg &#34;$env:TEMP\secpol.cfg&#34; | Out-Null; Select-String -P
               <span class="chev">▶</span>
             </span>
           </button>
-          <div class="fbody" hidden>
+          <div class="fbody">
             <div class="fld"><span class="k">Checks</span><span class="vv">Checks whether AutoPlay is disabled for all drive types.</span></div>
             <div class="fld"><span class="k">Found</span><span class="vv">AutoPlay is partially disabled (NoDriveTypeAutoRun = 158). Some drive types may still trigger AutoPlay.</span></div>
             
@@ -1366,7 +1371,7 @@ secedit /export /cfg &#34;$env:TEMP\secpol.cfg&#34; | Out-Null; Select-String -P
         </div>
         
         <div class="frow" data-status="WARN" data-text="audit policy hardening the following subcategories have auditing disabled: sensitive privilege use. security-relevant events may not be recorded. cis 17.1.1 auditpol /set /subcategory:&#39;logon&#39; /success:enable /failure:enable">
-          <button class="fhead">
+          <button class="fhead is-open">
             <span class="ficon" style="color:#ffb23d">!</span>
             <span class="fsev" style="color:#ffb23d;border:1px solid #ffb23d;background:transparent">MEDIUM</span>
             <span class="fname">
@@ -1378,7 +1383,7 @@ secedit /export /cfg &#34;$env:TEMP\secpol.cfg&#34; | Out-Null; Select-String -P
               <span class="chev">▶</span>
             </span>
           </button>
-          <div class="fbody" hidden>
+          <div class="fbody">
             <div class="fld"><span class="k">Checks</span><span class="vv">Checks that key audit policy subcategories log Success/Failure events.</span></div>
             <div class="fld"><span class="k">Found</span><span class="vv">The following subcategories have auditing disabled: Sensitive Privilege Use. Security-relevant events may not be recorded.</span></div>
             
@@ -1483,7 +1488,7 @@ secedit /export /cfg &#34;$env:TEMP\secpol.cfg&#34; | Out-Null; Select-String -P
       <div class="findings">
         
         <div class="frow" data-status="WARN" data-text="netbios over tcp/ip network 2 adapter(s) inherit netbios setting from dhcp. if the dhcp server does not explicitly disable netbios, it may be active.  (get-ciminstance win32_networkadapterconfiguration -filter &#39;ipenabled=true&#39;).settcpipnetbios(2)">
-          <button class="fhead">
+          <button class="fhead is-open">
             <span class="ficon" style="color:#ffb23d">!</span>
             <span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span>
             <span class="fname">
@@ -1495,7 +1500,7 @@ secedit /export /cfg &#34;$env:TEMP\secpol.cfg&#34; | Out-Null; Select-String -P
               <span class="chev">▶</span>
             </span>
           </button>
-          <div class="fbody" hidden>
+          <div class="fbody">
             <div class="fld"><span class="k">Checks</span><span class="vv">Checks whether NetBIOS over TCP/IP is disabled on all network adapters.</span></div>
             <div class="fld"><span class="k">Found</span><span class="vv">2 adapter(s) inherit NetBIOS setting from DHCP. If the DHCP server does not explicitly disable NetBIOS, it may be active.</span></div>
             
@@ -2137,6 +2142,17 @@ secedit /export /cfg &#34;$env:TEMP\secpol.cfg&#34; | Out-Null; Select-String -P
     });
   });
   search.addEventListener('input', apply);
+
+  // Executive-summary counters: apply the matching filter (delegate to the
+  // toolbar chip so the logic lives in one place) and jump to the results.
+  var toolbar = document.querySelector('.toolbar');
+  document.querySelectorAll('.pills .pill[data-k]').forEach(function(pill){
+    pill.addEventListener('click', function(){
+      var chip = document.querySelector('.fchip[data-k="' + pill.dataset.k + '"]');
+      if (chip) chip.click();
+      if (toolbar) window.scrollTo({ top: toolbar.getBoundingClientRect().top + window.scrollY - 12, behavior: 'smooth' });
+    });
+  });
 
   rows.forEach(function(row){
     var head = row.querySelector('.fhead'), body = row.querySelector('.fbody');

--- a/docs/vs-cis-cat/index.html
+++ b/docs/vs-cis-cat/index.html
@@ -59,8 +59,14 @@
         <a href="/#checks">Checks</a>
         <a href="/#scoring">Scoring</a>
         <a href="/#report">Report</a>
-        <a href="/lynis-for-windows/">Lynis for Windows</a>
-        <a href="/vs-harden-windows-security/">vs Harden Windows Security</a>
+        <div class="nav-drop">
+          <button class="nav-drop-btn" type="button" aria-haspopup="true">Compare <span class="dcaret">▾</span></button>
+          <div class="nav-drop-menu">
+            <a href="/lynis-for-windows/">vs Lynis</a>
+            <a href="/vs-cis-cat/">vs CIS-CAT</a>
+            <a href="/vs-harden-windows-security/" title="Apotrope vs Harden Windows Security">vs HWS</a>
+          </div>
+        </div>
         <a href="/#faq">FAQ</a>
         <a href="https://github.com/hexorcist404/apotrope">GitHub ↗</a>
       </div>

--- a/docs/vs-harden-windows-security/index.html
+++ b/docs/vs-harden-windows-security/index.html
@@ -58,8 +58,15 @@
         <a href="/#features">Features</a>
         <a href="/#checks">Checks</a>
         <a href="/#scoring">Scoring</a>
-        <a href="/vs-cis-cat/">vs CIS-CAT</a>
-        <a href="/lynis-for-windows/">Lynis for Windows</a>
+        <a href="/#report">Report</a>
+        <div class="nav-drop">
+          <button class="nav-drop-btn" type="button" aria-haspopup="true">Compare <span class="dcaret">▾</span></button>
+          <div class="nav-drop-menu">
+            <a href="/lynis-for-windows/">vs Lynis</a>
+            <a href="/vs-cis-cat/">vs CIS-CAT</a>
+            <a href="/vs-harden-windows-security/" title="Apotrope vs Harden Windows Security">vs HWS</a>
+          </div>
+        </div>
         <a href="/#faq">FAQ</a>
         <a href="https://github.com/hexorcist404/apotrope">GitHub ↗</a>
       </div>

--- a/src/apotrope/templates/report.html.j2
+++ b/src/apotrope/templates/report.html.j2
@@ -316,6 +316,9 @@
 
   .fbody { padding:2px 16px 18px 59px; display:grid; gap:13px;
            border-top:1px solid var(--line-soft); background:rgba(0,0,0,0.18); }
+  /* display:grid above beats the UA's [hidden]{display:none} — collapse needs
+     an explicit author rule or the toggle can never hide the body */
+  .fbody[hidden] { display:none; }
   .fbody .fld { display:grid; grid-template-columns: 82px 1fr; gap:14px; align-items:start; }
   .fbody .fld .k { font-size:10.5px; letter-spacing:0.14em; text-transform:uppercase; color:var(--faint); padding-top:2px; }
   .fbody .fld .vv { font-size:13px; color:var(--text); line-height:1.65; }
@@ -528,9 +531,14 @@
         </span>
       </div>
       <div class="findings">
+        {# Default state: FAIL/WARN rows start expanded so issues triage at a
+           glance; PASS/INFO (and ERROR) start collapsed. Keep the is-open
+           class and the hidden attribute in sync — the toggle JS relies on
+           [hidden] and the caret rotation on .is-open. #}
         {% for f in cat.findings %}
+        {% set f_open = f.status in ('FAIL', 'WARN') %}
         <div class="frow" data-status="{{ f.status }}" data-text="{{ f.check_name|lower }} {{ f.category|lower }} {{ f.details|lower }} {{ f.cis|lower }} {{ f.command|lower }}">
-          <button class="fhead">
+          <button class="fhead{% if f_open %} is-open{% endif %}">
             <span class="ficon" style="color:{{ f.status_color }}">{{ f.status_glyph }}</span>
             <span class="fsev" style="color:{{ f.sev_color }};border:1px solid {{ f.sev_color }};background:transparent">{{ f.severity }}</span>
             <span class="fname">
@@ -542,7 +550,7 @@
               <span class="chev">▶</span>
             </span>
           </button>
-          <div class="fbody" hidden>
+          <div class="fbody"{% if not f_open %} hidden{% endif %}>
             <div class="fld"><span class="k">Checks</span><span class="vv">{{ f.description }}</span></div>
             <div class="fld"><span class="k">Found</span><span class="vv">{{ f.details }}</span></div>
             {% if f.remediation or f.command %}

--- a/src/apotrope/templates/report.html.j2
+++ b/src/apotrope/templates/report.html.j2
@@ -219,6 +219,8 @@
   .pill-fail { color:var(--red);   border-color:rgba(255,81,71,0.3);  background:rgba(255,81,71,0.07); }
   .pill-warn { color:var(--amber); border-color:rgba(255,178,61,0.3); background:rgba(255,178,61,0.06); }
   .pill-info { color:var(--cyan);  border-color:rgba(68,224,230,0.28);background:rgba(68,224,230,0.05); }
+  button.pill { transition:filter .15s, text-shadow .15s; }
+  button.pill:hover, button.pill:focus-visible { filter:brightness(1.4); text-shadow:0 0 9px currentColor; }
 
   /* donut */
   .donut-row { display:flex; align-items:center; gap:18px; }
@@ -427,11 +429,13 @@
         <div class="summary-panel panel rise">
           <div class="summary-head">
             <span class="kicker">Executive Summary</span>
+            {# Counters double as shortcuts: click filters the results to that
+               status and jumps to them (delegates to the toolbar chips). #}
             <div class="pills">
-              <span class="pill pill-pass"><span class="n">{{ pass_count }}</span> passed</span>
-              <span class="pill pill-fail"><span class="n">{{ fail_count }}</span> failed</span>
-              <span class="pill pill-warn"><span class="n">{{ warn_count }}</span> warnings</span>
-              <span class="pill pill-info"><span class="n">{{ info_count }}</span> info</span>
+              <button class="pill pill-pass" data-k="PASS" title="Show the passed checks"><span class="n">{{ pass_count }}</span> passed</button>
+              <button class="pill pill-fail" data-k="FAIL" title="Show the failed checks"><span class="n">{{ fail_count }}</span> failed</button>
+              <button class="pill pill-warn" data-k="WARN" title="Show the warnings"><span class="n">{{ warn_count }}</span> warnings</button>
+              <button class="pill pill-info" data-k="INFO" title="Show the info results"><span class="n">{{ info_count }}</span> info</button>
             </div>
           </div>
           <div class="summary-body">{{ exec_summary_html }}</div>
@@ -622,6 +626,17 @@
     });
   });
   search.addEventListener('input', apply);
+
+  // Executive-summary counters: apply the matching filter (delegate to the
+  // toolbar chip so the logic lives in one place) and jump to the results.
+  var toolbar = document.querySelector('.toolbar');
+  document.querySelectorAll('.pills .pill[data-k]').forEach(function(pill){
+    pill.addEventListener('click', function(){
+      var chip = document.querySelector('.fchip[data-k="' + pill.dataset.k + '"]');
+      if (chip) chip.click();
+      if (toolbar) window.scrollTo({ top: toolbar.getBoundingClientRect().top + window.scrollY - 12, behavior: 'smooth' });
+    });
+  });
 
   rows.forEach(function(row){
     var head = row.querySelector('.fhead'), body = row.querySelector('.fbody');

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -143,6 +144,40 @@ class TestGenerateHtmlReport:
     def test_print_css_present(self):
         html = self._generate(_make_report())
         assert "@media print" in html
+
+    # ── Expand/collapse: the [hidden] toggle must actually hide content ────
+
+    @staticmethod
+    def _finding_rows(html: str) -> list[tuple[str, bool, bool]]:
+        """Per finding row: (status, header marked open, body hidden)."""
+        rows = []
+        for chunk in html.split('<div class="frow" ')[1:]:
+            status = re.search(r'data-status="(\w+)"', chunk).group(1)
+            is_open = 'class="fhead is-open"' in chunk
+            body_hidden = re.search(r'<div class="fbody"[^>]*\shidden', chunk) is not None
+            rows.append((status, is_open, body_hidden))
+        return rows
+
+    def test_fbody_hidden_css_rule_present(self):
+        """Regression: .fbody{display:grid} overrides the UA's [hidden] rule,
+        so an explicit author rule must hide collapsed bodies on screen —
+        without it every row renders permanently expanded."""
+        html = self._generate(_make_report())
+        assert re.search(r"\.fbody\[hidden\]\s*\{\s*display:\s*none", html)
+
+    def test_fail_warn_rows_expanded_by_default(self):
+        """FAIL/WARN rows start expanded (open header, visible body)."""
+        rows = self._finding_rows(self._generate(_make_report()))
+        triage = [r for r in rows if r[0] in ("FAIL", "WARN")]
+        assert triage, "fixture must contain FAIL/WARN rows"
+        assert all(is_open and not hidden for _, is_open, hidden in triage)
+
+    def test_pass_info_rows_collapsed_by_default(self):
+        """PASS/INFO rows start collapsed (closed header, hidden body)."""
+        rows = self._finding_rows(self._generate(_make_report()))
+        quiet = [r for r in rows if r[0] in ("PASS", "INFO")]
+        assert quiet, "fixture must contain PASS/INFO rows"
+        assert all(not is_open and hidden for _, is_open, hidden in quiet)
 
     def test_version_in_footer(self):
         html = self._generate(_make_report())

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -179,6 +179,16 @@ class TestGenerateHtmlReport:
         assert quiet, "fixture must contain PASS/INFO rows"
         assert all(not is_open and hidden for _, is_open, hidden in quiet)
 
+    def test_summary_counters_are_filter_buttons(self):
+        """The executive-summary count pills are keyboard-focusable buttons
+        wired to the same data-k filter keys the toolbar chips use."""
+        html = self._generate(_make_report())
+        for cls, key in (("pass", "PASS"), ("fail", "FAIL"),
+                         ("warn", "WARN"), ("info", "INFO")):
+            assert re.search(
+                rf'<button class="pill pill-{cls}" data-k="{key}"', html
+            ), f"missing clickable {key} pill"
+
     def test_version_in_footer(self):
         html = self._generate(_make_report())
         assert "Apotrope" in html


### PR DESCRIPTION
Implements all three items from the 2026-07-05 pre-HN handoff. The two report items are the P0/P1 blockers for Tuesday's Show HN; the nav item decrowds the site header.

## 1. Report expand/collapse was broken (P0)

**Root cause:** `.fbody { display:grid }` overrides the UA stylesheet's `[hidden] { display:none }` (author rules always beat UA rules regardless of specificity), so the toggle JS flipped the `hidden` attribute and the caret class but nothing ever hid. The print CSS already relied on `[hidden]` — the screen-side rule was simply missing.

**Fix:** one author rule, `.fbody[hidden] { display:none }`, plus triage-first defaults rendered server-side: FAIL/WARN rows start expanded, PASS/INFO (and ERROR) start collapsed. Carets now always reflect actual state. Documented in the template; print still expands everything.

## 2. Clickable executive-summary counters (P1)

The passed/failed/warnings/info pills are now real `<button>`s. Clicking one delegates to the matching toolbar filter chip (`chip.click()` — the filter logic stays in one place) and smooth-scrolls to the results. Hover/focus glow for affordance; native buttons keep it keyboard-operable. Report stays fully self-contained (inline CSS/JS, works from `file://`).

## 3. COMPARE nav dropdown (P1)

The three vs-links collapse into one COMPARE item with a CSS-only dropdown (hover + `:focus-within`, so the JS-free vs pages get the identical nav and keyboard access works). All three vs-page URLs unchanged. The vs pages get the same dropdown; vs-hws also picks up the Report link the other navs already had.

## Live demo regeneration

`docs/report.html` is a sanitized real scan whose data must not drift (the homepage mock is aligned to it), so it can't be re-rendered from an `AuditReport`. Instead the template diff was ported mechanically: style/script blocks swapped (verified **byte-identical** to a fresh render of the new template), pills converted, and the 6 FAIL/WARN rows defaulted open. Scan data untouched.

## Verification

- 785 tests pass (`pytest`), including 4 new template regression tests (hidden-rule present, FAIL/WARN default-open, PASS/INFO default-collapsed, pills are filter buttons)
- Headless-browser QA on both the fixture render and the live `docs/report.html` from `file://`: row toggle, EXPAND ALL / COLLAPSE across categories, counter-click filtering + scroll, keyboard focus, zero console errors
- Nav measured in-browser at 1440/1280/1150/1000/900/800/375: target layout `FEATURES · CHECKS · SCORING · REPORT · COMPARE ▾ · GET STARTED · FAQ · GITHUB · [Download]`, GITHUB/Download collision gone (94px clearance at 1280), dropdown opens on hover and focus, mobile behavior unchanged. Below 1020px (880px on vs pages) the dropdown hides — measured fit points, mirroring the old >1140px-only compare links; at 800px the nav is byte-identical to old main (pre-existing tightness, out of scope)


🤖 Generated with [Claude Code](https://claude.com/claude-code)