### PR TITLE
Assessment integrity: don't score incomplete scans 100/A/exit 0

### DIFF
--- a/src/apotrope/cli.py
+++ b/src/apotrope/cli.py
@@ -3,9 +3,10 @@
 Parses arguments and dispatches to the scanner and reporter.
 
 Exit codes:
-    0  Score >= 70 (passing) and no fatal scan errors
-    1  Score <  70 (failing security posture)
-    2  Fatal scan error (unhandled exception from the scanner)
+    0  Assessment completed and scored >= 70 (passing posture)
+    1  Assessment completed and scored <  70 (failing posture)
+    2  Result not trustworthy: invalid arguments, a fatal scan error,
+       zero controls evaluated, or one or more checks errored
 """
 
 from __future__ import annotations
@@ -167,14 +168,24 @@ def main() -> None:
     )
 
     # Import here so startup is fast for --version / --help
-    from apotrope.scanner import Scanner
+    from apotrope.scanner import Scanner, known_categories
     from apotrope.reporter import Reporter
     from apotrope.profile import load_profile
     from apotrope.utils import is_admin
 
     categories: list[str] | None = None
-    if args.category:
-        categories = [c.strip().lower() for c in args.category.split(",")]
+    if args.category is not None:
+        requested = [c.strip().lower() for c in args.category.split(",")]
+        if any(not tok for tok in requested):
+            parser.error("--category contains an empty category name")
+        valid = known_categories()
+        unknown = sorted({tok for tok in requested if tok not in valid})
+        if unknown:
+            parser.error(
+                f"unknown categor{'y' if len(unknown) == 1 else 'ies'}: "
+                f"{', '.join(unknown)}. Valid categories: {', '.join(sorted(valid))}"
+            )
+        categories = requested
 
     # Load optional profile (auto-detects apotrope.toml if --profile not given)
     profile = load_profile(getattr(args, "profile", None))
@@ -252,7 +263,13 @@ def main() -> None:
         diff = compare_reports(baseline, report)
         reporter.print_comparison(diff)
 
-    # Exit codes: 0 = score >= 70, 1 = score < 70, 2 = fatal error (handled above)
+    # Exit codes:
+    #   2  result cannot be trusted: zero controls evaluated, or >=1 ERROR
+    #   1  complete assessment, failing score (< 70)
+    #   0  complete assessment, passing score (>= 70)
+    # ERROR never changes the score (scoring.py) — it only affects the exit code.
+    if report.evaluated_count == 0 or report.error_count:
+        sys.exit(2)
     if report.score < 70:
         sys.exit(1)
 

--- a/src/apotrope/models.py
+++ b/src/apotrope/models.py
@@ -112,3 +112,13 @@ class AuditReport:
     def error_count(self) -> int:
         """Number of ERROR results."""
         return len(self.by_status(Status.ERROR))
+
+    @property
+    def evaluated_count(self) -> int:
+        """Number of results that actually evaluated a control (PASS/FAIL/WARN).
+
+        INFO (contextual notes, admin-skipped modules) and ERROR (a check that
+        could not complete) are excluded — neither represents an assessed
+        control, so this is the honest "how much did we actually audit?" count.
+        """
+        return self.pass_count + self.fail_count + self.warn_count

--- a/src/apotrope/reporter.py
+++ b/src/apotrope/reporter.py
@@ -870,7 +870,8 @@ class Reporter:
             f"across {total} security checks."
         )
 
-        if report.fail_count == 0 and report.warn_count == 0:
+        if (report.evaluated_count > 0 and report.error_count == 0
+                and report.fail_count == 0 and report.warn_count == 0):
             parts.append(
                 "All checks passed with no failures or warnings detected. "
                 "The system appears to be well-configured according to "
@@ -963,7 +964,8 @@ class Reporter:
             f"<b>{report.score}/100 ({letter})</b> across {total} security checks."
         ]
 
-        if report.fail_count == 0 and report.warn_count == 0:
+        if (report.evaluated_count > 0 and report.error_count == 0
+                and report.fail_count == 0 and report.warn_count == 0):
             parts.append(
                 '<span class="hl-ok">All checks passed with no failures or '
                 "warnings detected — the system is configured in line with "

--- a/src/apotrope/scanner.py
+++ b/src/apotrope/scanner.py
@@ -27,6 +27,37 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+def known_categories() -> set[str]:
+    """Return the lowercased ``CATEGORY`` of every check module.
+
+    These are exactly the tokens ``--category`` accepts. Derived from the
+    modules themselves (not hardcoded) so a new module's category is honoured
+    automatically, and mirrors the discovery logic in
+    :meth:`Scanner._discover_modules` (``pkgutil`` from source, the explicit
+    ``checks.MODULES`` registry when frozen). Importing a module does not run
+    its checks, so this is OS-independent and needs no elevation.
+    """
+    import sys
+
+    if getattr(sys, "frozen", False):
+        names: list[str] = list(checks_pkg.MODULES)
+    else:
+        names = [
+            m.name for m in pkgutil.iter_modules(checks_pkg.__path__)
+            if not m.name.startswith("_")
+        ]
+
+    categories: set[str] = set()
+    for name in names:
+        try:
+            module = importlib.import_module(f"apotrope.checks.{name}")
+        except Exception as exc:
+            log.error("Failed to import apotrope.checks.%s: %s", name, exc)
+            continue
+        categories.add(getattr(module, "CATEGORY", name).lower())
+    return categories
+
+
 class Scanner:
     """Discovers check modules and orchestrates an audit run.
 
