### PR TITLE
feat(report): executive report — Security Posture Assessment (--exec-report)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Executive report (`--exec-report FILE`) — the Security Posture Assessment.** A
+  plain-English, print-first HTML document for non-technical decision makers: cover
+  with grade box and generated verdict, executive-summary narrative built strictly
+  from scan data, posture-at-a-glance tiles and result distribution, a P1/P2/P3
+  prioritized remediation roadmap, detailed findings with per-category business-impact
+  context, a passed-controls attestation appendix, and a remediation-commands appendix.
+  Self-contained, script-free, letter-size print CSS (editorial serif direction from
+  the design system). When `--html` and `--exec-report` are generated in the same run,
+  the technical report's header links to the executive report ("Executive Report ↗").
 - **`brand/tokens.json` — single source of truth for the brand palette.** Codifies the
   two canonical layers from the design system (the `mark` — cyan/mint/ember on void
   ground `#0B0D0E` — and the `product` CRT/status palette) with the rules that travel

--- a/README.md
+++ b/README.md
@@ -203,8 +203,8 @@ to that subprocess and does not change the machine's policy setting.
 
 ### Sharing reports safely
 
-Generated reports (`--html` / `--json`) are written **only to your machine** — Apotrope
-never uploads them. But because a report's job is to inventory your security posture, it
+Generated reports (`--html` / `--exec-report` / `--json`) are written **only to your
+machine** — Apotrope never uploads them. But because a report's job is to inventory your security posture, it
 embeds machine-identifying and configuration detail: hostname, domain/workgroup, local
 administrator account names, listening ports and the processes behind them, service
 executable paths, and startup/scheduled-task names. Treat a saved report like any other
@@ -221,6 +221,8 @@ apotrope [OPTIONS]
 
 Options:
   --html PATH          Save a self-contained HTML report to PATH
+  --exec-report PATH   Save a plain-English executive report (Security Posture
+                       Assessment) to PATH — print-first, for decision makers
   --json PATH          Save a JSON report to PATH
   --baseline FILE      Save current scan as a JSON baseline for future comparisons
   --compare  FILE      Compare current scan against a saved baseline
@@ -248,6 +250,10 @@ apotrope
 
 # Save HTML report
 apotrope --html report.html
+
+# Technical report + plain-English executive report (the technical report's
+# header links to the executive one when both are generated together)
+apotrope --html report.html --exec-report assessment.html
 
 # Save JSON for automation / SIEM integration
 apotrope --json report.json

--- a/src/apotrope/cli.py
+++ b/src/apotrope/cli.py
@@ -27,6 +27,8 @@ def build_parser() -> argparse.ArgumentParser:
             "Examples:\n"
             "  apotrope                             Full audit, terminal output\n"
             "  apotrope --html report.html          Also save HTML report\n"
+            "  apotrope --html r.html --exec-report brief.html\n"
+            "                                       Technical + executive reports\n"
             "  apotrope --json report.json          Also save JSON report\n"
             "  apotrope --baseline b.json           Save scan as a baseline\n"
             "  apotrope --compare  b.json           Compare scan against baseline\n"
@@ -49,6 +51,14 @@ def build_parser() -> argparse.ArgumentParser:
         "--html",
         metavar="FILE",
         help="Save an HTML report to FILE",
+    )
+    parser.add_argument(
+        "--exec-report",
+        metavar="FILE",
+        help=(
+            "Save a plain-English executive report "
+            "(Security Posture Assessment) to FILE"
+        ),
     )
     parser.add_argument(
         "--json",
@@ -108,6 +118,27 @@ def build_parser() -> argparse.ArgumentParser:
         help="Internal logging verbosity (default: WARNING)",
     )
     return parser
+
+
+def _exec_href(html_path: str, exec_path: str) -> str:
+    """Href from the technical report to the executive report.
+
+    Relative when both live on the same drive (portable — the pair can be
+    moved or shared together); a ``file://`` URI when a Windows cross-drive
+    relpath is impossible. Percent-encoded either way.
+    """
+    import os
+    import urllib.parse
+    from pathlib import Path
+
+    try:
+        rel = os.path.relpath(
+            os.path.abspath(exec_path),
+            os.path.dirname(os.path.abspath(html_path)) or ".",
+        )
+    except ValueError:  # different drives on Windows
+        return Path(exec_path).resolve().as_uri()
+    return urllib.parse.quote(rel.replace(os.sep, "/"), safe="/")
 
 
 def main() -> None:
@@ -175,9 +206,19 @@ def main() -> None:
         print(f"\n[FATAL] Scan could not complete: {exc}", file=sys.stderr)
         sys.exit(2)
 
-    # Save outputs
+    # Save outputs. The executive report is generated first so the technical
+    # report's header link is only rendered once the target actually exists
+    # (generation is a no-op when Jinja2 or the template is unavailable).
+    if args.exec_report:
+        reporter.generate_executive_report(report, args.exec_report)
+
     if args.html:
-        reporter.generate_html_report(report, args.html)
+        exec_href = None
+        if args.exec_report:
+            from pathlib import Path
+            if Path(args.exec_report).exists():
+                exec_href = _exec_href(args.html, args.exec_report)
+        reporter.generate_html_report(report, args.html, exec_href=exec_href)
 
     if args.json:
         reporter.generate_json_report(report, args.json)
@@ -187,7 +228,8 @@ def main() -> None:
         save_baseline(report, args.baseline)
 
     # Terminal output
-    reporter.print_terminal(report, html_path=args.html, json_path=args.json)
+    reporter.print_terminal(report, html_path=args.html, json_path=args.json,
+                            exec_path=args.exec_report)
 
     # Comparison diff display
     if baseline is not None:

--- a/src/apotrope/reporter.py
+++ b/src/apotrope/reporter.py
@@ -16,6 +16,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
+    from markupsafe import Markup
+
     from apotrope.scanner import Scanner
 
 from apotrope import __version__
@@ -123,6 +125,112 @@ _HTML_SEVERITY: dict[Severity, str] = {
     Severity.LOW:      _CYAN,
     Severity.INFO:     _MUTED,
 }
+
+# ── Executive report (Security Posture Assessment) presentation config ────────
+# Curated plain-English "business impact" copy for the executive report's
+# finding cards, keyed by the canonical CATEGORY strings the check modules use.
+# These are category-level statements about why the control area matters — the
+# scan-derived specifics live in the finding's `details`, never here.
+
+_EXEC_IMPACT: dict[str, str] = {
+    "Accounts": (
+        "Weak account and password settings make it easier for an attacker to "
+        "guess or reuse credentials and take control of this machine."
+    ),
+    "Antivirus": (
+        "Gaps in malware protection mean malicious software can run, spread, "
+        "or persist without being detected or blocked."
+    ),
+    "Encryption": (
+        "If this device is lost or stolen, data on an unencrypted or "
+        "unprotected drive can be read by anyone with physical access."
+    ),
+    "Firewall": (
+        "Without firewall protection the machine accepts unsolicited network "
+        "traffic, exposing its services directly to attackers on the same "
+        "network."
+    ),
+    "Hardening": (
+        "Convenience features left enabled give attackers well-known shortcuts "
+        "to run code or gather information on this machine."
+    ),
+    "Network": (
+        "Insecure network protocols allow attackers on the local network to "
+        "intercept traffic or impersonate services this machine trusts."
+    ),
+    "System": (
+        "Platform integrity features protect the machine before Windows even "
+        "starts; gaps here undermine every other control."
+    ),
+    "PowerShell": (
+        "Loose PowerShell controls let malicious scripts run unrestricted and "
+        "leave little forensic record of what they did."
+    ),
+    "Remote Access": (
+        "Weak remote-access settings can let an attacker sign in to this "
+        "machine from elsewhere on the network or the internet."
+    ),
+    "Services": (
+        "Unnecessary or misconfigured services widen the attack surface and "
+        "can be abused to gain or escalate access."
+    ),
+    "File Sharing": (
+        "Legacy or unsigned file-sharing protocols are a primary path for "
+        "ransomware and lateral movement between machines."
+    ),
+    "Persistence": (
+        "Unreviewed startup entries and scheduled tasks are how malware "
+        "survives a reboot and keeps running unnoticed."
+    ),
+    "Access Control": (
+        "Weakened elevation prompts let software make administrator-level "
+        "changes without a person approving them."
+    ),
+    "Patching": (
+        "Missing updates leave publicly known vulnerabilities open — the most "
+        "common way machines are compromised."
+    ),
+}
+
+_EXEC_IMPACT_FALLBACK = (
+    "This finding weakens the machine's overall security posture and "
+    "increases the likelihood or impact of a compromise."
+)
+
+
+def _impact_for(category: str) -> str:
+    """Plain-English impact statement for a check category (with fallback)."""
+    return _EXEC_IMPACT.get(category, _EXEC_IMPACT_FALLBACK)
+
+
+# Remediation roadmap tiers: (key, label, time window). Assignment is by
+# severity of the open (FAIL/WARN) finding: CRITICAL/HIGH → P1, MEDIUM → P2,
+# everything else → P3.
+_EXEC_TIERS: tuple[tuple[str, str, str], ...] = (
+    ("P1", "Immediate",        "This week"),
+    ("P2", "Near-term",        "This maintenance cycle"),
+    ("P3", "Review & hygiene", "Next review"),
+)
+
+
+def _tier_index(r: CheckResult) -> int:
+    """Roadmap tier (0-based index into _EXEC_TIERS) for an open finding."""
+    if r.severity in (Severity.CRITICAL, Severity.HIGH):
+        return 0
+    if r.severity is Severity.MEDIUM:
+        return 1
+    return 2
+
+
+# Severity → CSS chip class in the executive report (light theme).
+_EXEC_SEV_CLASS: dict[Severity, str] = {
+    Severity.CRITICAL: "crit",
+    Severity.HIGH:     "high",
+    Severity.MEDIUM:   "med",
+    Severity.LOW:      "low",
+    Severity.INFO:     "info",
+}
+
 
 def _cis_version_for(report: AuditReport) -> str:
     """CIS Benchmark edition to display for *report*.
@@ -320,6 +428,7 @@ class Reporter:
         report: AuditReport,
         html_path: str | None = None,
         json_path: str | None = None,
+        exec_path: str | None = None,
     ) -> None:
         """Print the completed audit report to the terminal.
 
@@ -327,6 +436,7 @@ class Reporter:
             report:    Completed :class:`~apotrope.models.AuditReport`.
             html_path: If set, shown in footer as the saved HTML path.
             json_path: If set, shown in footer as the saved JSON path.
