### PR TITLE
Execution & remediation safety: absolute powershell.exe, no TPM clear, no bare reboots

### DIFF
--- a/src/apotrope/checks/os_info.py
+++ b/src/apotrope/checks/os_info.py
@@ -315,7 +315,9 @@ def _check_uptime() -> list[CheckResult]:
             description=f"Warns when uptime exceeds {_UPTIME_WARN_DAYS} days (suggests pending patch reboots).",
             details=f"System has been running for {days} days without a reboot.",
             remediation="Schedule a reboot to apply deferred updates.",
-            command="Restart-Computer",
+            # Reboot is a manual, maintenance-window action — never a copy-paste
+            # command that could restart the machine unattended.
+            command="# Reboot during a maintenance window to apply deferred updates:\n# Restart-Computer",
         )]
 
     return [CheckResult(
@@ -444,12 +446,16 @@ def _check_tpm() -> list[CheckResult]:
         details=f"TPM present. Ready: {ready}. Firmware version: {version}.",
         remediation=(
             "" if ready else
-            "Initialize the TPM and take ownership so it is ready for use."
+            "Initialize the TPM and take ownership so it is ready for use. Follow "
+            "Windows Security / your device vendor's guidance and ensure any "
+            "BitLocker recovery key is escrowed first — do not clear the TPM."
         ),
         command=(
             "" if ready else
-            "Get-Tpm\n"
-            "Initialize-Tpm -AllowClear -AllowPhysicalPresence"
+            # Read-only diagnostics only. A TPM clear (Initialize-Tpm -AllowClear /
+            # Clear-Tpm) can invalidate BitLocker protectors and force recovery, so
+            # it must never be a copy-paste command.
+            "Get-Tpm"
         ),
     )]
 

--- a/src/apotrope/checks/uac.py
+++ b/src/apotrope/checks/uac.py
@@ -111,7 +111,9 @@ def _check_uac_enabled(data: dict) -> list[CheckResult]:
         command=(
             "" if enabled else
             f"Set-ItemProperty -Path '{_REG_KEY}' -Name 'EnableLUA' -Value 1\n"
-            "Restart-Computer"
+            # Reboot required for the change to take effect — kept as a manual
+            # step so pasting the block cannot restart the machine unattended.
+            "# Reboot required for UAC to take effect:\n# Restart-Computer"
         ),
     )]
 

--- a/src/apotrope/exceptions.py
+++ b/src/apotrope/exceptions.py
@@ -9,3 +9,15 @@ class ApotropeError(Exception):
     Examples: PowerShell non-zero exit, timeout, JSON parse failure,
     access-denied registry read, or running on a non-Windows platform.
     """
+
+
+class PowerShellUnavailableError(ApotropeError):
+    """Raised when a trusted ``powershell.exe`` cannot be resolved at all.
+
+    Distinct from a plain :class:`ApotropeError` because the two mean different
+    things to a caller. A plain one is *this query* failed, and helpers such as
+    ``read_registry`` / ``get_wmi_object`` legitimately degrade to ``None`` /
+    ``[]``. This one means *no query can succeed*, so degrading would turn a
+    total execution failure into confident PASS/FAIL verdicts derived from no
+    data. Helpers re-raise it instead.
+    """

--- a/src/apotrope/scanner.py
+++ b/src/apotrope/scanner.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from apotrope import checks as checks_pkg
+from apotrope.exceptions import PowerShellUnavailableError
 from apotrope.models import AuditReport, CheckResult, Status, Severity
 from apotrope.scoring import calculate_score
 from apotrope.utils import get_wmi_object
@@ -333,7 +334,17 @@ class Scanner:
         denied, or a missing/non-integer value — so ``family_for_build`` falls
         back to build-only classification.
         """
-        rows = get_wmi_object("Win32_OperatingSystem", properties=["ProductType"])
+        try:
+            rows = get_wmi_object("Win32_OperatingSystem", properties=["ProductType"])
+        except PowerShellUnavailableError:
+            # get_wmi_object re-raises this rather than degrading to [], because
+            # for a *check* an empty result would read as "none found". Here the
+            # documented contract is None-on-unreadable, and this call sits in
+            # Scanner.run() after every module has already produced its results —
+            # letting it escape would unwind to cli.main()'s handler and discard
+            # the entire report on exactly the machine this case describes.
+            log.warning("Cannot determine ProductType: PowerShell is unavailable")
+            return None
         if not rows:
             return None
         product_type = rows[0].get("ProductType")

--- a/src/apotrope/utils.py
+++ b/src/apotrope/utils.py
@@ -14,6 +14,7 @@ import ntpath
 import os
 import subprocess
 import sys
+from typing import cast
 
 from apotrope.exceptions import ApotropeError, PowerShellUnavailableError
 
@@ -70,7 +71,11 @@ def _system_windows_directory() -> str:
             f"GetSystemWindowsDirectoryW failed (error {last_error})"
         )
 
-    path = buf[:written]
+    # cast: ctypes special-cases c_wchar arrays so slicing one returns str, but
+    # typeshed declares Array.__getitem__(slice) as list[T]. Only the Windows
+    # mypy legs see this — the sys.platform guard above makes the whole function
+    # unreachable to mypy on Linux, so the ubuntu legs never type-check it.
+    path = cast("str", buf[:written])
     # ntpath, not os.path: this is always a Windows path, and os.path is
     # posixpath on the Linux CI legs where the mocked tests run.
     if not ntpath.isabs(path):

