### PR TITLE
fix(checks): strip NUL bytes from TPM firmware version

### DIFF
--- a/src/apotrope/checks/os_info.py
+++ b/src/apotrope/checks/os_info.py
@@ -415,7 +415,9 @@ def _check_tpm() -> list[CheckResult]:
 
     present = bool(data.get("TpmPresent", False))
     ready = bool(data.get("TpmReady", False))
-    version = str(data.get("ManufacturerVersion") or "Unknown")
+    # Get-Tpm's ManufacturerVersion can carry trailing NUL bytes from the
+    # firmware WMI string; strip them so they don't leak into report output.
+    version = str(data.get("ManufacturerVersion") or "").replace("\x00", "").strip() or "Unknown"
 
     if not present:
         return [CheckResult(

--- a/tests/test_checks/test_os_info.py
+++ b/tests/test_checks/test_os_info.py
@@ -358,6 +358,23 @@ class TestCheckTpm:
         assert results[0].status == Status.PASS
         assert "Unknown" in results[0].details
 
+    def test_version_nul_bytes_stripped(self):
+        with patch("apotrope.checks.os_info.run_powershell_json",
+                   return_value=_tpm_json(present=True, ready=True,
+                                          version="7.2.3.1\x00\x00")):
+            results = os_info._check_tpm()
+        assert results[0].status == Status.PASS
+        assert "7.2.3.1" in results[0].details
+        assert "\x00" not in results[0].details
+
+    def test_version_all_nul_bytes_falls_back_to_unknown(self):
+        with patch("apotrope.checks.os_info.run_powershell_json",
+                   return_value=_tpm_json(present=True, ready=True,
+                                          version="\x00\x00")):
+            results = os_info._check_tpm()
+        assert results[0].status == Status.PASS
+        assert "Unknown" in results[0].details
+
 
 # ---------------------------------------------------------------------------
 # run() — integration


### PR DESCRIPTION
## Summary

`Get-Tpm`'s `ManufacturerVersion` can carry trailing NUL bytes from the firmware WMI string, which leaked verbatim into the report details line (`TPM present. Ready: True. Firmware version: 7.2.3.1␀␀.`). First noticed while sanitizing the v0.1.10 site demo report.

- Strip NUL bytes (and surrounding whitespace) before formatting; fall back to `Unknown` when nothing printable remains. Note the fallback now fires for all-NUL strings too — `"\x00"` is truthy, so the old `or "Unknown"` never caught it.
- No status/scoring change; output sanitization only.

## Tests

- `test_version_nul_bytes_stripped` — `"7.2.3.1\x00\x00"` renders clean, no NULs in details
- `test_version_all_nul_bytes_falls_back_to_unknown` — all-NUL string falls back to `Unknown`
- Full suite: **787 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)