### PR TITLE
docs(readme): absolute image URLs so screenshots render on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,12 +151,12 @@ attestations at install time yet.
 its own box listing each FAIL/WARN finding with its fix and a ready-to-paste
 PowerShell command:
 
-![Apotrope scan overview](assets/screenshots/Ap-scan-overview.png)
+![Apotrope scan overview](https://raw.githubusercontent.com/hexorcist404/apotrope/main/assets/screenshots/Ap-scan-overview.png)
 
 **Verbose mode (`--verbose`) — the same boxes for every category and every check,
 passing ones included:**
 
-![Apotrope verbose output](assets/screenshots/Ap-scan-verbose.png)
+![Apotrope verbose output](https://raw.githubusercontent.com/hexorcist404/apotrope/main/assets/screenshots/Ap-scan-verbose.png)
 
 ---
 


### PR DESCRIPTION
The two terminal screenshots used repo-relative paths, which render on GitHub but break on the PyPI project page (PyPI doesn't host repo files). Switch to `raw.githubusercontent.com` absolute URLs so they display on PyPI from the next release (v0.1.13) onward. Does not affect the already-published v0.1.12 page (published descriptions are immutable).