### PR TITLE
fix(compare): errored checks reported as indeterminate, not resolved (+ launch copy polish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **Baseline comparison no longer reports errored checks as resolved.** A check that was
+  FAIL/WARN in the baseline but could not be evaluated in the current scan (status ERROR)
+  was miscounted as remediated. Such checks now appear in a dedicated "Errored (could not
+  evaluate)" category — indeterminate, never resolved — mirroring how checks that drop out
+  of coverage are already handled.
+
 ## [0.1.11] - 2026-07-06
 
 ### Added

--- a/docs/index.html
+++ b/docs/index.html
@@ -59,7 +59,7 @@
     "@type": "FAQPage",
     "mainEntity": [
       { "@type": "Question", "name": "Does Apotrope send any data off the machine?", "acceptedAnswer": { "@type": "Answer", "text": "No. Apotrope is fully offline and read-only. It makes no network connections and has no telemetry." } },
-      { "@type": "Question", "name": "Does Apotrope change my system?", "acceptedAnswer": { "@type": "Answer", "text": "No. It is read-only. It queries configuration and does not modify settings, the registry, or files." } },
+      { "@type": "Question", "name": "Does Apotrope change my system?", "acceptedAnswer": { "@type": "Answer", "text": "No. It is read-only. It reads configuration to evaluate it and does not change your settings, the registry, or files. One check exports the current security policy to a temporary file that it reads and deletes immediately; nothing on your system is modified." } },
       { "@type": "Question", "name": "Which CIS Benchmark versions does it use?", "acceptedAnswer": { "@type": "Answer", "text": "CIS Microsoft Windows 11 Enterprise Benchmark v5.0.0 and Windows 10 v4.0.0, selected automatically from the OS build." } },
       { "@type": "Question", "name": "Is Apotrope free?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. Free and open source under the MIT license. No account or key." } },
       { "@type": "Question", "name": "Do I need Python?", "acceptedAnswer": { "@type": "Answer", "text": "No. The standalone apotrope.exe needs no Python. You can also install via pip on Python 3.12+." } }
@@ -634,7 +634,7 @@
         </details>
         <details class="faq-item">
           <summary>Does Apotrope change my system?</summary>
-          <p>No. It is read-only. It queries configuration and does not modify settings, the registry, or files.</p>
+          <p>No. It is read-only. It reads configuration to evaluate it and does not change your settings, the registry, or files. One check exports the current security policy to a temporary file that it reads and deletes immediately; nothing on your system is modified.</p>
         </details>
         <details class="faq-item">
           <summary>Which CIS Benchmark versions does it use?</summary>
@@ -666,7 +666,7 @@
           · <a href="/vs-cis-cat/">vs CIS-CAT Lite</a>
           · <a href="/vs-harden-windows-security/">vs Harden Windows Security</a>
         </div>
-        <div class="foot-auth">For authorized security assessment use only · <span class="nodata">No data left this machine</span></div>
+        <div class="foot-auth">For authorized security assessment use only · <span class="nodata">No data leaves this machine</span></div>
       </div>
       <div>◈ apotrope.sh</div>
     </div>

--- a/docs/report.html
+++ b/docs/report.html
@@ -2099,7 +2099,7 @@ secedit /export /cfg &#34;$env:TEMP\secpol.cfg&#34; | Out-Null; Select-String -P
 
     <!-- ── Footer ──────────────────────────────────────────────────────── -->
     <div class="foot">
-      <span class="auth">For authorized security assessment use only · <strong style="color:var(--green);font-weight:600;text-shadow:0 0 9px rgba(43,255,136,0.45)">No data left this machine</strong> · CIS Benchmark v5.0.0</span>
+      <span class="auth">For authorized security assessment use only · <strong style="color:var(--green);font-weight:600;text-shadow:0 0 9px rgba(43,255,136,0.45)">No data leaves this machine</strong> · CIS Benchmark v5.0.0</span>
       <span>apotrope.sh · <a href="https://github.com/hexorcist404/apotrope">github.com/hexorcist404/apotrope</a> · MIT</span>
       <span class="share-warn">⚠ This report contains this machine's hostname, account names, services, and configuration. Review and redact before sharing it outside your organization.</span>
     </div>

--- a/src/apotrope/compare.py
+++ b/src/apotrope/compare.py
@@ -23,10 +23,12 @@ from apotrope.models import AuditReport, CheckResult, Severity, Status
 
 log = logging.getLogger(__name__)
 
-# Statuses considered "bad" (contribute negatively)
+# Statuses considered "bad" — an active finding the user should act on.
 _BAD = {Status.FAIL, Status.WARN}