--- a/src/apotrope/utils.py
+++ b/src/apotrope/utils.py
@@ -10,16 +10,78 @@ from __future__ import annotations
 import ctypes
 import json
 import logging
+import ntpath
 import os
 import subprocess
 import sys
 
-from apotrope.exceptions import ApotropeError
+from apotrope.exceptions import ApotropeError, PowerShellUnavailableError
 
 log = logging.getLogger(__name__)
 
+_MAX_PATH = 260
+
+
+def _system_windows_directory() -> str:
+    """Return the shared Windows directory, via Win32 rather than the environment.
+
+    ``%SystemRoot%`` is part of the process environment block, which is supplied
+    by whoever created the process — so a hostile parent that elevates Apotrope
+    can point it at a directory it controls. ``GetSystemWindowsDirectoryW`` asks
+    the kernel instead. It is preferred over ``GetWindowsDirectoryW`` because
+    under Terminal Services / RDS the latter returns a *per-user* private
+    directory, while this one always returns the shared system directory where
+    the real ``powershell.exe`` lives.
+
+    Raises:
+        ApotropeError: If the API fails or returns anything but an absolute path.
+            Failing closed matters: the documented failure modes leave the buffer
+            untouched, and a caller that used it anyway would build the *relative*
+            path ``System32\\...\\powershell.exe`` and resolve it against the
+            current directory — reinstating the very hijack this exists to close.
+    """
+    if sys.platform != "win32":
+        # Unreachable via _powershell_path, which returns early off Windows.
+        # Kept explicit so the ctypes.WinDLL access below type-checks on the
+        # Linux CI legs, where typeshed marks it win32-only.
+        raise ApotropeError("GetSystemWindowsDirectoryW is Windows-only")
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    get_dir = kernel32.GetSystemWindowsDirectoryW
+    # uSize is documented in TCHARs (WCHARs here), NOT bytes: passing
+    # ctypes.sizeof(buf) would claim twice the real capacity and invite the API
+    # to write past the end of the allocation.
+    get_dir.argtypes = (ctypes.c_wchar_p, ctypes.c_uint)
+    get_dir.restype = ctypes.c_uint
+
+    # On success the return value is the length excluding the terminating null,
+    # so it is strictly less than uSize. If the buffer is too small the return
+    # value is instead the required size *including* the null, and nothing was
+    # copied — hence ``>=`` rather than ``>`` for the too-small test.
+    buf = ctypes.create_unicode_buffer(_MAX_PATH)
+    written = get_dir(buf, len(buf))
+    if written >= len(buf):
+        buf = ctypes.create_unicode_buffer(written)
+        written = get_dir(buf, len(buf))
+    if written == 0 or written >= len(buf):
+        # get_last_error only exists on a Windows ctypes build; the mocked tests
+        # reach here with sys.platform patched on Linux.
+        last_error = getattr(ctypes, "get_last_error", lambda: 0)()
+        raise ApotropeError(
+            f"GetSystemWindowsDirectoryW failed (error {last_error})"
+        )
+
+    path = buf[:written]
+    # ntpath, not os.path: this is always a Windows path, and os.path is
+    # posixpath on the Linux CI legs where the mocked tests run.
+    if not ntpath.isabs(path):
+        raise ApotropeError(
+            f"GetSystemWindowsDirectoryW returned a relative path: {path!r}"
+        )
+    return path
+
+
 def _powershell_path() -> str:
-    """Return the absolute path to Windows PowerShell.
+    """Resolve the absolute path to Windows PowerShell.
 
     Resolving the full ``System32`` path — ``Sysnative`` first so a 32-bit
     process on 64-bit Windows still reaches the native binary — avoids the
@@ -28,30 +90,73 @@ def _powershell_path() -> str:
     directory ahead of the real one. On Windows we fail closed (never fall back
     to a ``PATH``/CWD search) if the trusted binary is missing; off Windows the
     bare name is returned so the mocked test suite is unaffected.
