### PR TITLE
docs(changelog): correct 0.1.12 release date to 2026-07-16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [0.1.12] - 2026-07-13
+## [0.1.12] - 2026-07-16
 
 ### Added
 - **Executive report (`--exec-report FILE`) — the Security Posture Assessment.** A


### PR DESCRIPTION
One-line fix before tagging: the `[0.1.12]` heading was dated 2026-07-13 (when the release was prepped). Set it to the actual release/tag date, 2026-07-16.