-# Statuses considered "good" (neutral or positive)
-_GOOD = {Status.PASS, Status.INFO, Status.ERROR}
+# ERROR means the check could not be evaluated: indeterminate, never "good".
+# Bucketed separately so a check that stops evaluating is never mistaken for a
+# remediated one — the same honesty principle as ``missing_findings``.
+_INDETERMINATE = {Status.ERROR}
 
 
 @dataclasses.dataclass
@@ -45,6 +47,10 @@ class ScanDiff:
                            a disabled/admin-gated check, an import failure, or a rename)
                            — NOT proof of remediation. Tracked separately so a reduced
                            scan is never mistaken for fixed risk.
+        errored_findings:  Checks that were FAIL/WARN in baseline but ERRORed in the
+                           current scan (present, but could not be evaluated). Like
+                           missing_findings this is indeterminate — never counted as
+                           resolved, because an unevaluable check is not a fixed one.
         worsened_findings: Checks that were PASS/INFO in baseline but are now FAIL/WARN.
         unchanged_bad:     Checks that were FAIL/WARN in both scans.
         unchanged_count:   Total number of checks with the same status in both scans.
@@ -59,6 +65,7 @@ class ScanDiff:
     unchanged_bad: list[CheckResult]
     unchanged_count: int
     missing_findings: list[CheckResult] = dataclasses.field(default_factory=list)
+    errored_findings: list[CheckResult] = dataclasses.field(default_factory=list)
 
 
 def compare_reports(baseline: AuditReport, current: AuditReport) -> ScanDiff:
@@ -83,6 +90,7 @@ def compare_reports(baseline: AuditReport, current: AuditReport) -> ScanDiff:
     new_findings: list[CheckResult] = []
     resolved_findings: list[CheckResult] = []
     missing_findings: list[CheckResult] = []
+    errored_findings: list[CheckResult] = []
     worsened_findings: list[CheckResult] = []
     unchanged_bad: list[CheckResult] = []
     unchanged_count = 0
@@ -110,8 +118,14 @@ def compare_reports(baseline: AuditReport, current: AuditReport) -> ScanDiff:
             assert b is not None and c is not None
             b_bad = b.status in _BAD
             c_bad = c.status in _BAD
+            c_indeterminate = c.status in _INDETERMINATE
 
-            if b_bad and not c_bad:
+            if b_bad and c_indeterminate:
+                # Was a finding, now unevaluable: cannot confirm remediation.
+                # Must be intercepted before the resolved branch, since ERROR
+                # is not in _BAD and would otherwise read as "no longer bad".
+                errored_findings.append(c)
+            elif b_bad and not c_bad:
                 resolved_findings.append(c)
             elif not b_bad and c_bad:
                 worsened_findings.append(c)
@@ -129,6 +143,7 @@ def compare_reports(baseline: AuditReport, current: AuditReport) -> ScanDiff:
         new_findings=new_findings,
         resolved_findings=resolved_findings,
         missing_findings=missing_findings,
+        errored_findings=errored_findings,
         worsened_findings=worsened_findings,
         unchanged_bad=unchanged_bad,
         unchanged_count=unchanged_count,