+
+    Deliberately pure and uncached — :func:`_ps_executable` owns the caching, so
+    tests can drive this directly without cross-test contamination.
     """
     if sys.platform != "win32":
         return "powershell.exe"
-    system_root = os.environ.get("SystemRoot", r"C:\Windows")
+    system_root = _system_windows_directory()
     for subdir in ("Sysnative", "System32"):
         candidate = os.path.join(
             system_root, subdir, "WindowsPowerShell", "v1.0", "powershell.exe"
         )
         if os.path.isfile(candidate):
             return candidate
-    raise ApotropeError(
-        r"Trusted powershell.exe not found under %SystemRoot%\System32"
+    raise PowerShellUnavailableError(
+        rf"Trusted powershell.exe not found under {system_root}\System32"
     )
 
 
+# Resolution result, cached after the first attempt. A dict rather than a plain
+# module global so the cache is *mutated* rather than rebound — no ``global``
+# statement, and therefore no lint suppression, for what is only a memo.
+# Both outcomes are cached: retrying a failure once per helper call would mean
+# ~39 identical failures and ~39 identical log lines in a single scan.
+_ps_resolution: dict[str, str | PowerShellUnavailableError] = {}
+
+
+def _ps_executable() -> str:
+    """Return the cached PowerShell path, resolving it on first use.
+
+    Resolution is deliberately *lazy*. Doing it at import time meant a machine
+    without a trusted ``powershell.exe`` raised while ``apotrope.utils`` was
+    still being imported — an uncaught traceback that killed ``--dry-run`` and
+    exited 1, which the CLI documents as "complete assessment, failing score".
+
+    Raises:
+        PowerShellUnavailableError: If the trusted binary cannot be resolved.
+    """
+    if "exe" not in _ps_resolution:
+        try:
+            _ps_resolution["exe"] = _powershell_path()
+        except ApotropeError as exc:
+            _ps_resolution["exe"] = PowerShellUnavailableError(str(exc))
+    resolved = _ps_resolution["exe"]
+    if isinstance(resolved, PowerShellUnavailableError):
+        raise resolved
+    return resolved
+
+
+def _reset_ps_cache() -> None:
+    """Clear the cached resolution. For tests; see ``tests/conftest.py``."""
+    _ps_resolution.clear()
+
+
 # Base PowerShell invocation flags shared by every helper
-_PS_CMD = [
-    _powershell_path(),
+_PS_FLAGS = [
     "-NonInteractive",
     "-NoProfile",
     "-ExecutionPolicy",
     "Bypass",
     "-Command",
 ]
+
+
+def _ps_argv(command: str) -> list[str]:
+    """Build the full argv for a PowerShell invocation of *command*."""
+    return [_ps_executable(), *_PS_FLAGS, command]
+
 
 # Force PowerShell to emit UTF-8 so the ``encoding="utf-8"`` decode below is
 # correct for localized / non-ASCII output (service names, usernames), instead
@@ -60,17 +165,45 @@ _OUTPUT_ENCODING_PREAMBLE = "[Console]::OutputEncoding=[System.Text.Encoding]::U
 
 
 def _child_env() -> dict[str, str]:
-    """Environment for powershell.exe children, minus ``PSModulePath``.
+    """Environment for powershell.exe children.
 
-    A PowerShell 7 parent leaves its own Core-only module paths in the
-    inherited ``PSModulePath``; Windows PowerShell 5.1 then resolves modules
-    that exist in both editions (e.g. Microsoft.PowerShell.Security, home of
+    Two adjustments to the inherited environment:
+
+    ``PSModulePath`` is stripped. A PowerShell 7 parent leaves its own Core-only
+    module paths there; Windows PowerShell 5.1 then resolves modules that exist
+    in both editions (e.g. Microsoft.PowerShell.Security, home of
     ``Get-ExecutionPolicy``) to the PS7 copy and fails to load it. pwsh strips
     its paths when launching powershell.exe itself, but a Python parent passes
-    the environment through raw, so we strip the variable here — powershell.exe
-    rebuilds its correct default when it is absent.
+    the environment through raw — powershell.exe rebuilds its correct default
+    when the variable is absent.
+
+    ``SystemRoot``, ``windir`` and ``PATH`` are pinned to the kernel-reported
+    Windows directory. :func:`_powershell_path` goes to some trouble to resolve
+    a *trustworthy* binary; handing that binary an attacker-supplied
+    ``%SystemRoot%`` and ``%PATH%`` would let the hostile parent redirect what
+    the script it runs then loads. Off Windows the values are left alone, since
+    the whole path is mocked there.
     """
-    return {k: v for k, v in os.environ.items() if k.lower() != "psmodulepath"}
+    env = {k: v for k, v in os.environ.items() if k.lower() != "psmodulepath"}
+    if sys.platform != "win32":
+        return env
+    try:
+        system_root = _system_windows_directory()
+    except ApotropeError:
+        # Nothing trustworthy to pin to. run_powershell will fail at
+        # _ps_executable() anyway; don't mask that with a second error here.
+        return env
+    env["SystemRoot"] = system_root
+    env["windir"] = system_root
+    # ntpath and an explicit ';' — this is a Windows PATH, and os.path/os.pathsep
+    # are the posix flavours on the Linux CI legs where the mocked tests run.
+    env["PATH"] = ";".join((
+        ntpath.join(system_root, "System32"),
+        system_root,
+        ntpath.join(system_root, "System32", "Wbem"),
+        ntpath.join(system_root, "System32", "WindowsPowerShell", "v1.0"),
+    ))
+    return env
 
 
 # ---------------------------------------------------------------------------