@@ -261,6 +292,29 @@ class Scanner:
                     module.reset()
                 except Exception as exc:
                     log.warning("reset() on %s failed: %s", module.__name__, exc)
+
+        # A module must return at least one CheckResult (CLAUDE.md contract). An
+        # empty list or a non-CheckResult element would otherwise flow silently
+        # into the report and, being neither FAIL nor WARN, leave the score at
+        # 100 — a false "clean" result. Turn it into a synthetic ERROR instead.
+        if not results or not all(isinstance(r, CheckResult) for r in results):
+            log.error(
+                "%s.run() returned no valid CheckResult objects (%r)",
+                module.__name__, results,
+            )
+            results = [CheckResult(
+                category=cat,
+                check_name=f"{cat} — module error",
+                status=Status.ERROR,
+                severity=Severity.INFO,
+                description="The check module returned no valid results.",
+                details=(
+                    "run() returned an empty list."
+                    if not results
+                    else "run() returned a non-CheckResult element."
+                ),
+                remediation="Run with --log-level DEBUG for more detail.",
+            )]
 
         duration = time.monotonic() - t_start
         for r in results:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -549,6 +549,112 @@ class TestMainErrorPaths:
         load_mock.assert_called_once_with("custom.toml")
 
 
+class TestCategoryValidation:
+    """--category is validated against the real known category set before scanning."""
+    _SCANNER_PATH  = "apotrope.scanner.Scanner"
+    _REPORTER_PATH = "apotrope.reporter.Reporter"
+    _ADMIN_PATH    = "apotrope.utils.is_admin"
+    _PROFILE_PATH  = "apotrope.profile.load_profile"
+
+    def _reporter(self):
+        # A trustworthy, complete report so a valid run reaches exit 0.
+        mock_report = MagicMock(fail_count=0, warn_count=0, error_count=0,
+                                evaluated_count=10, score=90)
+        mock_reporter = MagicMock()
+        mock_reporter.run_with_progress.return_value = mock_report
+        return mock_reporter
+
+    def _patches(self, argv, mock_reporter):
+        # Only Scanner is patched; known_categories() runs for real (importing
+        # a check module does not run its checks, so this stays OS-independent).
+        return (
+            patch("sys.argv", ["apotrope"] + argv),
+            patch(self._SCANNER_PATH, return_value=MagicMock(is_admin=False)),
+            patch(self._REPORTER_PATH, return_value=mock_reporter),
+            patch(self._ADMIN_PATH, return_value=False),
+            patch(self._PROFILE_PATH, return_value=MagicMock()),
+        )
+
+    def _run(self, argv, mock_reporter):
+        from apotrope.cli import main
+        p1, p2, p3, p4, p5 = self._patches(argv, mock_reporter)
+        with p1, p2, p3, p4, p5:
+            main()
+
+    def test_unknown_category_exits_2(self, capsys):
+        rep = self._reporter()
+        with pytest.raises(SystemExit) as exc:
+            self._run(["--category", "firewal"], rep)
+        assert exc.value.code == 2
+        assert "unknown categor" in capsys.readouterr().err
+        rep.run_with_progress.assert_not_called()
+
+    def test_blank_category_token_exits_2(self, capsys):
+        rep = self._reporter()
+        with pytest.raises(SystemExit) as exc:
+            self._run(["--category", "firewall,,"], rep)
+        assert exc.value.code == 2
+        assert "empty category name" in capsys.readouterr().err
+
+    def test_comma_only_category_exits_2(self):
+        rep = self._reporter()
+        with pytest.raises(SystemExit) as exc:
+            self._run(["--category", ","], rep)
+        assert exc.value.code == 2
+
+    def test_valid_categories_lowercased_and_passed(self):
+        rep = self._reporter()
+        p1, p2, p3, p4, p5 = self._patches(["--category", "Firewall,PATCHING"], rep)
+        with p1, p2 as MockScanner, p3, p4, p5:
+            from apotrope.cli import main
+            main()
+        assert MockScanner.call_args[1]["categories"] == ["firewall", "patching"]
+
+
+class TestExitCodes:
+    """Exit code reflects assessment trustworthiness, not only the score."""
+    _SCANNER_PATH  = "apotrope.scanner.Scanner"
+    _REPORTER_PATH = "apotrope.reporter.Reporter"
+    _ADMIN_PATH    = "apotrope.utils.is_admin"
+    _PROFILE_PATH  = "apotrope.profile.load_profile"
+
+    def _run(self, *, evaluated_count, error_count, score):
+        mock_report = MagicMock(fail_count=0, warn_count=0,
+                                evaluated_count=evaluated_count,
+                                error_count=error_count, score=score)
+        mock_reporter = MagicMock()
+        mock_reporter.run_with_progress.return_value = mock_report
+        from apotrope.cli import main
+        with (
+            patch("sys.argv", ["apotrope"]),
+            patch(self._SCANNER_PATH, return_value=MagicMock(is_admin=False)),
+            patch(self._REPORTER_PATH, return_value=mock_reporter),
+            patch(self._ADMIN_PATH, return_value=False),
+            patch(self._PROFILE_PATH, return_value=MagicMock()),
+        ):
+            main()
+
+    def test_exit_2_when_zero_controls_evaluated(self):
+        # The false-assurance case: nothing ran, score defaults to 100.
+        with pytest.raises(SystemExit) as exc:
+            self._run(evaluated_count=0, error_count=0, score=100)
+        assert exc.value.code == 2
+
+    def test_exit_2_when_any_error(self):
+        with pytest.raises(SystemExit) as exc:
+            self._run(evaluated_count=12, error_count=1, score=100)
+        assert exc.value.code == 2
+
+    def test_exit_1_when_complete_and_failing(self):
+        with pytest.raises(SystemExit) as exc:
+            self._run(evaluated_count=12, error_count=0, score=55)
+        assert exc.value.code == 1
+
+    def test_exit_0_when_complete_and_passing(self):
+        # Returns normally (no SystemExit).
+        self._run(evaluated_count=12, error_count=0, score=85)
+
+
 # ---------------------------------------------------------------------------
 # python -m apotrope entry point
 # ---------------------------------------------------------------------------

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -38,3 +38,30 @@ class TestByCategory:
     def test_unknown_category_returns_empty(self):
         report = _report([_result("Firewall")])
         assert report.by_category("Nope") == []