--- a/src/apotrope/reporter.py
+++ b/src/apotrope/reporter.py
@@ -459,6 +459,7 @@ class Reporter:
         sections: list[tuple[str, str, list]] = [
             ("green",   "Resolved", diff.resolved_findings),
             ("magenta", "Not scanned (coverage lost)", diff.missing_findings),
+            (_MUTED,    "Errored (could not evaluate)", diff.errored_findings),
             ("red",     "New",      diff.new_findings),
             ("yellow",  "Worsened", diff.worsened_findings),
             ("yellow",  "Ongoing",  diff.unchanged_bad),
@@ -486,6 +487,7 @@ class Reporter:
         console.print(
             f"  Resolved: {len(diff.resolved_findings)}  |  "
             f"Not scanned: {len(diff.missing_findings)}  |  "
+            f"Errored: {len(diff.errored_findings)}  |  "
             f"New: {len(diff.new_findings)}  |  "
             f"Worsened: {len(diff.worsened_findings)}  |  "
             f"Unchanged: {diff.unchanged_count}"

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -141,6 +141,49 @@ class TestCompareReports:
 
 
 # ---------------------------------------------------------------------------
+# Errored checks: an ERROR in the current scan means "could not evaluate",
+# which is indeterminate — never proof of remediation.
+# ---------------------------------------------------------------------------
+
+class TestErroredChecks:
+    def test_fail_to_error_is_errored_not_resolved(self):
+        """A FAIL check that ERRORs in the current scan cannot be confirmed
+        remediated. It must be reported as errored, never resolved."""
+        baseline = _make_report([_make_result("Complexity", Status.FAIL)])
+        current  = _make_report([_make_result("Complexity", Status.ERROR)])
+        diff = compare_reports(baseline, current)
+        assert diff.resolved_findings == []
+        assert len(diff.errored_findings) == 1
+        assert diff.errored_findings[0].check_name == "Complexity"
+
+    def test_warn_to_error_is_errored_not_resolved(self):
+        baseline = _make_report([_make_result("Signature Age", Status.WARN)])
+        current  = _make_report([_make_result("Signature Age", Status.ERROR)])
+        diff = compare_reports(baseline, current)
+        assert diff.resolved_findings == []
+        assert len(diff.errored_findings) == 1
+
+    def test_error_to_pass_is_not_falsely_resolved(self):
+        """A check that was ERROR in baseline and PASSes now was never a known
+        finding — there is nothing to credit as resolved."""
+        baseline = _make_report([_make_result("X", Status.ERROR)])
+        current  = _make_report([_make_result("X", Status.PASS)])
+        diff = compare_reports(baseline, current)
+        assert diff.resolved_findings == []
+        assert diff.errored_findings == []
+        assert diff.unchanged_count == 1
+
+    def test_error_in_both_scans_is_not_a_finding(self):
+        """ERROR → ERROR is unchanged indeterminacy, not a resolved/new finding."""
+        baseline = _make_report([_make_result("Y", Status.ERROR)])
+        current  = _make_report([_make_result("Y", Status.ERROR)])
+        diff = compare_reports(baseline, current)
+        assert diff.resolved_findings == []
+        assert diff.errored_findings == []
+        assert diff.new_findings == []
+
+
+# ---------------------------------------------------------------------------
 # save_baseline / load_baseline
 # ---------------------------------------------------------------------------
 

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -152,7 +152,9 @@ class TestGenerateHtmlReport:
         """Per finding row: (status, header marked open, body hidden)."""
         rows = []
         for chunk in html.split('<div class="frow" ')[1:]:
-            status = re.search(r'data-status="(\w+)"', chunk).group(1)
+            status_match = re.search(r'data-status="(\w+)"', chunk)
+            assert status_match is not None
+            status = status_match.group(1)
             is_open = 'class="fhead is-open"' in chunk
             body_hidden = re.search(r'<div class="fbody"[^>]*\shidden', chunk) is not None
             rows.append((status, is_open, body_hidden))


### PR DESCRIPTION
## Summary

Post-v0.1.11 code review (Codex) surfaced a correctness bug in baseline comparison plus a few doc/copy nits. This PR fixes the code bug and the site copy. The wiki doc fixes are pushed separately (wiki has no PR mechanism).

### P1 — compare: errored checks miscounted as resolved (bug)

A check that was `FAIL`/`WARN` in the baseline but `ERROR`ed (couldn't be evaluated) in the current scan was reported as **resolved** — because `ERROR` isn't in `_BAD`, so `not c_bad` read as "no longer bad". That told users they'd remediated a control when the check merely failed to run.

**Fix:** a current-scan `ERROR` is now intercepted before the resolved branch and placed in a new **`errored_findings`** bucket, rendered as **"Errored (could not evaluate)"** in the terminal diff — indeterminate, never resolved. This mirrors the existing `missing_findings` ("coverage lost") philosophy. The dead, misleading `_GOOD` set (which *included* `ERROR`) was removed.

### Docs / copy (launch polish)

- **"Does Apotrope change my system?"** now discloses the single password-policy check that exports current policy to a temp file it reads and immediately deletes — pre-empts a procmon "gotcha" while keeping the read-only claim honest.
- Footer **"No data left this machine" → "No data leaves this machine"** (index.html + report.html).

### Housekeeping

- Fixed a mypy failure (`re.search(...).group(1)` on an `Optional` match) in `test_reporter.py`.
- CHANGELOG `[Unreleased]` entry for the compare fix.

## Testing

- `pytest`: **791 passed** (was 787; +4 regression tests: FAIL→ERROR, WARN→ERROR, ERROR→PASS, ERROR→ERROR)
- `ruff check .`: clean
- `mypy src tests`: **now succeeds** (previously failed on the test above)
- Rendered the compare output end-to-end: `FAIL→ERROR` → *Errored*, `FAIL→PASS` → *Resolved*


🤖 Generated with [Claude Code](https://claude.com/claude-code)