+            exec_path: If set, shown in footer as the saved executive report.
         """
         try:
             from rich.console import Console  # noqa: F401 – ensure Rich is present
@@ -348,14 +458,35 @@ class Reporter:
         else:
             self._print_category_boxes(console, report,
                                        only_issues=not self.verbose)
-        self._print_footer(console, report, html_path, json_path)
+        self._print_footer(console, report, html_path, json_path, exec_path)
 
-    def generate_html_report(self, report: AuditReport, path: str) -> None:
+    @staticmethod
+    def _resolve_template_dir() -> Path:
+        """Directory holding the Jinja2 templates (frozen-bundle aware)."""
+        import sys
+        if getattr(sys, "frozen", False):
+            # Running inside a PyInstaller one-file bundle; templates were
+            # added with --add-data "...;templates" so they extract to
+            # sys._MEIPASS/templates/
+            return Path(sys._MEIPASS) / "templates"  # type: ignore[attr-defined]
+        # Templates ship as package data inside apotrope/templates/, so the
+        # directory sits next to this module for both editable and installed
+        # (pip / PyPI) installs.
+        return Path(__file__).parent / "templates"
+
+    def generate_html_report(
+        self,
+        report: AuditReport,
+        path: str,
+        exec_href: str | None = None,
+    ) -> None:
         """Render and save a self-contained HTML report via the Jinja2 template.
 
         Args:
-            report: Completed :class:`~apotrope.models.AuditReport`.
-            path:   Destination file path for the HTML file.
+            report:    Completed :class:`~apotrope.models.AuditReport`.
+            path:      Destination file path for the HTML file.
+            exec_href: Optional href to a co-generated executive report; when
+                       set, the header renders an "Executive Report ↗" link.
         """
         try:
             from jinja2 import Environment, FileSystemLoader
@@ -363,17 +494,7 @@ class Reporter:
             log.error("Jinja2 not installed — cannot generate HTML report")
             return
 
-        import sys
-        if getattr(sys, "frozen", False):
-            # Running inside a PyInstaller one-file bundle; templates were
-            # added with --add-data "...;templates" so they extract to
-            # sys._MEIPASS/templates/
-            template_dir = Path(sys._MEIPASS) / "templates"  # type: ignore[attr-defined]
-        else:
-            # Templates ship as package data inside apotrope/templates/, so the
-            # directory sits next to this module for both editable and installed
-            # (pip / PyPI) installs.
-            template_dir = Path(__file__).parent / "templates"
+        template_dir = self._resolve_template_dir()
         env = Environment(
             loader=FileSystemLoader(str(template_dir)),
             autoescape=True,  # Always escape — the template is always HTML.
@@ -388,9 +509,45 @@ class Reporter:
 
         ctx = self._build_template_context(report)
         ctx["logo_data_uri"] = self._encode_logo_data_uri(template_dir)
+        ctx["exec_href"] = exec_href
         html = template.render(**ctx)
         Path(path).write_text(html, encoding="utf-8")
         log.info("HTML report saved to %s", path)
+
+    def generate_executive_report(self, report: AuditReport, path: str) -> None:
+        """Render and save the executive report (Security Posture Assessment).
+
+        A plain-English, print-first HTML document for non-technical decision
+        makers: generated narrative, prioritized remediation roadmap, detailed
+        findings with business impact, a passed-controls attestation, and a
+        remediation-commands appendix. Self-contained and script-free.
+
+        Args:
+            report: Completed :class:`~apotrope.models.AuditReport`.
+            path:   Destination file path for the HTML file.
+        """
+        try:
+            from jinja2 import Environment, FileSystemLoader
+        except ImportError:
+            log.error("Jinja2 not installed — cannot generate executive report")
+            return
+
+        template_dir = self._resolve_template_dir()
+        env = Environment(
+            loader=FileSystemLoader(str(template_dir)),
+            autoescape=True,  # Always escape — the template is always HTML.
+        )
+        try:
+            template = env.get_template("exec_report.html.j2")
+        except Exception as exc:
+            log.error("Could not load executive report template: %s", exc)
+            return
+
+        ctx = self._build_exec_template_context(report)
+        ctx["logo_data_uri"] = self._encode_logo_data_uri(template_dir)
+        html = template.render(**ctx)
+        Path(path).write_text(html, encoding="utf-8")
+        log.info("Executive report saved to %s", path)
 
     @staticmethod
     def _encode_logo_data_uri(template_dir: Path) -> str | None:
@@ -860,6 +1017,410 @@ class Reporter:
 
         return Markup(" ".join(parts))
 
+    # ── Executive report (Security Posture Assessment) ───────────────────────
+
+    @staticmethod
+    def _exec_open_sorted(report: AuditReport) -> list[CheckResult]:
+        """Open (FAIL/WARN) findings in roadmap order.
+
+        Tier (P1→P3), then FAIL before WARN, then severity, then
+        (category, check_name) so output is deterministic.
+        """
+        open_findings = [
+            r for r in report.results if r.status in (Status.FAIL, Status.WARN)
+        ]
+        open_findings.sort(key=lambda r: (
+            _tier_index(r),
+            0 if r.status == Status.FAIL else 1,
+            _SEV_ORDER.get(r.severity, 5),
+            r.category,
+            r.check_name,
+        ))
+        return open_findings
+
+    def _build_exec_template_context(self, report: AuditReport) -> dict:
+        """Template variable dict for the executive report.
+
+        Reuses the technical report's context (counts, grade, categories,
+        CIS version, formatted timestamp) and layers on the executive
+        document's generated narrative and section data.
+        """
+        ctx = self._build_template_context(report)
+
+        open_findings = self._exec_open_sorted(report)
+        p_counts = [0, 0, 0]
+        for r in open_findings:
+            p_counts[_tier_index(r)] += 1
+
+        ts = report.scan_timestamp
+        ctx.update({
+            "assessment_date":  f"{ts.day} {ts.strftime('%B %Y')}",
+            "assessment_mode":  "Read-only · non-invasive",
+            "privilege_level":  "Administrator" if report.is_admin
+                                else "Standard user",
+            "deck":             self._build_exec_deck(report),
+            "verdict":          self._build_exec_verdict(report),
+            "lede":             self._build_exec_lede(report),
+            "exec_paragraphs":  self._build_exec_paragraphs(report),
+            "bottom_line":      self._build_exec_bottom_line(report),
+            "p1_count":         p_counts[0],
+            "p2_count":         p_counts[1],
+            "p3_count":         p_counts[2],
+            "dist_segments":    self._build_distribution(report),
+            "tiers":            self._build_exec_tiers(report),
+            "findings_cards":   self._build_exec_findings_cards(report),
+            "attestation_groups": self._build_attestation_groups(report),
+            "commands":         self._build_exec_commands(report),
+            "scoring_note": (
+                "Scores start at 100 and deduct weighted points per finding: "
+                "failed controls deduct 15, 10, 5, or 2 points for critical, "
+                "high, medium, or low severity respectively; warnings deduct "
+                "7, 5, 2, or 1. Informational items and checks that could not "
+                "be evaluated do not affect the score."
+            ),
+        })
+        return ctx
+
+    def _build_exec_deck(self, report: AuditReport) -> "Markup":
+        """Cover deck sentence (escaped scan data, our markup)."""
+        from markupsafe import Markup, escape
+
+        host  = escape(report.hostname)
+        total = len(report.results)
+        open_n = report.fail_count + report.warn_count
+        tail = (
+            "with a prioritized plan for remediation." if open_n
+            else "in which all evaluated controls passed."
+        )
+        return Markup(
+            f"An independent, read-only evaluation of endpoint <b>{host}</b> "
+            f"against {total} security controls aligned to the CIS Microsoft "
+            f"Windows Benchmarks, {tail}"
+        )
+
+    def _build_exec_verdict(self, report: AuditReport) -> str:
+        """One-sentence gradebox verdict (plain text, counts only)."""
+        total  = len(report.results)
+        open_n = report.fail_count + report.warn_count
+        p1 = sum(
+            1 for r in report.results
+            if r.status in (Status.FAIL, Status.WARN)
+            and r.severity in (Severity.CRITICAL, Severity.HIGH)
+        )
+
+        if total == 0:
+            return "No controls could be evaluated in this assessment."
+        if open_n == 0 and report.error_count == 0:
+            return (f"All {total} evaluated controls passed; no corrective "
+                    "action is required at this time.")
+        if open_n == 0:
+            e = report.error_count
+            return (f"All evaluated controls passed; {e} "
+                    f"control{'s' if e != 1 else ''} could not be evaluated.")
+        if p1:
+            rest = open_n - p1
+            head = (f"{p1} high-priority finding{'s' if p1 != 1 else ''} "
+                    "should be addressed this week")
+            if rest:
+                return (f"{head}; {rest} further "
+                        f"item{'s' if rest != 1 else ''} can be scheduled "
+                        "into routine maintenance.")
+            return f"{head}."
+        if report.score >= 90:
+            return (f"Overall posture is strong; the {open_n} open "
+                    f"item{'s' if open_n != 1 else ''} below are low-impact "
+                    "refinements.")
+        if report.score >= 80:
+            return (f"Overall posture is good, with {open_n} open "
+                    f"item{'s' if open_n != 1 else ''} to fold into routine "
+                    "maintenance.")
+        if report.score >= 70:
+            return ("Overall posture is fair; a focused round of remediation "
+                    "is recommended.")
+        if report.score >= 60:
+            return ("Overall posture is below standard; remediation should "
+                    "begin promptly.")
+        return "Overall posture requires prompt attention."
+
+    def _build_exec_lede(self, report: AuditReport) -> "Markup":
+        """§1 lede sentence (escaped scan data, our markup)."""
+        from markupsafe import Markup, escape
+
+        letter, label = score_grade(report.score)
+        host   = escape(report.hostname)
+        open_n = report.fail_count + report.warn_count
+        cats   = len({r.category for r in report.results
+                      if r.status in (Status.FAIL, Status.WARN)})
+
+        lede = (f"<b>{host}</b> scored <b>{report.score} out of 100</b> — "
+                f"“{label}” ({letter}) on Apotrope's A–F scale.")
+        if open_n:
+            lede += (f" {open_n} finding{'s are' if open_n != 1 else ' is'} "
+                     f"open for remediation across "
+                     f"{cats} area{'s' if cats != 1 else ''}.")
+        return Markup(lede)
+
+    def _build_exec_paragraphs(self, report: AuditReport) -> "list[Markup]":
+        """§1 executive-summary paragraphs (2–4, strictly data-derived)."""
+        from collections import Counter
+
+        from markupsafe import Markup, escape
+
+        letter, label = score_grade(report.score)
+        total  = len(report.results)
+        host   = escape(report.hostname)
+        os_v   = escape(report.os_version)
+        open_findings = [
+            r for r in report.results if r.status in (Status.FAIL, Status.WARN)
+        ]
+        p1 = [r for r in open_findings
+              if r.severity in (Severity.CRITICAL, Severity.HIGH)]
+        paragraphs: list[Markup] = []
+
+        # P1 — scope (always present).
+        ts = report.scan_timestamp
+        date_str = f"{ts.day} {ts.strftime('%B %Y')}"
+        priv = (
+            "with administrator privileges"
+            if report.is_admin
+            else "without administrator privileges, so some checks that "
+                 "require elevation were skipped"
+        )
+        scope = (
+            f"On {date_str}, Apotrope evaluated {total} security "
+            f"control{'s' if total != 1 else ''} on <b>{host}</b> ({os_v}) "
+            f"against thresholds aligned to the CIS Microsoft Windows "
+            f"Benchmark {escape(_cis_version_for(report))}. The assessment "
+            f"ran in read-only mode {priv} and made no changes to the "
+            f"system. The device scored <b>{report.score}/100 "
+            f"({letter} — {label})</b>."
+        )
+        if report.cis_caveat:
+            scope += f" {escape(report.cis_caveat)}."
+        paragraphs.append(Markup(scope))
+
+        if open_findings:
+            # P2 — findings.
+            detail_parts: list[str] = []
+            if report.fail_count:
+                n = report.fail_count
+                detail_parts.append(f"{n} check{'s' if n != 1 else ''} failed")
+            if report.warn_count:
+                n = report.warn_count
+                detail_parts.append(
+                    f"{n} check{'s' if n != 1 else ''} issued warnings")
+            findings_p = f"Of the checks performed, {' and '.join(detail_parts)}."
+            if p1:
+                names = ", ".join(
+                    f"<b>{escape(r.check_name)}</b>" for r in p1[:3])
+                more = ", among others" if len(p1) > 3 else ""
+                findings_p += (
+                    f" Of these, {len(p1)} "
+                    f"{'is' if len(p1) == 1 else 'are'} high priority: "
+                    f"{names}{more}."
+                )
+            else:
+                findings_p += (" None of the open findings are critical or "
+                               "high severity.")
+            issue_cats = Counter(r.category for r in open_findings)
+            top_cats = [escape(c) for c, _ in issue_cats.most_common(3)]
+            if len(top_cats) == 1:
+                findings_p += (f" The primary area of concern is "
+                               f"<b>{top_cats[0]}</b>.")
+            elif top_cats:
+                joined = (", ".join(f"<b>{c}</b>" for c in top_cats[:-1])
+                          + f" and <b>{top_cats[-1]}</b>")
+                findings_p += f" The primary areas of concern are {joined}."
+            paragraphs.append(Markup(findings_p))
+
+            # P3 — strengths.
+            if report.pass_count:
+                strengths = (f"{report.pass_count} of {total} controls "
+                             "passed.")
+                open_cats = {r.category for r in open_findings}
+                clean = sorted(
+                    {r.category for r in report.results} - open_cats)
+                if clean:
+                    shown = ", ".join(escape(c) for c in clean[:3])
+                    prefix = ("Categories including" if len(clean) > 3
+                              else "The" if len(clean) == 1 else "Categories")
+                    if len(clean) == 1:
+                        strengths += (f" The {shown} category passed all of "
+                                      "its checks.")
+                    else:
+                        strengths += (f" {prefix} {shown} passed all of "
+                                      "their checks.")
+                paragraphs.append(Markup(strengths))
+        else:
+            # P2-alt — all clear.
+            paragraphs.append(Markup(
+                "Every evaluated control passed — no failures or warnings "
+                "were detected. The system's configuration is in line with "
+                "the evaluated Windows security baselines."
+            ))
+
+        # P4 — caveats.
+        caveats: list[str] = []
+        if report.error_count:
+            n = report.error_count
+            hint = (
+                "see the per-check detail for the cause"
+                if report.is_admin
+                else "run as Administrator for full results"
+            )
+            caveats.append(
+                f"Note: {n} check{'s' if n != 1 else ''} could not "
+                f"complete — {hint}."
+            )
+        info_n = sum(1 for r in report.results if r.status == Status.INFO)
+        if info_n:
+            caveats.append(
+                f"{info_n} informational item{'s were' if info_n != 1 else ' was'} "
+                "recorded for context; they do not affect the score."
+            )
+        if caveats:
+            paragraphs.append(Markup(escape(" ".join(caveats))))
+
+        return paragraphs
+
+    def _build_exec_bottom_line(self, report: AuditReport) -> "Markup":
+        """The "Bottom line" note-box sentence."""
+        from markupsafe import Markup
+
+        open_n = report.fail_count + report.warn_count
+        p1 = sum(
+            1 for r in report.results
+            if r.status in (Status.FAIL, Status.WARN)
+            and r.severity in (Severity.CRITICAL, Severity.HIGH)
+        )
+        if open_n == 0:
+            return Markup(
+                "No corrective action is required. Maintain the current "
+                "configuration and re-assess after significant system changes."
+            )
+        if p1:
+            rest = open_n - p1
+            msg = (f"Address the {p1} Priority 1 "
+                   f"item{'s' if p1 != 1 else ''} within the week")
+            if rest:
+                msg += (f"; schedule the remaining {rest} "
+                        f"item{'s' if rest != 1 else ''} into the next "
+                        "maintenance cycle.")
+            else:
+                msg += "."
+            return Markup(msg)
+        return Markup(
+            f"No urgent action is required — fold the {open_n} open "
+            f"item{'s' if open_n != 1 else ''} into routine maintenance and "
+            "re-assess afterwards."
+        )
+
+    @staticmethod
+    def _build_distribution(report: AuditReport) -> list[dict]:
+        """Result-distribution bar segments (flex-grow widths, % legend)."""
+        total = len(report.results)
+        info_n = sum(1 for r in report.results if r.status == Status.INFO)
+        segments = [
+            ("Passed",        report.pass_count,  "seg-pass"),
+            ("Failed",        report.fail_count,  "seg-fail"),
+            ("Warnings",      report.warn_count,  "seg-warn"),
+            ("Informational", info_n,             "seg-info"),
+        ]
+        if report.error_count:
+            segments.append(("Not evaluated", report.error_count, "seg-err"))
+        return [
+            {
+                "label": label,
+                "count": count,
+                "pct":   round(count / (total or 1) * 100),
+                "css":   css,
+            }
+            for label, count, css in segments
+        ]
+
+    def _build_exec_tiers(self, report: AuditReport) -> list[dict]:
+        """P1/P2/P3 roadmap tiers with their (possibly empty) rows."""
+        open_findings = self._exec_open_sorted(report)
+        tiers: list[dict] = [
+            {"key": key, "label": label, "window": window, "rows": []}
+            for key, label, window in _EXEC_TIERS
+        ]
+        for r in open_findings:
+            tiers[_tier_index(r)]["rows"].append({
+                "category":   r.category,
+                "check_name": r.check_name,
+                "action":     r.remediation
+                              or "See the detailed findings section for context.",
+                "severity":   r.severity.value,
+                "sev_class":  _EXEC_SEV_CLASS.get(r.severity, "info"),
+                "status":     r.status.value,
+                "cis":        r.cis_reference,
+            })
+        return tiers
+
+    def _build_exec_findings_cards(self, report: AuditReport) -> list[dict]:
+        """§4 finding cards: every open finding, roadmap order."""
+        cards = []
+        for r in self._exec_open_sorted(report):
+            cards.append({
+                "status":       r.status.value,
+                "status_class": "fail" if r.status == Status.FAIL else "warn",
+                "status_label": "Failed" if r.status == Status.FAIL
+                                else "Warning",
+                "severity":     r.severity.value,
+                "sev_class":    _EXEC_SEV_CLASS.get(r.severity, "info"),
+                "category":     r.category,
+                "cis":          r.cis_reference,
+                "check_name":   r.check_name,
+                "details":      r.details,
+                "impact":       _impact_for(r.category),
+                "remediation":  r.remediation,
+                "tier_key":     _EXEC_TIERS[_tier_index(r)][0],
+            })
+        return cards
+
+    @staticmethod
+    def _build_attestation_groups(report: AuditReport) -> list[dict]:
+        """Appendix A: PASS controls grouped by category (alphabetical)."""
+        from collections import defaultdict
+
+        by_cat: dict[str, list[CheckResult]] = defaultdict(list)
+        for r in report.results:
+            if r.status == Status.PASS:
+                by_cat[r.category].append(r)
+        return [
+            {
+                "name": cat,
+                "rows": [
+                    {
+                        "check_name": r.check_name,
+                        "details":    r.details,
+                        "cis":        r.cis_reference,
+                    }
+                    for r in sorted(by_cat[cat], key=lambda r: r.check_name)
+                ],
+            }
+            for cat in sorted(by_cat)
+        ]
+
+    def _build_exec_commands(self, report: AuditReport) -> list[dict]:
+        """Appendix B: numbered command blocks for open findings, P1→P3."""
+        commands = []
+        for r in self._exec_open_sorted(report):
+            if not r.command:
+                continue
+            commands.append({
+                "num":        f"{len(commands) + 1:02d}",
+                "check_name": r.check_name,
+                "category":   r.category,
+                "severity":   r.severity.value,
+                "sev_class":  _EXEC_SEV_CLASS.get(r.severity, "info"),
+                "tier_key":   _EXEC_TIERS[_tier_index(r)][0],
+                "cis":        r.cis_reference,
+                "command":    r.command,
+            })
+        return commands
+
     def _make_console(self):
         import sys
 
@@ -1197,6 +1758,7 @@ class Reporter:
         report: AuditReport,
         html_path: str | None,
         json_path: str | None,
+        exec_path: str | None = None,
     ) -> None:
         """Print the single-arrow summary footer (plus any caveats, muted)."""
         g = _glyphs(console)
@@ -1219,6 +1781,12 @@ class Reporter:
                 tail += f" {g['sep']} --verbose for per-check detail"
             console.print(_text("  ", (head, _GREEN), (tail, _MUTED)))
 
+        if exec_path:
+            console.print(_text(
+                "  ",
+                (f"{g['sep']} {exec_path} written", _MUTED),
+                (" — executive summary for decision makers", _MUTED),
+            ))
         if json_path:
             console.print(_text("  ", (f"{g['sep']} {json_path} written", _MUTED)))
         if report.error_count:

--- a/src/apotrope/templates/exec_report.html.j2
+++ b/src/apotrope/templates/exec_report.html.j2
@@ -1,0 +1,432 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Security Posture Assessment — {{ hostname }}</title>
+<style>{% raw %}
+/* Apotrope — Security Posture Assessment (executive report).
+   Print-first, self-contained, script-free. Editorial visual direction:
+   serif display, warm ivory ink, deep evergreen accent. Offline font
+   stacks only — no web fonts, no network. */
+
+* { box-sizing: border-box; }
+
+:root {
+  /* semantic severity — tuned for legibility on white */
+  --crit:  #9e1b32;
+  --high:  #b4451f;
+  --med:   #8a6a00;
+  --ok:    #0d6b4f;
+  --info:  #3f6ea3;
+  --crit-bg: #f7e9ec; --high-bg: #f8ece5; --med-bg: #f6f0dd; --ok-bg: #e6f1ec; --info-bg: #eaf0f6;
+
+  /* editorial theme tokens */
+  --ink:    #1c1a16;
+  --body:   #35322b;
+  --muted:  #6f6a60;
+  --faint:  #9d988c;
+  --rule:   #e0dbd0;
+  --rule-2: #cfc9bb;
+  --accent: #0b5d4e;
+  --accent-2: #094a3e;
+  --accent-soft: #ecf2ef;
+  --card:   #ffffff;
+  --tint:   #faf8f3;
+  --f-display: "Source Serif 4", Georgia, "Times New Roman", serif;
+  --f-body: "Libre Franklin", "Segoe UI", system-ui, sans-serif;
+  --f-mono: "IBM Plex Mono", "Cascadia Code", Consolas, monospace;
+}
+
+html, body { margin: 0; padding: 0; }
+body { background: #d8d6d0; }
+
+/* On screen: a paper sheet. In print: hand the page over to @page margins. */
+.sheet {
+  max-width: 8.5in;
+  margin: 28px auto;
+  background: var(--card);
+  box-shadow: 0 2px 26px rgba(0,0,0,0.16);
+  padding: 0.8in;
+  color: var(--body);
+  font-family: var(--f-body);
+  font-size: 10.6pt;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+h1, h2, h3, h4 { color: var(--ink); font-family: var(--f-display); font-weight: 600; letter-spacing: -0.01em; }
+p { margin: 0 0 9pt; }
+a { color: var(--accent); }
+strong, b { color: var(--ink); font-weight: 600; }
+
+.mono { font-family: var(--f-mono); }
+.tnum { font-variant-numeric: tabular-nums; }
+.muted { color: var(--muted); }
+.faint { color: var(--faint); }
+
+/* ── Cover ─────────────────────────────────────────────────────────────── */
+.cover { padding: 6pt 0 0; }
+.cover-top { display: flex; align-items: center; justify-content: space-between; gap: 16pt; padding-bottom: 12pt; border-bottom: 1.5pt solid var(--ink); }
+.brandlock { display: flex; align-items: center; gap: 10pt; }
+.brandlock img { width: 34pt; height: 34pt; display: block; border-radius: 6pt; }
+.brandlock .glyph { width: 34pt; height: 34pt; display: flex; align-items: center; justify-content: center; font-size: 22pt; color: var(--accent); }
+.brandlock .wm { font-family: var(--f-display); font-weight: 700; letter-spacing: 0.26em; font-size: 13pt; color: var(--ink); text-transform: uppercase; }
+.brandlock .sub { font-family: var(--f-mono); font-size: 7.4pt; letter-spacing: 0.14em; color: var(--muted); text-transform: uppercase; }
+.cover-class { font-family: var(--f-mono); font-size: 7.6pt; letter-spacing: 0.18em; text-transform: uppercase; color: var(--muted); border: 1px solid var(--rule-2); padding: 4pt 8pt; border-radius: 3pt; white-space: nowrap; }
+
+.cover-title { margin-top: 30pt; }
+.cover-title .eyebrow { font-family: var(--f-mono); font-size: 8.5pt; letter-spacing: 0.2em; text-transform: uppercase; color: var(--accent); margin-bottom: 8pt; }
+.cover-title h1 { font-size: 33pt; line-height: 1.04; margin: 0; letter-spacing: -0.015em; }
+.cover-title .deck { font-family: var(--f-body); font-size: 12pt; color: var(--muted); margin-top: 10pt; max-width: 34em; line-height: 1.45; }
+
+.cover-panel { margin-top: 26pt; display: grid; grid-template-columns: 1.35fr 1fr; gap: 22pt; align-items: stretch; break-inside: avoid; page-break-inside: avoid; }
+.cover-meta { display: grid; grid-template-columns: 1fr 1fr; gap: 12pt 20pt; align-content: start; }
+.cmeta { border-top: 1px solid var(--rule); padding-top: 6pt; }
+.cmeta .k { font-family: var(--f-mono); font-size: 7.4pt; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
+.cmeta .v { font-size: 10.5pt; color: var(--ink); margin-top: 2pt; }
+
+/* grade badge */
+.gradebox { border: 1.5pt solid var(--ink); border-radius: 6pt; padding: 16pt 18pt; display: flex; flex-direction: column; justify-content: center; background: var(--tint); break-inside: avoid; page-break-inside: avoid; }
+.gradebox .gline { display: flex; align-items: baseline; gap: 12pt; }
+.gradebox .letter { font-family: var(--f-display); font-size: 52pt; line-height: 0.8; font-weight: 700; color: var(--ink); }
+.gradebox .scorewrap { display: flex; flex-direction: column; }
+.gradebox .score { font-family: var(--f-mono); font-size: 20pt; font-weight: 600; color: var(--ink); line-height: 1; }
+.gradebox .score span { color: var(--faint); font-size: 12pt; }
+.gradebox .band { font-family: var(--f-mono); font-size: 8pt; letter-spacing: 0.2em; text-transform: uppercase; color: var(--muted); margin-top: 3pt; }
+.gradebox .verdict { margin-top: 12pt; padding-top: 11pt; border-top: 1px solid var(--rule-2); font-size: 10pt; color: var(--body); line-height: 1.45; }
+.gradebox .verdict b { color: var(--ink); }
+
+/* ── Sections ──────────────────────────────────────────────────────────── */
+.doc-section { margin-top: 26pt; }
+.sec-h { display: flex; align-items: baseline; gap: 10pt; padding-bottom: 6pt; border-bottom: 1px solid var(--rule-2); margin-bottom: 12pt; break-after: avoid; page-break-after: avoid; }
+.sec-h .n { font-family: var(--f-display); font-size: 12pt; font-weight: 700; color: var(--accent); min-width: 1.6em; }
+.sec-h h2 { font-size: 15.5pt; margin: 0; flex: 1; }
+.sec-h .tag { font-family: var(--f-mono); font-size: 7.6pt; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
+
+.lede { font-size: 12.5pt; line-height: 1.5; color: var(--ink); font-family: var(--f-display); font-weight: 400; margin-bottom: 12pt; }
+
+/* stat tiles */
+.tiles { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10pt; margin: 14pt 0; }
+.tile { border: 1px solid var(--rule); border-radius: 4pt; padding: 11pt 12pt; break-inside: avoid; page-break-inside: avoid; }
+.tile .k { font-family: var(--f-mono); font-size: 7.2pt; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
+.tile .v { font-family: var(--f-mono); font-size: 21pt; font-weight: 600; color: var(--ink); line-height: 1.1; margin-top: 4pt; }
+.tile .v small { font-size: 11pt; color: var(--faint); }
+.tile .note { font-size: 8.4pt; color: var(--muted); margin-top: 2pt; }
+.tile.accent { border-color: var(--accent); background: var(--accent-soft); }
+.tile.accent .v { color: var(--accent-2); }
+
+/* distribution bar — segment widths are proportional via flex-grow */
+.distrib { display: flex; height: 12pt; border-radius: 3pt; overflow: hidden; margin: 4pt 0 6pt; border: 1px solid var(--rule); }
+.distrib > span { display: block; height: 100%; }
+.seg-pass { background: var(--ok); }
+.seg-fail { background: var(--high); }
+.seg-warn { background: var(--med); }
+.seg-info { background: var(--info); }
+.seg-err  { background: var(--faint); }
+.distrib-legend { display: flex; flex-wrap: wrap; gap: 4pt 16pt; font-family: var(--f-mono); font-size: 8.4pt; color: var(--muted); }
+.distrib-legend .li { display: inline-flex; align-items: center; gap: 6pt; }
+.distrib-legend .sw { width: 8pt; height: 8pt; border-radius: 2pt; display: inline-block; }
+.distrib-legend b { color: var(--ink); }
+
+/* ── Roadmap ───────────────────────────────────────────────────────────── */
+.tier { margin-bottom: 14pt; break-inside: avoid; page-break-inside: avoid; }
+.tier-h { display: flex; align-items: center; gap: 9pt; margin-bottom: 7pt; }
+.tier-badge { font-family: var(--f-mono); font-size: 8pt; font-weight: 700; letter-spacing: 0.08em; color: #fff; padding: 3pt 8pt; border-radius: 3pt; }
+.tier-badge.p1 { background: var(--crit); }
+.tier-badge.p2 { background: var(--high); }
+.tier-badge.p3 { background: var(--med); }
+.tier-h .lbl { font-family: var(--f-display); font-size: 11.5pt; font-weight: 600; color: var(--ink); }
+.tier-h .when { font-family: var(--f-mono); font-size: 8pt; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); margin-left: auto; }
+.tier-empty { font-size: 9.4pt; color: var(--faint); padding: 4pt 0 2pt; border-top: 1px solid var(--rule); }
+
+.rm-item { display: grid; grid-template-columns: 1.5fr 1fr auto; gap: 6pt 16pt; padding: 8pt 0; border-top: 1px solid var(--rule); break-inside: avoid; page-break-inside: avoid; }
+.rm-item:first-of-type { border-top: 1px solid var(--rule-2); }
+.rm-title { font-weight: 600; color: var(--ink); font-size: 10.4pt; }
+.rm-title .cat { font-family: var(--f-mono); font-size: 7.6pt; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); display: block; margin-bottom: 1pt; }
+.rm-action { color: var(--body); font-size: 9.6pt; }
+.rm-meta { text-align: right; white-space: nowrap; }
+.rm-meta .cis-ref { display: block; font-family: var(--f-mono); font-size: 8pt; letter-spacing: 0.06em; color: var(--muted); margin-top: 4pt; }
+
+/* ── Findings ──────────────────────────────────────────────────────────── */
+.finding { border: 1px solid var(--rule); border-radius: 5pt; padding: 13pt 15pt; margin-bottom: 11pt; break-inside: avoid; page-break-inside: avoid; background: var(--card); }
+.finding-h { display: flex; align-items: center; gap: 9pt; margin-bottom: 9pt; flex-wrap: wrap; }
+.chip { font-family: var(--f-mono); font-size: 7.4pt; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; padding: 3pt 7pt; border-radius: 3pt; border: 1px solid transparent; white-space: nowrap; }
+.chip.status { color: #fff; }
+.chip.st-fail { background: var(--high); }
+.chip.st-warn { background: var(--med); }
+.sev { font-family: var(--f-mono); font-size: 7.4pt; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; padding: 2.5pt 7pt; border-radius: 3pt; }
+.sev.crit { color: var(--crit); background: var(--crit-bg); border: 1px solid var(--crit); }
+.sev.high { color: var(--high); background: var(--high-bg); border: 1px solid var(--high); }
+.sev.med { color: var(--med); background: var(--med-bg); border: 1px solid var(--med); }
+.sev.low { color: var(--info); background: var(--info-bg); border: 1px solid var(--info); }
+.sev.info { color: var(--muted); background: var(--tint); border: 1px solid var(--rule-2); }
+.finding-h .fcat { font-family: var(--f-mono); font-size: 8pt; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); }
+.finding-h .fcis { font-family: var(--f-mono); font-size: 8pt; color: var(--faint); margin-left: auto; }
+.finding-h .fname { flex-basis: 100%; font-family: var(--f-display); font-size: 12.5pt; font-weight: 600; color: var(--ink); margin-top: 1pt; letter-spacing: -0.005em; }
+
+.finding-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8pt 20pt; }
+.fblock .fk { font-family: var(--f-mono); font-size: 7.4pt; letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent); margin-bottom: 3pt; }
+.fblock p { margin: 0; font-size: 9.8pt; line-height: 1.46; }
+.fblock p.fdetails { white-space: pre-line; }
+.fblock.full { grid-column: 1 / -1; }
+.finding .action { border-left: 2.5pt solid var(--accent); padding: 6pt 11pt; margin-top: 9pt; background: var(--accent-soft); border-radius: 0 3pt 3pt 0; }
+.finding .action .fk { color: var(--accent-2); }
+.finding .action p { color: var(--ink); }
+
+/* ── Attestation table (Appendix A) ────────────────────────────────────── */
+.attest { width: 100%; border-collapse: collapse; font-size: 9.4pt; }
+.attest thead th { font-family: var(--f-mono); font-size: 7.4pt; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); text-align: left; padding: 6pt 8pt; border-bottom: 1.5pt solid var(--ink); font-weight: 500; }
+.attest td { padding: 5pt 8pt; border-bottom: 1px solid var(--rule); vertical-align: top; }
+.attest tr { break-inside: avoid; page-break-inside: avoid; }
+.attest .cat-row td { font-family: var(--f-mono); font-size: 7.8pt; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent-2); font-weight: 600; padding-top: 10pt; border-bottom: 1px solid var(--rule-2); background: var(--tint); }
+.attest .ck { color: var(--ink); font-weight: 500; }
+.attest .st { font-family: var(--f-mono); font-size: 7.6pt; font-weight: 600; letter-spacing: 0.06em; color: var(--ok); }
+.attest .cis { font-family: var(--f-mono); font-size: 8pt; color: var(--faint); white-space: nowrap; }
+.attest .dt { color: var(--muted); font-size: 9pt; white-space: pre-line; }
+
+/* ── Command blocks (Appendix B) ───────────────────────────────────────── */
+.cmd { margin-bottom: 12pt; break-inside: avoid; page-break-inside: avoid; }
+.cmd-h { display: flex; align-items: baseline; gap: 9pt; margin-bottom: 5pt; }
+.cmd-h .num { font-family: var(--f-mono); font-size: 8.5pt; font-weight: 700; color: var(--accent); }
+.cmd-h .t { font-weight: 600; color: var(--ink); font-size: 10.2pt; }
+.cmd-h .c { font-family: var(--f-mono); font-size: 8pt; color: var(--muted); margin-left: auto; }
+.cmd pre { font-family: var(--f-mono); font-size: 8.6pt; line-height: 1.55; background: #0f1412; color: #d7e6df; border-radius: 4pt; padding: 10pt 12pt; margin: 0; white-space: pre-wrap; overflow-wrap: anywhere; border: 1px solid #1c2723; }
+.cmd pre .cmt { color: #6f8a80; }
+
+/* ── Callout / note ────────────────────────────────────────────────────── */
+.note-box { border: 1px solid var(--rule-2); border-radius: 4pt; padding: 10pt 13pt; background: var(--tint); font-size: 9.6pt; color: var(--body); break-inside: avoid; page-break-inside: avoid; }
+.note-box .fk { font-family: var(--f-mono); font-size: 7.4pt; letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent); margin-bottom: 3pt; }
+.all-clear { border-color: var(--ok); background: var(--ok-bg); }
+.all-clear .fk { color: var(--ok); }
+
+/* running footer (static, end of document) */
+.doc-foot { display: flex; justify-content: space-between; align-items: center; gap: 14pt; flex-wrap: wrap; margin-top: 26pt; padding-top: 10pt; border-top: 1px solid var(--rule); font-family: var(--f-mono); font-size: 7.6pt; letter-spacing: 0.08em; color: var(--faint); text-transform: uppercase; }
+.doc-foot .b { color: var(--muted); }
+
+hr.rule { border: none; border-top: 1px solid var(--rule); margin: 14pt 0; }
+
+/* ── Print ─────────────────────────────────────────────────────────────── */
+@page { size: letter; margin: 0.8in; }
+/* Margin boxes: static tool copy only (never scan data — CSS string context).
+   Supported by Chromium 131+; older engines ignore them harmlessly. */
+@page {
+  @bottom-center { content: "Apotrope · Security Posture Assessment · Confidential"; font-family: monospace; font-size: 7pt; color: #9d988c; }
+  @bottom-right { content: counter(page); font-family: monospace; font-size: 7pt; color: #9d988c; }
+}
+.page-break { break-before: page; page-break-before: always; }
+
+@media print {
+  body { background: #fff; }
+  .sheet { max-width: none; margin: 0; padding: 0; box-shadow: none; }
+  a { color: inherit; text-decoration: none; }
+}
+{% endraw %}</style>
+</head>
+<body>
+<div class="sheet">
+
+  <!-- ═══ COVER ═══ -->
+  <section class="cover">
+    <div class="cover-top">
+      <div class="brandlock">
+        {% if logo_data_uri %}<img src="{{ logo_data_uri }}" alt="Apotrope" />{% else %}<span class="glyph">◈</span>{% endif %}
+        <div>
+          <div class="wm">Apotrope</div>
+          <div class="sub">Windows Security Tooling</div>
+        </div>
+      </div>
+      <div class="cover-class">Confidential</div>
+    </div>
+
+    <div class="cover-title">
+      <div class="eyebrow">Endpoint Security Assessment</div>
+      <h1>Security Posture Assessment</h1>
+      <p class="deck">{{ deck }}</p>
+    </div>
+
+    <div class="cover-panel">
+      <div class="cover-meta">
+        <div class="cmeta"><div class="k">Host</div><div class="v">{{ hostname }}</div></div>
+        <div class="cmeta"><div class="k">Operating system</div><div class="v">{{ os_version }}</div></div>
+        <div class="cmeta"><div class="k">Assessment date</div><div class="v">{{ assessment_date }}</div></div>
+        <div class="cmeta"><div class="k">Controls evaluated</div><div class="v">{{ total_checks }} across {{ n_cats }} area{{ 's' if n_cats != 1 }}</div></div>
+        <div class="cmeta"><div class="k">Assessment mode</div><div class="v">{{ assessment_mode }}</div></div>
+        <div class="cmeta"><div class="k">Privileges</div><div class="v">{{ privilege_level }}</div></div>
+        <div class="cmeta"><div class="k">Tool</div><div class="v">Apotrope v{{ version }}</div></div>
+        <div class="cmeta"><div class="k">Scan duration</div><div class="v">{{ scan_duration }} seconds</div></div>
+      </div>
+
+      <div class="gradebox">
+        <div class="gline">
+          <div class="letter">{{ grade_letter }}</div>
+          <div class="scorewrap">
+            <div class="score">{{ score }}<span>/100</span></div>
+            <div class="band">{{ grade_label }}</div>
+          </div>
+        </div>
+        <div class="verdict">{{ verdict }}</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══ 1. EXECUTIVE SUMMARY ═══ -->
+  <section class="doc-section" id="summary">
+    <div class="sec-h"><span class="n">1</span><h2>Executive summary</h2><span class="tag">Plain language</span></div>
+
+    <p class="lede">{{ lede }}</p>
+
+    {% for para in exec_paragraphs %}
+    <p>{{ para }}</p>
+    {% endfor %}
+
+    <div class="note-box{% if not open_total %} all-clear{% endif %}">
+      <div class="fk">Bottom line</div>
+      {{ bottom_line }}
+    </div>
+  </section>
+
+  <!-- ═══ 2. POSTURE AT A GLANCE ═══ -->
+  <section class="doc-section" id="glance">
+    <div class="sec-h"><span class="n">2</span><h2>Posture at a glance</h2></div>
+
+    {% set pass_pct = ((pass_count * 100 / total_checks) | round | int) if total_checks else 0 %}
+    <div class="tiles">
+      <div class="tile accent"><div class="k">Overall score</div><div class="v tnum">{{ score }}<small>/100</small></div><div class="note">Grade {{ grade_letter }} — {{ grade_label }}</div></div>
+      <div class="tile"><div class="k">Controls passed</div><div class="v tnum">{{ pass_count }}<small>/{{ total_checks }}</small></div><div class="note">{{ pass_pct }}% compliant</div></div>
+      <div class="tile"><div class="k">Open findings</div><div class="v tnum">{{ open_total }}</div><div class="note">{{ fail_count }} failed · {{ warn_count }} warning{{ 's' if warn_count != 1 }}</div></div>
+      <div class="tile"><div class="k">High-severity</div><div class="v tnum">{{ p1_count }}</div><div class="note">Priority-1 item{{ 's' if p1_count != 1 }}</div></div>
+    </div>
+
+    {% if total_checks %}
+    <div class="distrib">
+      {% for s in dist_segments %}{% if s.count %}<span class="{{ s.css }}" style="flex-grow:{{ s.count }}"></span>{% endif %}{% endfor %}
+    </div>
+    <div class="distrib-legend">
+      {% for s in dist_segments %}
+      <span class="li"><span class="sw {{ s.css }}"></span>{{ s.label }} <b>{{ s.count }}</b> ({{ s.pct }}%)</span>
+      {% endfor %}
+    </div>
+    {% if info_count %}
+    <p class="muted" style="font-size:9.4pt;margin-top:8pt;">{{ info_count }} informational item{{ 's' if info_count != 1 }} (system inventory and context) {{ 'are' if info_count != 1 else 'is' }} recorded for reference and do{{ 'es' if info_count == 1 }} not affect the score.</p>
+    {% endif %}
+    {% else %}
+    <p class="muted">No controls were evaluated in this assessment.</p>
+    {% endif %}
+  </section>
+
+  <!-- ═══ 3. REMEDIATION ROADMAP ═══ -->
+  <section class="doc-section" id="roadmap">
+    <div class="sec-h"><span class="n">3</span><h2>Prioritized remediation roadmap</h2><span class="tag">{{ open_total }} action{{ 's' if open_total != 1 }}</span></div>
+
+    {% if open_total %}
+    {% for tier in tiers %}
+    <div class="tier">
+      <div class="tier-h"><span class="tier-badge {{ tier.key | lower }}">{{ tier.key }}</span><span class="lbl">{{ tier.label }}</span><span class="when">{{ tier.window }}</span></div>
+      {% for row in tier.rows %}
+      <div class="rm-item">
+        <div class="rm-title"><span class="cat">{{ row.category }}</span>{{ row.check_name }}</div>
+        <div class="rm-action">{{ row.action }}</div>
+        <div class="rm-meta"><span class="sev {{ row.sev_class }}">{{ row.severity }}</span>{% if row.cis %}<span class="cis-ref">{{ row.cis }}</span>{% endif %}</div>
+      </div>
+      {% else %}
+      <div class="tier-empty">No items in this tier.</div>
+      {% endfor %}
+    </div>
+    {% endfor %}
+    {% else %}
+    <div class="note-box all-clear">
+      <div class="fk">All clear</div>
+      Every evaluated control passed — there are no remediation actions to prioritize.
+    </div>
+    {% endif %}
+  </section>
+
+  <!-- ═══ 4. DETAILED FINDINGS ═══ -->
+  <section class="doc-section" id="findings">
+    <div class="sec-h"><span class="n">4</span><h2>Detailed findings</h2><span class="tag">Open items only</span></div>
+
+    {% for f in findings_cards %}
+    <div class="finding">
+      <div class="finding-h">
+        <span class="chip status st-{{ f.status_class }}">{{ f.status_label }}</span>
+        <span class="sev {{ f.sev_class }}">{{ f.severity }}</span>
+        <span class="fcat">{{ f.category }}</span>
+        {% if f.cis %}<span class="fcis">{{ f.cis }}</span>{% endif %}
+        <span class="fname">{{ f.check_name }}</span>
+      </div>
+      <div class="finding-grid">
+        <div class="fblock"><div class="fk">Finding</div><p class="fdetails">{{ f.details }}</p></div>
+        <div class="fblock"><div class="fk">Business impact</div><p>{{ f.impact }}</p></div>
+      </div>
+      {% if f.remediation %}
+      <div class="fblock full action"><div class="fk">Recommended action</div><p>{{ f.remediation }}</p></div>
+      {% endif %}
+    </div>
+    {% else %}
+    <div class="note-box all-clear">
+      <div class="fk">No open findings</div>
+      Every evaluated control passed; there are no failed or warning findings to detail.
+    </div>
+    {% endfor %}
+  </section>
+
+  <!-- ═══ APPENDIX A — ATTESTATION ═══ -->
+  <section class="doc-section page-break" id="appendix-a">
+    <div class="sec-h"><span class="n">A</span><h2>Attestation — controls passed</h2><span class="tag">{{ pass_count }} control{{ 's' if pass_count != 1 }}</span></div>
+
+    {% if attestation_groups %}
+    <p class="muted" style="font-size:9.6pt;margin-bottom:10pt;">The following controls were evaluated and passed. This record can serve as evidence of the endpoint's compliant configuration at the time of assessment.</p>
+
+    <table class="attest">
+      <thead>
+        <tr><th style="width:32%;">Control</th><th style="width:10%;">Result</th><th style="width:42%;">Detail</th><th style="width:16%;">Benchmark</th></tr>
+      </thead>
+      <tbody>
+        {% for group in attestation_groups %}
+        <tr class="cat-row"><td colspan="4">{{ group.name }}</td></tr>
+        {% for row in group.rows %}
+        <tr><td class="ck">{{ row.check_name }}</td><td class="st">Pass</td><td class="dt">{{ row.details }}</td><td class="cis">{{ row.cis or '—' }}</td></tr>
+        {% endfor %}
+        {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+    <p class="muted">No controls passed in this assessment, so there is nothing to attest.</p>
+    {% endif %}
+  </section>
+
+  <!-- ═══ APPENDIX B — REMEDIATION COMMANDS ═══ -->
+  <section class="doc-section page-break" id="appendix-b">
+    <div class="sec-h"><span class="n">B</span><h2>Remediation commands</h2><span class="tag">For IT</span></div>
+
+    {% if commands %}
+    <div class="note-box" style="margin-bottom:13pt;">
+      <div class="fk">Before you run these</div>
+      Run in an <b>elevated</b> PowerShell prompt. Commands mirror the findings above; review each against your environment and change-management process before applying to a production device.
+    </div>
+
+    {% for c in commands %}
+    <div class="cmd">
+      <div class="cmd-h"><span class="num">{{ c.num }}</span><span class="t">{{ c.check_name }}</span><span class="c">{{ c.category }} · {{ c.tier_key }}</span></div>
+      <pre>{% for ln in c.command.split('\n') %}{% if ln.strip() == '' %}<div> </div>{% elif ln.lstrip().startswith('#') %}<div class="cmt">{{ ln }}</div>{% else %}<div>{{ ln }}</div>{% endif %}{% endfor %}</pre>
+    </div>
+    {% endfor %}
+    {% else %}
+    <p class="muted">No scripted remediation applies to the findings in this assessment.</p>
+    {% endif %}
+
+    <hr class="rule" />
+    <p class="muted" style="font-size:9pt;">About this assessment — Apotrope performs a read-only, non-invasive scan of Windows security configuration, scoring against thresholds aligned to the CIS Microsoft Windows Benchmark {{ cis_version }}{% if cis_caveat %} ({{ cis_caveat }}){% endif %}. No changes are made to the system during assessment. {{ scoring_note }} The scan completed in {{ scan_duration }} seconds. When printing, disable the browser's own header and footer — this document supplies its own.</p>
+  </section>
+
+  <div class="doc-foot">
+    <span class="b">Apotrope v{{ version }} · Security Posture Assessment</span>
+    <span>{{ hostname }}</span>
+    <span>Confidential</span>
+  </div>
+
+</div>
+</body>
+</html>

--- a/src/apotrope/templates/report.html.j2
+++ b/src/apotrope/templates/report.html.j2
@@ -200,6 +200,11 @@
             text-transform:uppercase; color:var(--cyan); border:1px solid rgba(68,224,230,0.3);
             background:rgba(68,224,230,0.06); padding:5px 10px; border-radius:2px; white-space:nowrap; }
   .ro-tag .dot { width:6px; height:6px; border-radius:50%; background:var(--cyan); box-shadow:0 0 7px var(--cyan); }
+  .exec-link { display:inline-flex; align-items:center; gap:7px; font-size:10px; letter-spacing:0.16em;
+               text-transform:uppercase; color:var(--accent); border:1px solid var(--accent);
+               background:var(--accent-dim); padding:5px 11px; border-radius:2px; white-space:nowrap;
+               transition:background .15s, color .15s, box-shadow .15s; }
+  .exec-link:hover { background:var(--accent); color:var(--void); box-shadow:0 0 12px var(--accent-dim); }
 
   /* hero grid */
   .hero { display:grid; grid-template-columns: 320px 1fr; gap:var(--gap); margin-top:var(--gap); align-items:start; }
@@ -430,7 +435,7 @@
     .wrap { padding-bottom:0; }
     .panel { background:#fff !important; border-color:#bbb !important; }
     .panel::before, .panel::after { display:none; }
-    .toolbar, .tool-right, .search, .filters { display:none !important; }
+    .toolbar, .tool-right, .search, .filters, .exec-link { display:none !important; }
     .cat-bar { position:static; background:#f2f2f2 !important; }
     .cat-name, .brand .name, .ti-name, .fname b, .meta-item .v b { color:#111 !important; }
     .fbody[hidden] { display:grid !important; }   /* show all details on paper */
@@ -463,6 +468,7 @@
         <div class="meta-item"><span class="label">System</span><span class="v">{{ os_version }}</span></div>
         <div class="meta-item"><span class="label">Scan</span><span class="v">{{ scan_timestamp }} <span style="color:var(--faint)">· {{ scan_duration }}s</span></span></div>
         <span class="ro-tag"><span class="dot"></span>Read-only audit</span>
+        {% if exec_href %}<a class="exec-link" href="{{ exec_href }}" title="Plain-English summary for decision makers">Executive Report ↗</a>{% endif %}
       </div>
     </div>
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from apotrope.cli import build_parser
+from apotrope.cli import _exec_href, build_parser
 
 
 # ---------------------------------------------------------------------------
@@ -29,6 +29,14 @@ class TestBuildParser:
     def test_html_flag(self):
         ns = self._parse("--html", "report.html")
         assert ns.html == "report.html"
+
+    def test_exec_report_flag(self):
+        ns = self._parse("--exec-report", "brief.html")
+        assert ns.exec_report == "brief.html"
+
+    def test_exec_report_default_none(self):
+        ns = self._parse()
+        assert ns.exec_report is None
 
     def test_json_flag(self):
         ns = self._parse("--json", "out.json")
@@ -82,6 +90,30 @@ class TestBuildParser:
 
     def test_fix_hidden_from_help(self):
         assert "--fix" not in build_parser().format_help()
+
+
+# ---------------------------------------------------------------------------
+# _exec_href — link from the technical report to the executive report
+# ---------------------------------------------------------------------------
+
+class TestExecHref:
+    def test_same_directory_is_basename(self):
+        assert _exec_href("report.html", "brief.html") == "brief.html"
+
+    def test_subdirectory_uses_forward_slashes_and_encoding(self):
+        href = _exec_href("out/report.html", "out/sub/exec report.html")
+        assert href == "sub/exec%20report.html"
+
+    def test_parent_directory_relpath(self):
+        href = _exec_href("out/deep/report.html", "out/brief.html")
+        assert href == "../brief.html"
+
+    def test_cross_drive_falls_back_to_file_uri(self):
+        with patch("os.path.relpath",
+                   side_effect=ValueError("different drives")):
+            href = _exec_href("C:/reports/report.html", "D:/other/brief.html")
+        assert href.startswith("file:///")
+        assert href.endswith("brief.html")
 
 
 # ---------------------------------------------------------------------------
@@ -385,7 +417,51 @@ class TestMainErrorPaths:
         mock_reporter, mock_report = self._reporter_with_report()
         self._run_main(["--html", "out.html", "--json", "out.json"], mock_reporter)
         mock_reporter.print_terminal.assert_called_once_with(
-            mock_report, html_path="out.html", json_path="out.json"
+            mock_report, html_path="out.html", json_path="out.json",
+            exec_path=None,
+        )
+
+    def test_exec_report_saved_when_flag_provided(self):
+        mock_reporter, mock_report = self._reporter_with_report()
+        self._run_main(["--exec-report", "brief.html"], mock_reporter)
+        mock_reporter.generate_executive_report.assert_called_once_with(
+            mock_report, "brief.html"
+        )
+
+    def test_no_exec_report_by_default(self):
+        mock_reporter, _ = self._reporter_with_report()
+        self._run_main([], mock_reporter)
+        mock_reporter.generate_executive_report.assert_not_called()
+
+    def test_exec_href_passed_when_both_outputs(self):
+        """The technical report links to the exec report only when it exists."""
+        mock_reporter, mock_report = self._reporter_with_report()
+        with patch("pathlib.Path.exists", return_value=True):
+            self._run_main(
+                ["--html", "out.html", "--exec-report", "brief.html"],
+                mock_reporter,
+            )
+        mock_reporter.generate_html_report.assert_called_once_with(
+            mock_report, "out.html", exec_href="brief.html"
+        )
+
+    def test_exec_href_none_when_exec_file_missing(self):
+        """No dangling header link when exec generation wrote nothing."""
+        mock_reporter, mock_report = self._reporter_with_report()
+        with patch("pathlib.Path.exists", return_value=False):
+            self._run_main(
+                ["--html", "out.html", "--exec-report", "brief.html"],
+                mock_reporter,
+            )
+        mock_reporter.generate_html_report.assert_called_once_with(
+            mock_report, "out.html", exec_href=None
+        )
+
+    def test_exec_href_none_when_only_html(self):
+        mock_reporter, mock_report = self._reporter_with_report()
+        self._run_main(["--html", "out.html"], mock_reporter)
+        mock_reporter.generate_html_report.assert_called_once_with(
+            mock_report, "out.html", exec_href=None
         )
 
     def test_fix_flag_is_noop_with_notice(self, capsys):

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -334,6 +334,378 @@ class TestGenerateHtmlReport:
             "outside your organization." in html
         )
 
+    def test_exec_link_rendered_when_href_given(self):
+        """Header links to a co-generated executive report via exec_href."""
+        reporter = Reporter()
+        with tempfile.NamedTemporaryFile(suffix=".html", delete=False) as f:
+            path = f.name
+        try:
+            reporter.generate_html_report(
+                _make_report(), path, exec_href="brief%20v1.html")
+            html = Path(path).read_text(encoding="utf-8")
+        finally:
+            os.unlink(path)
+        assert 'class="exec-link"' in html
+        assert 'href="brief%20v1.html"' in html
+        assert "Executive Report" in html
+
+    def test_no_exec_link_by_default(self):
+        """Without exec_href, no dead 'Executive Report' link is rendered."""
+        html = self._generate(_make_report())
+        assert 'class="exec-link"' not in html
+        assert "Executive Report" not in html
+
+
+# ---------------------------------------------------------------------------
+# Executive report (Security Posture Assessment) generation
+# ---------------------------------------------------------------------------
+
+class TestGenerateExecutiveReport:
+    def _generate(self, report: AuditReport) -> str:
+        reporter = Reporter()
+        with tempfile.NamedTemporaryFile(suffix=".html", delete=False) as f:
+            path = f.name
+        try:
+            reporter.generate_executive_report(report, path)
+            return Path(path).read_text(encoding="utf-8")
+        finally:
+            os.unlink(path)
+
+    @staticmethod
+    def _section(html: str, start_id: str, end_id: str | None = None) -> str:
+        """Slice the document between two section ids."""
+        part = html.split(f'id="{start_id}"', 1)[1]
+        return part.split(f'id="{end_id}"', 1)[0] if end_id else part
+
+    def test_valid_html_document(self):
+        html = self._generate(_make_report())
+        assert html.startswith("<!DOCTYPE html>")
+        assert "</html>" in html
+        assert "Security Posture Assessment" in html
+
+    def test_self_contained_and_script_free(self):
+        """Offline and print-first: no network references and no JS at all."""
+        html = self._generate(_make_report())
+        assert "cdn." not in html
+        assert "googleapis.com" not in html
+        assert "<script" not in html
+
+    def test_cover_meta_admin(self):
+        html = self._generate(_make_report(is_admin=True))
+        assert "TEST-PC" in html
+        assert "Windows 11 Pro 10.0.22621" in html
+        assert "Read-only · non-invasive" in html
+        assert "Administrator" in html
+        assert "Apotrope v" in html
+
+    def test_cover_meta_standard_user(self):
+        html = self._generate(_make_report(is_admin=False))
+        assert "Standard user" in html
+
+    def test_gradebox_and_verdict(self):
+        # Fixture: 1 CRITICAL FAIL + 1 MEDIUM WARN open → 1 P1, 1 remainder.
+        html = self._generate(_make_report(score=80))
+        assert 'class="letter">B<' in html
+        assert (
+            "1 high-priority finding should be addressed this week; "
+            "1 further item can be scheduled into routine maintenance." in html
+        )
+
+    def test_stat_tiles_and_distribution(self):
+        html = self._generate(_make_report())
+        assert "Controls passed" in html
+        assert "Open findings" in html
+        assert "flex-grow:" in html
+        assert "Priority-1 item" in html
+
+    def test_tier_assignment_and_order(self):
+        low = CheckResult("Hardening", "Low Hygiene Item", Status.FAIL,
+                          Severity.LOW, "desc", "found", "Tidy it up")
+        html = self._generate(_make_report(extra_results=[low]))
+        roadmap = self._section(html, "roadmap", "findings")
+        # P1 (CRITICAL fail) before P2 (MEDIUM warn) before P3 (LOW fail).
+        i_p1 = roadmap.index("Public Profile")
+        i_p2 = roadmap.index("Risky Services")
+        i_p3 = roadmap.index("Low Hygiene Item")
+        assert i_p1 < i_p2 < i_p3
+        assert "No items in this tier." not in roadmap.split("Low Hygiene")[0]
+
+    def test_severity_chip_classes(self):
+        extras = [
+            CheckResult("Hardening", "Low Sev Item", Status.FAIL,
+                        Severity.LOW, "d", "f", "fix"),
+            CheckResult("Network", "Info Sev Item", Status.WARN,
+                        Severity.INFO, "d", "f", "fix"),
+        ]
+        html = self._generate(_make_report(extra_results=extras))
+        assert 'sev low"' in html
+        assert 'sev info"' in html
+
+    def test_cis_ref_shown_when_present(self):
+        extra = CheckResult("Firewall", "CIS Tagged Check", Status.FAIL,
+                            Severity.HIGH, "d", "f", "fix",
+                            cis_reference="CIS 9.9.9")
+        html = self._generate(_make_report(extra_results=[extra]))
+        assert "CIS 9.9.9" in html
+
+    def test_findings_cards_open_only(self):
+        html = self._generate(_make_report())
+        findings = self._section(html, "findings", "appendix-a")
+        assert "Public Profile" in findings   # FAIL — has a card
+        assert "Risky Services" in findings   # WARN — has a card
+        assert "Domain Profile" not in findings  # PASS — attestation only
+        assert "OS Version" not in findings      # INFO — not open
+
+    def test_impact_copy_known_category_and_fallback(self):
+        from markupsafe import escape
+
+        from apotrope.reporter import _EXEC_IMPACT, _EXEC_IMPACT_FALLBACK
+        unknown = CheckResult("CustomCat", "Odd Check", Status.FAIL,
+                              Severity.HIGH, "d", "f", "fix")
+        html = self._generate(_make_report(extra_results=[unknown]))
+        # Compare the autoescaped forms (the copy contains apostrophes).
+        assert str(escape(_EXEC_IMPACT["Firewall"])) in html
+        assert str(escape(_EXEC_IMPACT_FALLBACK)) in html
+
+    def test_attestation_pass_only(self):
+        html = self._generate(_make_report())
+        attest = self._section(html, "appendix-a", "appendix-b")
+        assert "Domain Profile" in attest      # the PASS control
+        assert "Public Profile" not in attest  # the FAIL control
+        assert "OS Version" not in attest      # INFO is not attested
+
+    def test_commands_ordered_numbered_comment_styled(self):
+        extras = [
+            CheckResult("Hardening", "Low Cmd Item", Status.FAIL, Severity.LOW,
+                        "d", "f", "fix", "Set-Low -Value 1"),
+            CheckResult("Firewall", "Crit Cmd Item", Status.FAIL,
+                        Severity.CRITICAL, "d", "f", "fix",
+                        "# review first\nSet-Crit -Value 1"),
+        ]
+        html = self._generate(_make_report(extra_results=extras))
+        appendix = self._section(html, "appendix-b")
+        # P1 command is numbered 01 and appears before the P3 command.
+        assert appendix.index("Crit Cmd Item") < appendix.index("Low Cmd Item")
+        assert ">01<" in appendix
+        assert '<div class="cmt"># review first</div>' in appendix
+        assert "PS&gt;" not in appendix  # paper copies must retype clean
+
+    def test_commands_empty_note(self):
+        # Base fixture has open findings but none carry a command.
+        html = self._generate(_make_report())
+        assert "No scripted remediation applies" in html
+
+    def test_clean_report_all_clear(self):
+        results = [
+            CheckResult("Firewall", "Domain Profile", Status.PASS,
+                        Severity.HIGH, "desc", "ok"),
+            CheckResult("Accounts", "Guest Account", Status.PASS,
+                        Severity.HIGH, "desc", "ok"),
+        ]
+        report = AuditReport(
+            hostname="TEST-PC", os_version="Windows 11",
+            scan_timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            scan_duration=1.0, results=results, score=100, is_admin=True,
+        )
+        html = self._generate(report)
+        assert ("All 2 evaluated controls passed; no corrective action is "
+                "required at this time." in html)
+        assert "No corrective action is required." in html
+        assert "no remediation actions to prioritize" in html
+        assert "no failed or warning findings" in html
+
+    def test_error_results_excluded_and_noted(self):
+        err = CheckResult("Network", "Broken Check", Status.ERROR,
+                          Severity.INFO, "d", "probe failed")
+        html = self._generate(_make_report(extra_results=[err]))
+        findings = self._section(html, "findings", "appendix-a")
+        attest = self._section(html, "appendix-a", "appendix-b")
+        assert "Broken Check" not in findings
+        assert "Broken Check" not in attest
+        assert "could not" in html  # caveat sentence in the narrative
+
+    def test_html_special_chars_escaped(self):
+        """Autoescape must cover every scan-derived field in this template too."""
+        xss = "<script>alert(1)</script>"
+        report = AuditReport(
+            hostname=f"HOST-{xss}",
+            os_version="10.0.22631",
+            scan_timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            scan_duration=1.0,
+            results=[
+                CheckResult(
+                    "Security", "XSS Check", Status.FAIL, Severity.HIGH,
+                    "desc", f"Details: {xss}", f"Remediate {xss}",
+                    f"Set-Item {xss}",
+                ),
+            ],
+            score=50,
+            is_admin=False,
+        )
+        html = self._generate(report)
+        assert "<script>alert(1)</script>" not in html
+        assert "&lt;script&gt;" in html
+
+    def test_print_css_present(self):
+        html = self._generate(_make_report())
+        assert "@page" in html
+        assert "size: letter" in html
+        assert "break-before: page" in html
+
+    def test_footer_line(self):
+        html = self._generate(_make_report())
+        foot = html.split('class="doc-foot"')[1]
+        assert "Security Posture Assessment" in foot
+        assert "TEST-PC" in foot
+        assert "Confidential" in foot
+
+    def test_no_file_written_when_jinja2_missing(self):
+        import sys
+        from unittest import mock
+
+        reporter = Reporter()
+        with tempfile.NamedTemporaryFile(suffix=".html", delete=False) as f:
+            path = f.name
+        os.unlink(path)
+        try:
+            with mock.patch.dict(sys.modules, {"jinja2": None}):
+                reporter.generate_executive_report(_make_report(), path)
+            assert not os.path.exists(path)
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_no_file_written_when_template_load_fails(self):
+        from unittest import mock
+
+        from jinja2 import Environment
+
+        reporter = Reporter()
+        with tempfile.NamedTemporaryFile(suffix=".html", delete=False) as f:
+            path = f.name
+        os.unlink(path)
+        try:
+            with mock.patch.object(
+                Environment, "get_template", side_effect=OSError("boom")
+            ):
+                reporter.generate_executive_report(_make_report(), path)
+            assert not os.path.exists(path)
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_frozen_bundle_uses_meipass_template_dir(self):
+        """PyInstaller path: templates resolve under sys._MEIPASS/templates."""
+        import sys
+        from unittest import mock
+
+        import apotrope.reporter as reporter_mod
+
+        package_dir = Path(reporter_mod.__file__).parent
+        with mock.patch.object(sys, "frozen", True, create=True), \
+             mock.patch.object(sys, "_MEIPASS", str(package_dir), create=True):
+            html = self._generate(_make_report())
+        assert "<!DOCTYPE html>" in html
+
+
+# ---------------------------------------------------------------------------
+# Executive report narrative builders
+# ---------------------------------------------------------------------------
+
+class TestExecNarrative:
+    @staticmethod
+    def _report(results, score=80, is_admin=True):
+        return AuditReport(
+            hostname="TEST-PC", os_version="Windows 11 Pro 10.0.22621",
+            scan_timestamp=datetime(2026, 3, 15, 12, 0, tzinfo=timezone.utc),
+            scan_duration=2.0, results=results, score=score, is_admin=is_admin,
+        )
+
+    def test_verdict_no_controls(self):
+        verdict = Reporter()._build_exec_verdict(self._report([]))
+        assert verdict == "No controls could be evaluated in this assessment."
+
+    def test_verdict_clean(self):
+        results = [CheckResult("Firewall", "FW", Status.PASS, Severity.HIGH,
+                               "d", "ok")]
+        verdict = Reporter()._build_exec_verdict(self._report(results, 100))
+        assert "All 1 evaluated controls passed" in verdict
+
+    def test_verdict_clean_with_errors(self):
+        results = [
+            CheckResult("Firewall", "FW", Status.PASS, Severity.HIGH, "d", "ok"),
+            CheckResult("Network", "NB", Status.ERROR, Severity.INFO, "d", "x"),
+        ]
+        verdict = Reporter()._build_exec_verdict(self._report(results, 100))
+        assert "1 control could not be evaluated" in verdict
+
+    def test_verdict_p1(self):
+        results = [CheckResult("Firewall", "FW", Status.FAIL,
+                               Severity.CRITICAL, "d", "off", "fix")]
+        verdict = Reporter()._build_exec_verdict(self._report(results, 85))
+        assert "1 high-priority finding should be addressed this week." == verdict
+
+    def test_verdict_score_bands_without_p1(self):
+        med = [CheckResult("Services", "Svc", Status.WARN, Severity.MEDIUM,
+                           "d", "warn", "fix")]
+        r = Reporter()
+        assert "strong" in r._build_exec_verdict(self._report(med, 92))
+        assert "good" in r._build_exec_verdict(self._report(med, 85))
+        assert "fair" in r._build_exec_verdict(self._report(med, 75))
+        assert "below standard" in r._build_exec_verdict(self._report(med, 65))
+        assert "prompt attention" in r._build_exec_verdict(self._report(med, 40))
+
+    def test_bottom_line_branches(self):
+        r = Reporter()
+        clean = [CheckResult("Firewall", "FW", Status.PASS, Severity.HIGH,
+                             "d", "ok")]
+        assert "No corrective action" in str(
+            r._build_exec_bottom_line(self._report(clean, 100)))
+        p1 = [CheckResult("Firewall", "FW", Status.FAIL, Severity.HIGH,
+                          "d", "off", "fix"),
+              CheckResult("Services", "Svc", Status.WARN, Severity.MEDIUM,
+                          "d", "warn", "fix")]
+        line = str(r._build_exec_bottom_line(self._report(p1, 70)))
+        assert "Address the 1 Priority 1 item within the week" in line
+        assert "remaining 1 item" in line
+        med_only = [CheckResult("Services", "Svc", Status.WARN,
+                                Severity.MEDIUM, "d", "warn", "fix")]
+        assert "routine maintenance" in str(
+            r._build_exec_bottom_line(self._report(med_only, 85)))
+
+    def test_paragraphs_scope_and_findings(self):
+        results = [
+            CheckResult("Firewall", "FW Check", Status.FAIL, Severity.HIGH,
+                        "d", "off", "fix"),
+            CheckResult("Accounts", "Guest", Status.PASS, Severity.HIGH,
+                        "d", "ok"),
+        ]
+        paras = Reporter()._build_exec_paragraphs(self._report(results, 70))
+        joined = " ".join(str(p) for p in paras)
+        assert len(paras) >= 2
+        assert "15 March 2026" in joined
+        assert "with administrator privileges" in joined
+        assert "1 check failed" in joined
+        assert "FW Check" in joined
+        assert "The primary area of concern is <b>Firewall</b>." in joined
+        # Accounts has no open findings → named as a clean category.
+        assert "Accounts" in joined
+
+    def test_paragraphs_non_admin_clause(self):
+        results = [CheckResult("Firewall", "FW", Status.PASS, Severity.HIGH,
+                               "d", "ok")]
+        paras = Reporter()._build_exec_paragraphs(
+            self._report(results, 100, is_admin=False))
+        joined = " ".join(str(p) for p in paras)
+        assert "without administrator privileges" in joined
+
+    def test_paragraphs_clean_report(self):
+        results = [CheckResult("Firewall", "FW", Status.PASS, Severity.HIGH,
+                               "d", "ok")]
+        paras = Reporter()._build_exec_paragraphs(self._report(results, 100))
+        joined = " ".join(str(p) for p in paras)
+        assert "Every evaluated control passed" in joined
+
 
 # ---------------------------------------------------------------------------
 # JSON report generation

--- a/tests/test_reporter_terminal.py
+++ b/tests/test_reporter_terminal.py
@@ -408,6 +408,16 @@ class TestFooter:
                       json_path="report.json")
         assert "report.json written" in out
 
+    def test_exec_path_mentioned(self):
+        out = _render(Reporter(), "print_terminal", _report(_default_results()),
+                      exec_path="brief.html")
+        assert "brief.html written" in out
+        assert "executive summary for decision makers" in out
+
+    def test_no_exec_hint_by_default(self):
+        out = _render(Reporter(), "print_terminal", _report(_default_results()))
+        assert "executive summary" not in out
+
     def test_error_caveat_admin_points_to_debug(self):
         results = [_result(name="Broken", status=Status.ERROR, severity=Severity.INFO)]
         out = _render(Reporter(), "print_terminal", _report(results, score=100))


### PR DESCRIPTION
## Summary

Implements the design system's **Security Posture Assessment** — a plain-English, print-first HTML report for non-technical decision makers/clients — as a real product output: `apotrope --exec-report FILE`. This is the document the technical report's new "Executive Report ↗" header link targets.

## What it contains

- **Cover** — brand lockup, Confidential tag, meta grid (host / OS / date / controls / mode / privileges / tool / duration), grade box with a **generated verdict sentence**.
- **§1 Executive summary** — 2–4 narrative paragraphs + "Bottom line" note, generated **strictly from scan data** (counts, names, severities, categories). No claim is made that isn't derivable from the report.
- **§2 Posture at a glance** — stat tiles + proportional result-distribution bar (flex-grow segments, no rounding drift).
- **§3 Prioritized remediation roadmap** — P1 (crit/high · this week) / P2 (medium · maintenance cycle) / P3 (low · next review). Severity + CIS ref shown; no fabricated time estimates.
- **§4 Detailed findings** — open findings with Finding | **Business impact** (curated per-category copy, 14 canonical categories + fallback) | Recommended action.
- **Appendix A** — passed-controls attestation table grouped by category.
- **Appendix B** — remediation commands (muted `#` comments, no `PS>` prompts so paper copies retype clean) + methodology note.

## Constraints preserved

Single self-contained file · zero network · offline font stacks (Source Serif 4 → Georgia etc.) · **no JavaScript at all** · everything scan-derived is escaped (incl. an XSS regression test) · letter-size `@page` print CSS with clean breaks (verified: Chromium PDF export = exact 612×792pt pages).

## CLI wiring

- New `--exec-report FILE` flag beside `--html`/`--json`; README + CHANGELOG updated.
- Exec report generates **before** the technical report; the header link renders only when the target file exists — it can never dangle.
- Cross-drive-safe href (`os.path.relpath` → `file://` URI fallback), percent-encoded.
- Terminal footer hint mirrors `--json`: `· brief.html written — executive summary for decision makers`.

## Verification

- **841 tests pass** (46 new: exec generation, narrative branches incl. clean/error/non-admin edge cases, tier ordering, attestation PASS-only, command styling, CLI wiring, `_exec_href` unit tests, footer hints).
- Browser QA on generated output: no console errors; clicking "Executive Report ↗" in the technical report opens the assessment; print PDF is 14 clean letter pages.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