+
+
+def _status_result(status: Status) -> CheckResult:
+    return CheckResult(
+        category="Test", check_name="x", status=status,
+        severity=Severity.LOW, description="d", details="ok",
+    )
+
+
+class TestEvaluatedCount:
+    def test_counts_pass_fail_warn_only(self):
+        report = _report([
+            _status_result(Status.PASS),
+            _status_result(Status.FAIL),
+            _status_result(Status.WARN),
+            _status_result(Status.INFO),
+            _status_result(Status.ERROR),
+        ])
+        # INFO and ERROR are not evaluated controls.
+        assert report.evaluated_count == 3
+
+    def test_all_error_report_evaluates_nothing(self):
+        report = _report([_status_result(Status.ERROR), _status_result(Status.ERROR)])
+        assert report.evaluated_count == 0
+
+    def test_empty_report_evaluates_nothing(self):
+        assert _report([]).evaluated_count == 0

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -936,6 +936,23 @@ class TestBuildExecutiveSummary:
         s = self._summary(results, score=100)
         assert "pass" in s.lower() or "no failure" in s.lower()
 
+    def test_all_error_report_not_marked_clean(self):
+        # Every check errored: score is 100 (ERROR does not deduct) but the
+        # machine was never actually assessed — must not claim "all passed".
+        results = [
+            CheckResult("Firewall", "FW", Status.ERROR, Severity.INFO, "d", "boom"),
+            CheckResult("Accounts", "AC", Status.ERROR, Severity.INFO, "d", "boom"),
+        ]
+        s = self._summary(results, score=100)
+        assert "all checks passed" not in s.lower()
+        assert "best practices" not in s.lower()
+        assert "could not complete" in s.lower()
+
+    def test_empty_report_not_marked_clean(self):
+        s = self._summary([], score=100)
+        assert "all checks passed" not in s.lower()
+        assert "best practices" not in s.lower()
+
     def test_critical_failures_called_out(self):
         results = [
             CheckResult("Firewall", "FW", Status.FAIL, Severity.CRITICAL, "d", "off", "fix"),

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -216,6 +216,35 @@ class TestModuleErrorHandling:
         results = scanner._run_module(mod)
         assert results[0].status == Status.ERROR
 
+    def test_empty_list_becomes_error(self):
+        # A module that returns [] must not silently vanish (it would leave the
+        # score at 100). It is turned into a synthetic ERROR result instead.
+        scanner = Scanner()
+        mod = ModuleType("empty_mod")
+        mod.CATEGORY = "Test"
+        mod.run = lambda: []
+        results = scanner._run_module(mod)
+        assert len(results) == 1
+        assert results[0].status == Status.ERROR
+        assert "empty list" in results[0].details
+
+    def test_non_checkresult_element_becomes_error(self):
+        scanner = Scanner()
+        mod = ModuleType("junk_mod")
+        mod.CATEGORY = "Test"
+        mod.run = lambda: ["not a CheckResult"]
+        results = scanner._run_module(mod)
+        assert len(results) == 1
+        assert results[0].status == Status.ERROR
+        assert "non-CheckResult" in results[0].details
+
+    def test_valid_results_untouched(self):
+        scanner = Scanner()
+        mod = _make_module(results=[_pass_result()])
+        results = scanner._run_module(mod)
+        assert len(results) == 1
+        assert results[0].status == Status.PASS
+
 
 # ---------------------------------------------------------------------------
 # Timing
@@ -390,6 +419,39 @@ class TestDiscoverModules:
             mods = Scanner()._discover_modules()
         assert mods == [good]
         imp.assert_called_once_with("apotrope.checks.frozen_mod")
+
+    def test_known_categories_contains_expected(self):
+        from apotrope.scanner import known_categories
+
+        cats = known_categories()
+        # Tokens are the modules' CATEGORY values, not their filenames.
+        assert {"firewall", "patching", "access control", "file sharing"} <= cats
+        assert "uac" not in cats       # filename, not a CATEGORY value
+        assert "updates" not in cats
+
+    def test_known_categories_frozen_uses_registry(self):
+        import sys
+        from apotrope.scanner import known_categories
+
+        good = _make_module("apotrope.checks.frozen_mod", "Frozen")
+        with (
+            patch.object(sys, "frozen", True, create=True),
+            patch("apotrope.checks.MODULES", ["frozen_mod"]),
+            patch("apotrope.scanner.importlib.import_module", return_value=good),
+        ):
+            assert known_categories() == {"frozen"}
+
+    def test_known_categories_skips_import_failures(self):
+        from types import SimpleNamespace
+        from apotrope.scanner import known_categories
+
+        with (
+            patch("apotrope.scanner.pkgutil.iter_modules",
+                  return_value=[SimpleNamespace(name="broken")]),
+            patch("apotrope.scanner.importlib.import_module",
+                  side_effect=ImportError("nope")),
+        ):
+            assert known_categories() == set()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

An incomplete assessment could silently look healthy. Three paths all produced **score 100 / grade A / exit 0** on a machine that was never actually audited:

- an unknown or blank `--category` discovered 0 modules;
- a check module returning `[]` or a non-`CheckResult` element vanished from the report;
- an all-`ERROR` run (e.g. `powershell.exe` blocked) deducts nothing, so the score stays 100.

This is the highest-priority class from the reconciled review.

## What changed (smallest diffs)

- **cli**: validate `--category` against the real known category set (derived from each module's `CATEGORY`); `parser.error` → exit 2 on unknown/blank tokens, before scanning.
- **scanner**: an empty or non-`CheckResult` `run()` result becomes a synthetic `ERROR` instead of silently disappearing.
- **cli**: exit **2** when zero controls were evaluated or any check errored; keep exit 1 for a complete failing score. `ERROR` still never changes the score (scoring unchanged) — it only affects the exit code.
- **reporter**: the "all checks passed … best practices" summary (plain + HTML) now requires ≥1 evaluated control and no errors, so all-ERROR/empty reports read honestly.
- **models**: add `AuditReport.evaluated_count` (PASS + FAIL + WARN).

## Tests

885 passed, 99% coverage (95% gate). New: unknown/blank/comma-only category → exit 2; `[]`/non-`CheckResult` → ERROR; exit 2 on zero-evaluated and on any-ERROR, exit 1 on complete<70, exit 0 on complete≥70; all-ERROR & empty reports never say "all checks passed"; `evaluated_count` semantics.