### PR TITLE
docs: clarify pip vs release-exe integrity channels (pre-HN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ expect a SmartScreen warning on first run). PyInstaller-packaged executables
 also sometimes trip antivirus machine-learning heuristics, so a few generic
 detections on VirusTotal are expected for this class of binary; if your AV
 quarantines the exe, `pip install apotrope` is the alternative channel.
-Instead of asking you to trust a bare binary, releases are verifiable two ways.
+Instead of asking you to trust a bare binary, the downloaded exe is verifiable
+two ways — both steps below operate on `apotrope.exe`, so they apply to the
+GitHub release only, not to a `pip install`.
 
 **1. Verify build provenance** — releases **from v0.1.10 onward** are built on
 GitHub-hosted CI and attested at build time. Requires the
@@ -128,7 +130,9 @@ step catches download corruption and tampered mirrors — not a compromised
 repository. Step 1 is the authenticity check; this is the quick integrity
 check.
 
-**Prefer not to run a downloaded exe at all?** `pip install apotrope` gets the
+**Installed with `pip`, or prefer not to run a downloaded exe at all?** Then
+there's no `apotrope.exe` on disk to hash or attest — the two steps above don't
+apply to you. `pip install apotrope` gets the
 same tool from PyPI, where every release is published straight from CI via
 [trusted publishing](https://docs.pypi.org/trusted-publishers/) (OpenID
 Connect, no long-lived tokens) with [PEP 740](https://peps.python.org/pep-0740/)

--- a/docs/index.html
+++ b/docs/index.html
@@ -561,6 +561,7 @@
           <div>
             <h3>Download the executable</h3>
             <p>Grab <span class="mono">apotrope.exe</span> from the <a href="https://github.com/hexorcist404/apotrope/releases/latest">latest release</a> and save it somewhere easy to find — Desktop or Downloads works fine.</p>
+            <p style="margin-top:8px">Want to verify it first? See <a href="https://github.com/hexorcist404/apotrope#verify-your-download">Verify Your Download</a> — SHA-256 plus CI build provenance. Installing with <span class="mono">pip</span> instead? There's no exe to hash; your integrity comes from <a href="https://pypi.org/project/apotrope/">PyPI</a> (PEP 740 attestations).</p>
           </div>
         </div>
         <div class="step" data-reveal>


### PR DESCRIPTION
## What & why

The pre-HN pip-channel verification (handoff #4) surfaced a docs gap: the README **Verify Your Download** steps (SHA256SUMS + `gh attestation verify`) read generically, so a `pip install` user can try to `Get-FileHash apotrope.exe` — a file the pip channel never ships — and hit a confusing "file not found." A new user could easily repeat that mistake.

Smallest diff to make the channel distinction explicit:

- **README** — scope the two verify steps to the release `.exe`, and reframe the pip paragraph from an "escape hatch" into an explicit second channel: no `apotrope.exe` to hash; integrity is PyPI trusted-publishing + PEP 740.
- **docs/index.html** — the public download page had zero verify guidance; added one line pointing exe users to Verify Your Download and telling pip users their integrity comes from PyPI/PEP 740.

Docs-only. No code, check, or scoring changes.

## Verification pass (all green)

Fresh Windows / Python 3.14 venv against live PyPI **0.1.10**:

- `pip install apotrope` → 0.1.10 + deps
- launcher `Scripts\apotrope.exe` resolves & runs; `apotrope --version` → `apotrope 0.1.10`
- `apotrope --dry-run` → 14 modules (matches source baseline)
- full audit `apotrope --html … --json … --verbose` completes (both reports written); **53 checks / 14 areas**
- wheel contains all 14 check modules + `templates/report.html.j2`
- current source (→ v0.1.11) carries the PR #77 report UI (working expand/collapse + clickable counters); published 0.1.10 does **not**, so the post-publish re-check is meaningful

Should merge before the v0.1.11 tag so the wording ships in the release snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