@@ -94,7 +227,7 @@ def run_powershell(command: str, timeout: int = 30) -> str:
     log.debug("run_powershell: %s", command[:200])
     try:
         result = subprocess.run(
-            [*_PS_CMD, _OUTPUT_ENCODING_PREAMBLE + command],
+            _ps_argv(_OUTPUT_ENCODING_PREAMBLE + command),
             capture_output=True,
             text=True,
             encoding="utf-8",
@@ -220,6 +353,11 @@ def read_registry(hive: str, path: str, value_name: str) -> str | int | None:
 
     try:
         output = run_powershell(script)
+    except PowerShellUnavailableError:
+        # No PowerShell at all: every read would fail identically. Returning
+        # None here would read as "value not set" and produce a confident
+        # verdict from no data, so let it propagate.
+        raise
     except ApotropeError as exc:
         log.warning(
             "Registry read failed (%s\\%s\\%s): %s", hive, path, value_name, exc
@@ -276,6 +414,9 @@ def get_wmi_object(
 
     try:
         output = run_powershell(script)
+    except PowerShellUnavailableError:
+        # See read_registry: [] would read as "no instances found".
+        raise
     except ApotropeError as exc:
         log.warning("WMI query failed for %s: %s", wmi_class, exc)
         return []

--- a/src/apotrope/utils.py
+++ b/src/apotrope/utils.py
@@ -18,15 +18,45 @@ from apotrope.exceptions import ApotropeError
 
 log = logging.getLogger(__name__)
 
+def _powershell_path() -> str:
+    """Return the absolute path to Windows PowerShell.
+
+    Resolving the full ``System32`` path — ``Sysnative`` first so a 32-bit
+    process on 64-bit Windows still reaches the native binary — avoids the
+    executable-search hijack where an elevated run would otherwise pick up a
+    ``powershell.exe`` planted in the application directory or the current
+    directory ahead of the real one. On Windows we fail closed (never fall back
+    to a ``PATH``/CWD search) if the trusted binary is missing; off Windows the
+    bare name is returned so the mocked test suite is unaffected.
+    """
+    if sys.platform != "win32":
+        return "powershell.exe"
+    system_root = os.environ.get("SystemRoot", r"C:\Windows")
+    for subdir in ("Sysnative", "System32"):
+        candidate = os.path.join(
+            system_root, subdir, "WindowsPowerShell", "v1.0", "powershell.exe"
+        )
+        if os.path.isfile(candidate):
+            return candidate
+    raise ApotropeError(
+        r"Trusted powershell.exe not found under %SystemRoot%\System32"
+    )
+
+
 # Base PowerShell invocation flags shared by every helper
 _PS_CMD = [
-    "powershell.exe",
+    _powershell_path(),
     "-NonInteractive",
     "-NoProfile",
     "-ExecutionPolicy",
     "Bypass",
     "-Command",
 ]
+
+# Force PowerShell to emit UTF-8 so the ``encoding="utf-8"`` decode below is
+# correct for localized / non-ASCII output (service names, usernames), instead
+# of depending on the host's OEM/ANSI console code page.
+_OUTPUT_ENCODING_PREAMBLE = "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8; "
 
 
 def _child_env() -> dict[str, str]:
@@ -64,9 +94,11 @@ def run_powershell(command: str, timeout: int = 30) -> str:
     log.debug("run_powershell: %s", command[:200])
     try:
         result = subprocess.run(
-            [*_PS_CMD, command],
+            [*_PS_CMD, _OUTPUT_ENCODING_PREAMBLE + command],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
             env=_child_env(),
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,20 @@ import pytest
 from apotrope.models import AuditReport, CheckResult, Severity, Status
 
 
+@pytest.fixture(autouse=True)
+def _reset_powershell_cache():
+    """Clear the cached PowerShell resolution between tests.
+
+    ``utils._ps_executable()`` caches both outcomes in a module global. Without
+    this, whichever test resolves first would decide the value every later test
+    sees — an order-dependent failure that looks like flakiness.
+    """
+    from apotrope import utils
+    utils._reset_ps_cache()
+    yield
+    utils._reset_ps_cache()
+
+
 @pytest.fixture()
 def pass_result() -> CheckResult:
     """A sample PASS CheckResult."""

--- a/tests/test_checks/test_os_info.py
+++ b/tests/test_checks/test_os_info.py
@@ -243,6 +243,15 @@ class TestCheckUptime:
         assert "45 days" in results[0].details
         assert results[0].remediation != ""
 
+    def test_uptime_reboot_command_is_commented(self):
+        # A bare Restart-Computer would restart the machine the moment the
+        # block is pasted; the reboot must be a commented manual step.
+        with patch("apotrope.checks.os_info.run_powershell", return_value="45"):
+            results = os_info._check_uptime()
+        active = [ln for ln in results[0].command.splitlines()
+                  if not ln.strip().startswith("#")]
+        assert not any("Restart-Computer" in ln for ln in active)
+
     def test_ps_error_returns_error_result(self):
         with patch("apotrope.checks.os_info.run_powershell",
                    side_effect=ApotropeError("timeout")):
@@ -337,6 +346,17 @@ class TestCheckTpm:
                    return_value=_tpm_json(present=True, ready=False)):
             results = os_info._check_tpm()
         assert results[0].status == Status.WARN
+
+    def test_tpm_not_ready_command_is_readonly(self):
+        # The "not ready" remediation must never ship a TPM-clear: -AllowClear /
+        # Clear-Tpm can invalidate BitLocker protectors and force recovery.
+        with patch("apotrope.checks.os_info.run_powershell_json",
+                   return_value=_tpm_json(present=True, ready=False)):
+            cmd = os_info._check_tpm()[0].command
+        assert "AllowClear" not in cmd
+        assert "AllowPhysicalPresence" not in cmd
+        assert "Initialize-Tpm" not in cmd
+        assert "Clear-Tpm" not in cmd
 
     def test_no_tpm_returns_warn(self):
         with patch("apotrope.checks.os_info.run_powershell_json",

--- a/tests/test_checks/test_uac.py
+++ b/tests/test_checks/test_uac.py
@@ -41,6 +41,14 @@ class TestCheckUacEnabled:
         assert r.severity == Severity.CRITICAL
         assert "EnableLUA" in r.command
 
+    def test_uac_disabled_reboot_command_is_commented(self):
+        # The EnableLUA fix requires a reboot, but a bare Restart-Computer must
+        # not restart the machine the moment the block is pasted.
+        r = uac._check_uac_enabled(_data(lua=0))[0]
+        active = [ln for ln in r.command.splitlines()
+                  if not ln.strip().startswith("#")]
+        assert not any("Restart-Computer" in ln for ln in active)
+
     def test_uac_absent_is_warn(self):
         r = uac._check_uac_enabled({})[0]
         assert r.status == Status.WARN

--- a/tests/test_remediation_commands.py
+++ b/tests/test_remediation_commands.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
 
-from command_audit import collect_commands, lint_commands  # noqa: E402
+from command_audit import Command, collect_commands, lint_commands  # noqa: E402
 
 
 def test_command_inventory_is_populated() -> None:
@@ -48,3 +48,19 @@ def test_no_broken_remediation_commands() -> None:
         raise AssertionError(
             f"{len(violations)} remediation command(s) match a runtime-failure pattern:\n{report}"
         )
+
+
+def test_destructive_command_rule_flags_tpm_clear_and_bare_reboot() -> None:
+    planted = [
+        Command("fake.py", 1, "Get-Tpm\nInitialize-Tpm -AllowClear -AllowPhysicalPresence"),
+        Command("fake.py", 2, "Restart-Computer"),
+        Command("fake.py", 3, "Clear-Tpm"),
+    ]
+    destructive = [v for v in lint_commands(planted) if v.rule == "destructive-command"]
+    assert len(destructive) == 3
+
+
+def test_commented_reboot_is_not_flagged_destructive() -> None:
+    # A reboot kept as a comment is safe — the lint only inspects active lines.
+    ok = [Command("fake.py", 1, "Set-ItemProperty -Path X -Name Y -Value 1\n# Restart-Computer")]
+    assert not [v for v in lint_commands(ok) if v.rule == "destructive-command"]

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -584,3 +584,38 @@ class TestApplyCisReferences:
         result.cis_reference = "CIS 1.2.3"
         Scanner._apply_cis_references([result])
         assert result.cis_reference == "CIS 1.2.3"
+
+
+# ---------------------------------------------------------------------------
+# PowerShell unavailable must not discard the report
+# ---------------------------------------------------------------------------
+
+class TestPowerShellUnavailable:
+    """_detect_product_type runs *after* every module, outside any handler.
+
+    get_wmi_object re-raises PowerShellUnavailableError rather than degrading to
+    [], because for a check an empty result reads as "none found". Scanner.run
+    must therefore swallow it here: letting it escape would unwind to
+    cli.main()'s handler and throw away a report whose modules already ran.
+    """
+
+    def test_scan_completes_when_powershell_unavailable(self):
+        from apotrope.exceptions import PowerShellUnavailableError
+
+        scanner = Scanner()
+        mod = _make_module()
+        with patch(
+            "apotrope.scanner.get_wmi_object",
+            side_effect=PowerShellUnavailableError("no powershell"),
+        ):
+            report = scanner.run(modules=[mod])      # must not raise
+        assert len(report.results) == 1
+
+    def test_detect_product_type_returns_none_when_unavailable(self):
+        from apotrope.exceptions import PowerShellUnavailableError
+
+        with patch(
+            "apotrope.scanner.get_wmi_object",
+            side_effect=PowerShellUnavailableError("no powershell"),
+        ):
+            assert Scanner._detect_product_type() is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -48,7 +48,8 @@ class TestRunPowershell:
             assert "-NoProfile" in args
             assert "-ExecutionPolicy" in args
             assert "Bypass" in args
-            assert "Get-Date" in args
+            # The command rides in the last argument (behind the UTF-8 preamble).
+            assert any("Get-Date" in a for a in args)
 
     def test_nonzero_exit_raises_apotrope_error(self):
         with patch(
@@ -121,6 +122,53 @@ class TestRunPowershell:
         env = kwargs["env"]
         assert not any(k.lower() == "psmodulepath" for k in env)
         assert env["PATH"] == r"C:\Windows\System32"
+
+
+class TestPowershellExecutable:
+    """powershell.exe is resolved to a trusted absolute path (no PATH/CWD hijack)."""
+
+    def test_resolves_system32_path_on_windows(self):
+        def _isfile(p):
+            return "System32" in p and p.endswith("powershell.exe")
+        with (
+            patch.object(utils.sys, "platform", "win32"),
+            patch.dict("apotrope.utils.os.environ", {"SystemRoot": r"C:\FakeWin"}),
+            patch("apotrope.utils.os.path.isfile", side_effect=_isfile),
+        ):
+            path = utils._powershell_path()
+        assert "System32" in path
+        assert path.endswith("powershell.exe")
+
+    def test_prefers_sysnative_when_present(self):
+        with (
+            patch.object(utils.sys, "platform", "win32"),
+            patch.dict("apotrope.utils.os.environ", {"SystemRoot": r"C:\FakeWin"}),
+            patch("apotrope.utils.os.path.isfile", side_effect=lambda p: "Sysnative" in p),
+        ):
+            assert "Sysnative" in utils._powershell_path()
+
+    def test_fails_closed_when_binary_missing_on_windows(self):
+        with (
+            patch.object(utils.sys, "platform", "win32"),
+            patch("apotrope.utils.os.path.isfile", return_value=False),
+        ):
+            with pytest.raises(ApotropeError, match="Trusted powershell.exe not found"):
+                utils._powershell_path()
+
+    def test_bare_name_off_windows(self):
+        with patch.object(utils.sys, "platform", "linux"):
+            assert utils._powershell_path() == "powershell.exe"
+
+
+class TestSubprocessDecoding:
+    def test_decodes_utf8_and_forces_ps_utf8_output(self):
+        with patch("apotrope.utils.subprocess.run", return_value=_mock_ps("ok")) as mock_run:
+            utils.run_powershell("Get-Thing")
+        _, kwargs = mock_run.call_args
+        assert kwargs["encoding"] == "utf-8"
+        assert kwargs["errors"] == "replace"
+        # PS is told to emit UTF-8 so the decode above is correct for non-ASCII.
+        assert "OutputEncoding" in mock_run.call_args[0][0][-1]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -111,6 +111,11 @@ class TestRunPowershell:
             assert kwargs["timeout"] == 5
 
     def test_psmodulepath_stripped_from_child_env(self):
+        # Only asserts the platform-independent half of _child_env's contract.
+        # PATH is deliberately NOT asserted here: on Windows it is pinned to the
+        # kernel-reported system directory, so an equality check against the
+        # inherited value passes on Linux and fails on the Windows matrix legs.
+        # Both branches are pinned explicitly in the platform-specific tests below.
         polluted = {
             "PSModulePath": r"C:\Program Files\PowerShell\7\Modules",
             "PATH": r"C:\Windows\System32",
@@ -121,7 +126,6 @@ class TestRunPowershell:
                 _, kwargs = mock_run.call_args
         env = kwargs["env"]
         assert not any(k.lower() == "psmodulepath" for k in env)
-        assert env["PATH"] == r"C:\Windows\System32"
 
     def test_child_env_pins_systemroot_and_path_on_windows(self):
         """A trustworthy binary handed an attacker-supplied %SystemRoot% is not safe."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from apotrope.exceptions import ApotropeError
+from apotrope.exceptions import ApotropeError, PowerShellUnavailableError
 from apotrope import utils
 
 
@@ -123,6 +123,39 @@ class TestRunPowershell:
         assert not any(k.lower() == "psmodulepath" for k in env)
         assert env["PATH"] == r"C:\Windows\System32"
 
+    def test_child_env_pins_systemroot_and_path_on_windows(self):
+        """A trustworthy binary handed an attacker-supplied %SystemRoot% is not safe."""
+        hostile = {"SystemRoot": r"C:\Evil", "windir": r"C:\Evil", "PATH": r"C:\Evil"}
+        with (
+            patch.object(utils.sys, "platform", "win32"),
+            patch("apotrope.utils._system_windows_directory", return_value=r"C:\Windows"),
+            patch.dict("apotrope.utils.os.environ", hostile, clear=True),
+        ):
+            env = utils._child_env()
+        assert env["SystemRoot"] == r"C:\Windows"
+        assert env["windir"] == r"C:\Windows"
+        assert "Evil" not in env["PATH"]
+        assert env["PATH"].startswith("C:\\Windows\\System32")
+
+    def test_child_env_left_alone_off_windows(self):
+        with (
+            patch.object(utils.sys, "platform", "linux"),
+            patch.dict("apotrope.utils.os.environ", {"PATH": "/usr/bin"}, clear=True),
+        ):
+            assert utils._child_env()["PATH"] == "/usr/bin"
+
+    def test_child_env_degrades_when_windows_dir_unreadable(self):
+        """Don't mask the real failure with a second one — _ps_executable reports it."""
+        with (
+            patch.object(utils.sys, "platform", "win32"),
+            patch(
+                "apotrope.utils._system_windows_directory",
+                side_effect=ApotropeError("nope"),
+            ),
+            patch.dict("apotrope.utils.os.environ", {"PATH": r"C:\X"}, clear=True),
+        ):
+            assert utils._child_env()["PATH"] == r"C:\X"
+
 
 class TestPowershellExecutable:
     """powershell.exe is resolved to a trusted absolute path (no PATH/CWD hijack)."""
@@ -132,7 +165,7 @@ class TestPowershellExecutable:
             return "System32" in p and p.endswith("powershell.exe")
         with (
             patch.object(utils.sys, "platform", "win32"),
-            patch.dict("apotrope.utils.os.environ", {"SystemRoot": r"C:\FakeWin"}),
+            patch("apotrope.utils._system_windows_directory", return_value=r"C:\FakeWin"),
             patch("apotrope.utils.os.path.isfile", side_effect=_isfile),
         ):
             path = utils._powershell_path()
@@ -142,7 +175,7 @@ class TestPowershellExecutable:
     def test_prefers_sysnative_when_present(self):
         with (
             patch.object(utils.sys, "platform", "win32"),
-            patch.dict("apotrope.utils.os.environ", {"SystemRoot": r"C:\FakeWin"}),
+            patch("apotrope.utils._system_windows_directory", return_value=r"C:\FakeWin"),
             patch("apotrope.utils.os.path.isfile", side_effect=lambda p: "Sysnative" in p),
         ):
             assert "Sysnative" in utils._powershell_path()
@@ -150,14 +183,136 @@ class TestPowershellExecutable:
     def test_fails_closed_when_binary_missing_on_windows(self):
         with (
             patch.object(utils.sys, "platform", "win32"),
+            patch("apotrope.utils._system_windows_directory", return_value=r"C:\FakeWin"),
             patch("apotrope.utils.os.path.isfile", return_value=False),
         ):
             with pytest.raises(ApotropeError, match="Trusted powershell.exe not found"):
                 utils._powershell_path()
 
+    def test_windows_directory_comes_from_win32_not_the_environment(self):
+        """%SystemRoot% is attacker-controllable; it must not steer resolution."""
+        with (
+            patch.object(utils.sys, "platform", "win32"),
+            patch.dict("apotrope.utils.os.environ", {"SystemRoot": r"C:\Evil"}),
+            patch("apotrope.utils._system_windows_directory", return_value=r"C:\FakeWin"),
+            patch("apotrope.utils.os.path.isfile", return_value=True),
+        ):
+            path = utils._powershell_path()
+        assert path.startswith(r"C:\FakeWin")
+        assert "Evil" not in path
+
     def test_bare_name_off_windows(self):
         with patch.object(utils.sys, "platform", "linux"):
             assert utils._powershell_path() == "powershell.exe"
+
+
+class TestSystemWindowsDirectory:
+    """GetSystemWindowsDirectoryW must be called correctly and fail closed.
+
+    A mishandled return value yields an empty buffer, hence the *relative* path
+    ``System32\\...\\powershell.exe`` — which os.path.isfile then resolves
+    against the CWD, reinstating the hijack the helper exists to prevent.
+    """
+
+    @staticmethod
+    def _windll(path: str | None):
+        """kernel32 stub faithful to the documented GetSystemWindowsDirectoryW contract.
+
+        Copies *path* and returns its length when it fits; otherwise copies
+        nothing and returns the required size *including* the null terminator.
+        Pass ``path=None`` to model outright API failure (returns 0).
+        """
+        calls = []
+
+        def _fn(buf, size):
+            calls.append((buf, size))
+            if path is None:
+                return 0
+            if len(path) + 1 > size:
+                return len(path) + 1      # required size, nothing copied
+            buf.value = path
+            return len(path)
+
+        windll = MagicMock()
+        windll.GetSystemWindowsDirectoryW = _fn
+        return windll, calls
+
+    def _run(self, windll):
+        with (
+            patch.object(utils.sys, "platform", "win32"),
+            patch("apotrope.utils.ctypes.WinDLL", return_value=windll, create=True),
+        ):
+            return utils._system_windows_directory()
+
+    def test_returns_the_reported_directory(self):
+        windll, _ = self._windll(r"C:\Windows")
+        assert self._run(windll) == r"C:\Windows"
+
+    def test_buffer_size_is_passed_in_wchars_not_bytes(self):
+        """uSize is TCHARs; sizeof() would claim double and risk a heap overflow."""
+        windll, calls = self._windll(r"C:\Windows")
+        self._run(windll)
+        _, size = calls[0]
+        assert size == utils._MAX_PATH        # 260, not 520
+
+    def test_raises_when_api_returns_zero(self):
+        windll, _ = self._windll(None)
+        with pytest.raises(ApotropeError, match="GetSystemWindowsDirectoryW failed"):
+            self._run(windll)
+
+    def test_retries_once_when_buffer_too_small(self):
+        long_path = "C:\\" + "W" * 300        # longer than MAX_PATH
+        windll, calls = self._windll(long_path)
+        assert self._run(windll) == long_path
+        assert len(calls) == 2
+        assert calls[1][1] == len(long_path) + 1   # resized to the size asked for
+
+    def test_raises_on_a_relative_path(self):
+        """An empty/relative result would build a CWD-relative powershell path."""
+        windll, _ = self._windll("Windows")
+        with pytest.raises(ApotropeError, match="relative path"):
+            self._run(windll)
+
+
+class TestPowerShellResolutionCache:
+    """Resolution is lazy and cached; failure must not silently fail open."""
+
+    def test_resolution_is_lazy_and_cached(self):
+        with patch("apotrope.utils._powershell_path", return_value="ps.exe") as resolve:
+            utils._ps_executable()
+            utils._ps_executable()
+        resolve.assert_called_once()
+
+    def test_failure_is_cached_not_retried(self):
+        boom = ApotropeError("no powershell")
+        with patch("apotrope.utils._powershell_path", side_effect=boom) as resolve:
+            for _ in range(3):
+                with pytest.raises(PowerShellUnavailableError):
+                    utils._ps_executable()
+        resolve.assert_called_once()
+
+    def test_read_registry_reraises_rather_than_returning_none(self):
+        """None would read as 'value not set' and produce a verdict from no data."""
+        with patch(
+            "apotrope.utils.run_powershell",
+            side_effect=PowerShellUnavailableError("no powershell"),
+        ):
+            with pytest.raises(PowerShellUnavailableError):
+                utils.read_registry("HKLM", "SOFTWARE\\X", "Y")
+
+    def test_get_wmi_object_reraises_rather_than_returning_empty(self):
+        with patch(
+            "apotrope.utils.run_powershell",
+            side_effect=PowerShellUnavailableError("no powershell"),
+        ):
+            with pytest.raises(PowerShellUnavailableError):
+                utils.get_wmi_object("Win32_Service")
+
+    def test_ordinary_failures_still_degrade(self):
+        """A per-query failure is not a total one — the old behaviour stands."""
+        with patch("apotrope.utils.run_powershell", side_effect=ApotropeError("denied")):
+            assert utils.read_registry("HKLM", "SOFTWARE\\X", "Y") is None
+            assert utils.get_wmi_object("Win32_Service") == []
 
 
 class TestSubprocessDecoding:

--- a/tools/command_audit.py
+++ b/tools/command_audit.py
@@ -171,6 +171,12 @@ def collect_commands() -> list[Command]:
 _CIM_METHOD = re.compile(r"\)\s*\.\s*[A-Za-z_]\w*\s*\(")
 # angle-bracket placeholder, but NOT a regex named group `(?<name>...)`
 _ANGLE_PLACEHOLDER = re.compile(r"(?<!\?)<[A-Za-z_][\w -]*>")
+# Destructive / unattended-impact commands that must never ship as copy-paste:
+# a TPM clear can invalidate BitLocker protectors; a bare Restart-Computer can
+# reboot the machine the moment the block is pasted. Reboots belong in comments.
+_DESTRUCTIVE = re.compile(
+    r"\b(Clear-Tpm|Restart-Computer|Stop-Computer)\b|-AllowClear\b|-AllowPhysicalPresence\b"
+)
 
 
 def _uncommented_lines(text: str) -> list[str]:
@@ -206,6 +212,13 @@ def lint_commands(commands: list[Command]) -> list[Violation]:
             violations.append(Violation(
                 cmd.module, cmd.line, "angle-bracket-placeholder",
                 "<...> placeholder is parsed as a redirection operator by PowerShell",
+                text,
+            ))
+        if _DESTRUCTIVE.search(active):
+            violations.append(Violation(
+                cmd.module, cmd.line, "destructive-command",
+                "destructive/unattended command (TPM clear or bare reboot) must be a "
+                "commented manual step, not copy-paste",
                 text,
             ))
     return violations


### PR DESCRIPTION
Two security issues and two robustness gaps in how Apotrope runs PowerShell and what it tells operators to paste.

## Why

- **Planted-binary hijack** — `subprocess.run(["powershell.exe", ...])` used the bare name. Windows searches the application directory and the working directory early, so an elevated `apotrope.exe` sitting beside a malicious `powershell.exe` — both freshly downloaded, say — would execute attacker code elevated.
- **Destructive TPM remediation** — the "TPM present but not ready" finding shipped `Initialize-Tpm -AllowClear -AllowPhysicalPresence` as copy-paste. `-AllowClear` can wipe the TPM, invalidate BitLocker protectors and force recovery.
- **Bare reboots** — the uptime and `EnableLUA` remediations ended in a bare `Restart-Computer`, so pasting either block restarts the machine unattended.
- **Locale-dependent decoding** — `text=True` with no explicit encoding decoded PowerShell output using the host code page, so localized output could be corrupted or fail to decode.

## What changed

- **PowerShell is resolved by absolute path.** The Windows directory comes from `GetSystemWindowsDirectoryW`, not `%SystemRoot%` — the environment block is supplied by whoever created the process, so trusting it reinstates the very hijack this closes. Resolution is lazy and cached (a failure is not retried once per query), and `SystemRoot`, `windir` and `PATH` are pinned in the child environment.
- **UTF-8 end to end.** Output is decoded `utf-8` with `errors="replace"`, and a `[Console]::OutputEncoding` preamble makes PowerShell emit UTF-8.
- **`PowerShellUnavailableError`** separates "no query can succeed" from "this query failed". `read_registry` and `get_wmi_object` re-raise it rather than degrading to `None`/`[]`, which callers read as "not set" / "none found" — that would turn a total execution failure into confident verdicts drawn from no data.
- **Unsafe remediations removed.** The TPM command is now a read-only `Get-Tpm`; the uptime and `EnableLUA` reboots are commented manual steps.
- **A lint rule keeps them out.** `tools/command_audit.py` gains a `destructive-command` rule rejecting `Clear-Tpm`, `-AllowClear`, `-AllowPhysicalPresence` and bare `Restart-Computer`/`Stop-Computer` on active (uncommented) lines.

## Notes

The `[Console]::OutputEncoding` preamble is deliberate. It governs how `powershell.exe` **encodes**, not how we decode. Without it the child encodes through a single-byte console code page and unrepresentable characters become `?` *inside the child*, where no parent-side decode can recover them — a Cyrillic- or CJK-named service would be corrupted in the report, the JSON, and every later `--compare`, and as a mangled `check_name` would manufacture phantom findings on both sides of the diff.

**Residual risk:** pinning `SystemRoot`, `windir` and `PATH` closes one leg of the hijack. A hostile parent still controls every other inherited variable.

**Wants real-Windows validation:** PowerShell path resolution native vs WOW64, and the UTF-8 round trip on a non-English install.

## Tests

911 pass. New coverage for path resolution (System32 / Sysnative / fail-closed / off-Windows), the `GetSystemWindowsDirectoryW` buffer protocol (wchar sizing, zero return, retry, relative-path rejection), lazy and cached resolution, the re-raise contract for both helpers, the pinned child environment, and the destructive-command rule firing on planted commands while ignoring commented ones.
