### PR TITLE
Accounts: identify security principals by SID, not localized display name

### DIFF
--- a/src/apotrope/checks/accounts.py
+++ b/src/apotrope/checks/accounts.py
@@ -56,6 +56,15 @@ _PS_SECEDIT = (
     "finally { Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue }"
 )
 
+# The three password-policy controls. These strings key cis_map.py, --compare and
+# profile.disabled_checks, so they are defined once and shared by the evaluators
+# and by the secedit-failure path: a name that appears in only one of the two
+# drops the control out of the report instead of degrading it to ERROR.
+_PW_MIN_LENGTH = "Password Policy — Minimum Length"
+_PW_LOCKOUT = "Password Policy — Account Lockout"
+_PW_COMPLEXITY = "Password Policy — Complexity"
+_PW_POLICY_CHECKS = (_PW_MIN_LENGTH, _PW_LOCKOUT, _PW_COMPLEXITY)
+
 _ADMIN_WARN_THRESHOLD = 2
 _MIN_PW_FAIL = 8
 _MIN_PW_WARN = 12
@@ -238,7 +247,7 @@ def _check_password_policy() -> list[CheckResult]:
     try:
         inf_text = run_powershell(_PS_SECEDIT)
     except ApotropeError as exc:
-        return [_error("Password Policy", str(exc))]
+        return _password_policy_unavailable(exc)
 
     policy = _parse_secedit_inf(inf_text)
     return [
@@ -248,8 +257,35 @@ def _check_password_policy() -> list[CheckResult]:
     ]
 
 
+def _password_policy_unavailable(exc: ApotropeError) -> list[CheckResult]:
+    """Degrade a failed secedit export into one ERROR *per* password-policy control.
+
+    These three ``check_name`` strings key ``cis_map.py``, ``--compare``, and
+    ``profile.disabled_checks``, so collapsing the failure into a single
+    differently-named "Password Policy" result deleted three CIS-mapped rows from
+    the report rather than degrading them: the operator saw no Minimum Length,
+    Account Lockout or Complexity row at all, and a baseline diff read the
+    disappearance as lost coverage on both sides.
+
+    The overwhelmingly common cause is elevation, not a broken machine — secedit
+    exports from ``%windir%\\security\\database\\secedit.sdb``, which is ACL'd to
+    SYSTEM and Administrators only, so the documented non-elevated invocation
+    always lands here. Say that in ``details`` instead of surfacing a bare
+    stderr, and point the remediation at re-running elevated.
+    """
+    detail = (
+        f"Could not export the local security policy ({exc}) — password policy "
+        "was not evaluated. secedit reads a database readable only by SYSTEM and "
+        "Administrators, so a scan run without elevation always reports this."
+    )
+    return [
+        _error(name, detail, remediation="Re-run Apotrope as Administrator to evaluate password policy.")
+        for name in _PW_POLICY_CHECKS
+    ]
+
+
 def _eval_min_length(policy: dict[str, str]) -> CheckResult:
-    name = "Password Policy — Minimum Length"
+    name = _PW_MIN_LENGTH
     raw = policy.get("minimumpasswordlength")
     if raw is None:
         return _error(name, "MinimumPasswordLength missing from the exported security policy.")
@@ -286,7 +322,7 @@ def _eval_min_length(policy: dict[str, str]) -> CheckResult:
 
 
 def _eval_lockout(policy: dict[str, str]) -> CheckResult:
-    name = "Password Policy — Account Lockout"
+    name = _PW_LOCKOUT
     raw = policy.get("lockoutbadcount")
     if raw is None:
         return _error(name, "LockoutBadCount missing from the exported security policy.")
@@ -320,7 +356,7 @@ def _eval_lockout(policy: dict[str, str]) -> CheckResult:
 
 
 def _eval_complexity(policy: dict[str, str]) -> CheckResult:
-    name = "Password Policy — Complexity"
+    name = _PW_COMPLEXITY
     raw = policy.get("passwordcomplexity")
     if raw not in ("0", "1"):
         return _error(
@@ -374,7 +410,11 @@ def _parse_secedit_inf(text: str) -> dict[str, str]:
     return result
 
 
-def _error(check_name: str, details: str) -> CheckResult:
+def _error(
+    check_name: str,
+    details: str,
+    remediation: str = "Run with --log-level DEBUG for more detail.",
+) -> CheckResult:
     return CheckResult(
         category=CATEGORY,
         check_name=check_name,
@@ -382,5 +422,5 @@ def _error(check_name: str, details: str) -> CheckResult:
         severity=Severity.INFO,
         description="An error occurred while running this check.",
         details=details,
-        remediation="Run with --log-level DEBUG for more detail.",
+        remediation=remediation,
     )

--- a/src/apotrope/checks/accounts.py
+++ b/src/apotrope/checks/accounts.py
@@ -1,4 +1,13 @@
-"""Check: Local accounts, Administrators group, and password policy."""
+"""Check: Local accounts, Administrators group, and password policy.
+
+Security principals are identified by SID, not by display name: the built-in
+Administrator/Guest are matched on their RID suffix (-500 / -501) and the
+Administrators group by its well-known SID ``S-1-5-32-544``. This survives
+renamed accounts and non-English Windows, where a name-based lookup silently
+finds nothing. Every query is written so that a failure (access denied, module
+missing) exits non-zero → ``ApotropeError`` → an ERROR result, which is kept
+distinct from a *successful* query that legitimately returns no rows.
+"""
 
 from __future__ import annotations
 
@@ -12,28 +21,39 @@ log = logging.getLogger(__name__)
 
 CATEGORY = "Accounts"
 
-_PS_GUEST = "(Get-LocalUser -Name 'Guest' -ErrorAction SilentlyContinue).Enabled"
+_ADMINISTRATORS_SID = "S-1-5-32-544"
 
-_PS_ADMIN = (
-    "Get-LocalUser -Name 'Administrator' -ErrorAction SilentlyContinue "
-    "| Select-Object Name, Enabled | ConvertTo-Json -Compress"
+# Enumerate every local user with a flat SID string. -ErrorAction Stop + the
+# try/catch turn any failure into exit 1 → ApotropeError, so a denied query is
+# never confused with "no such account". The calculated SID property is required
+# because projecting $_.SID directly serialises a nested object, not the string.
+_PS_LOCAL_USERS = (
+    "try { "
+    "Get-LocalUser -ErrorAction Stop | "
+    "Select-Object Name, Enabled, @{Name='SID';Expression={$_.SID.Value}} | "
+    "ConvertTo-Json -Compress "
+    "} catch { Write-Error $_; exit 1 }"
 )
 
+# Administrators group by well-known SID (locale-neutral), same failure discipline.
 _PS_ADMINS = (
-    "Get-LocalGroupMember -Group 'Administrators' -ErrorAction SilentlyContinue "
-    "| Select-Object Name, PrincipalSource, ObjectClass | ConvertTo-Json -Compress"
+    "try { "
+    f"Get-LocalGroupMember -SID '{_ADMINISTRATORS_SID}' -ErrorAction Stop | "
+    "Select-Object Name, PrincipalSource, ObjectClass | "
+    "ConvertTo-Json -Compress "
+    "} catch { Write-Error $_; exit 1 }"
 )
 
-_PS_NET_ACCOUNTS = "net accounts"
-
-# Export local security policy to a temp file, extract complexity setting, clean up.
-_PS_COMPLEXITY = (
+# One secedit export → locale-neutral INF keys. The $LASTEXITCODE check surfaces a
+# secedit failure that Out-Null would otherwise mask; the temp file is always removed.
+_PS_SECEDIT = (
     "$tmp = [System.IO.Path]::GetTempFileName(); "
-    "secedit /export /cfg $tmp /quiet | Out-Null; "
-    "$c = Get-Content $tmp -ErrorAction SilentlyContinue; "
-    "Remove-Item $tmp -Force -ErrorAction SilentlyContinue; "
-    "$line = $c | Where-Object { $_ -like 'PasswordComplexity*' }; "
-    "if ($line) { ($line -split '=')[1].Trim() } else { 'Unknown' }"
+    "try { "
+    "secedit /export /cfg $tmp /areas SECURITYPOLICY /quiet | Out-Null; "
+    "if ($LASTEXITCODE -ne 0) { throw \"secedit exited $LASTEXITCODE\" }; "
+    "Get-Content -LiteralPath $tmp -ErrorAction Stop "
+    "} catch { Write-Error $_; exit 1 } "
+    "finally { Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue }"
 )
 
 _ADMIN_WARN_THRESHOLD = 2
@@ -57,66 +77,78 @@ def run() -> list[CheckResult]:
     return results
 
 
+def _local_users() -> list[dict]:
+    """Enumerate local users (Name, Enabled, SID). Raises ApotropeError on query failure."""
+    data = run_powershell_json(_PS_LOCAL_USERS)
+    return data if isinstance(data, list) else ([data] if data else [])
+
+
+def _find_by_rid(users: list[dict], rid: str) -> dict | None:
+    """Return the user whose SID ends in ``-<rid>`` (e.g. ``-500``), else ``None``.
+
+    The leading hyphen anchors the match so RID 500 is never confused with 1500.
+    """
+    suffix = f"-{rid}"
+    return next((u for u in users if str(u.get("SID", "")).endswith(suffix)), None)
+
+
 def _check_guest_account() -> list[CheckResult]:
-    """Check whether the built-in Guest account is enabled."""
+    """Check whether the built-in Guest account (RID-501) is disabled."""
     try:
-        output = run_powershell(_PS_GUEST).strip()
+        users = _local_users()
     except ApotropeError as exc:
         return [_error("Guest Account", str(exc))]
 
-    if not output:
+    guest = _find_by_rid(users, "501")
+    if guest is None:
         return [CheckResult(
             category=CATEGORY,
             check_name="Guest Account",
             status=Status.INFO,
             severity=Severity.HIGH,
             description="Checks whether the built-in Guest account is disabled.",
-            details="Guest account not found (may have been renamed or deleted — good practice).",
+            details="Built-in Guest account (RID-501) is not present on this system.",
             remediation="",
         )]
 
-    enabled = output.lower() == "true"
+    enabled = bool(guest.get("Enabled", False))
+    name = str(guest.get("Name", "Guest"))
+    sid = str(guest.get("SID", ""))
     return [CheckResult(
         category=CATEGORY,
         check_name="Guest Account",
         status=Status.FAIL if enabled else Status.PASS,
         severity=Severity.HIGH,
         description="Checks whether the built-in Guest account is disabled.",
-        details=f"Built-in Guest account is {'enabled' if enabled else 'disabled'}.",
-        remediation=(
-            "" if not enabled else
-            "Disable the built-in Guest account."
-        ),
-        command=(
-            "" if not enabled else
-            "Disable-LocalUser -Name 'Guest'"
-        ),
+        details=f"Built-in Guest account ('{name}', RID-501) is "
+                f"{'enabled' if enabled else 'disabled'}.",
+        remediation="" if not enabled else "Disable the built-in Guest account.",
+        command="" if not enabled else f"Disable-LocalUser -SID '{sid}'",
     )]
 
 
 def _check_builtin_admin() -> list[CheckResult]:
-    """Check whether the built-in Administrator account is enabled and/or renamed."""
+    """Check whether the built-in Administrator account (RID-500) is enabled/renamed."""
     try:
-        data = run_powershell_json(_PS_ADMIN)
+        users = _local_users()
     except ApotropeError as exc:
         return [_error("Built-in Administrator Account", str(exc))]
 
-    if not data:
+    admin = _find_by_rid(users, "500")
+    if admin is None:
         return [CheckResult(
             category=CATEGORY,
             check_name="Built-in Administrator Account",
             status=Status.INFO,
             severity=Severity.MEDIUM,
             description="Checks if the built-in Administrator account is enabled and not renamed.",
-            details="Administrator account not found (likely renamed — good practice).",
+            details="Built-in Administrator account (RID-500) is not present on this system.",
             remediation="",
         )]
 
-    if isinstance(data, list):
-        data = data[0] if data else {}
-
-    name = str(data.get("Name", "Administrator"))
-    enabled = bool(data.get("Enabled", False))
+    name = str(admin.get("Name", "Administrator"))
+    enabled = bool(admin.get("Enabled", False))
+    sid = str(admin.get("SID", ""))
     is_default_name = name.lower() == "administrator"
 
     if enabled and is_default_name:
@@ -126,11 +158,8 @@ def _check_builtin_admin() -> list[CheckResult]:
             "Rename the built-in Administrator account and disable it if it is not in active use."
         )
         command = (
-            "# The built-in admin is identified by its well-known RID-500 SID; pick your\n"
-            "# own name in place of 'RenamedAdmin'.\n"
-            "$admin = Get-LocalUser | Where-Object { $_.SID.Value -like 'S-1-5-21-*-500' }\n"
-            "Rename-LocalUser -SID $admin.SID -NewName 'RenamedAdmin'\n"
-            "Disable-LocalUser -SID $admin.SID"
+            f"Rename-LocalUser -SID '{sid}' -NewName 'RenamedAdmin'\n"
+            f"Disable-LocalUser -SID '{sid}'"
         )
     elif enabled:
         status, sev = Status.WARN, Severity.LOW
@@ -138,7 +167,7 @@ def _check_builtin_admin() -> list[CheckResult]:
         remediation = (
             "Consider disabling the built-in Administrator account if it is not in active use."
         )
-        command = f"Disable-LocalUser -Name '{name}'"
+        command = f"Disable-LocalUser -SID '{sid}'"
     else:
         status, sev = Status.PASS, Severity.MEDIUM
         rename_note = f" (renamed to '{name}')" if not is_default_name else ""
@@ -159,13 +188,23 @@ def _check_builtin_admin() -> list[CheckResult]:
 
 
 def _check_admin_count() -> list[CheckResult]:
-    """Count members of the local Administrators group."""
+    """Count members of the local Administrators group (well-known SID S-1-5-32-544)."""
     try:
         data = run_powershell_json(_PS_ADMINS)
     except ApotropeError as exc:
         return [_error("Local Administrators", str(exc))]
 
     members = data if isinstance(data, list) else ([data] if data else [])
+    if not members:
+        # The built-in Administrators group always has at least one member (the
+        # built-in admin). An empty result means the enumeration failed, not that
+        # there are zero admins — report ERROR, never a false "0 administrators" PASS.
+        return [_error(
+            "Local Administrators",
+            "Could not enumerate the Administrators group (S-1-5-32-544 returned no "
+            "members). Re-run as Administrator for a reliable count.",
+        )]
+
     count = len(members)
     # Strip domain prefix from display names
     names = [str(m.get("Name", "Unknown")).split("\\")[-1] for m in members]
@@ -186,80 +225,88 @@ def _check_admin_count() -> list[CheckResult]:
         command=(
             "" if not over_threshold else
             "# List current local administrators\n"
-            "Get-LocalGroupMember -Group 'Administrators'\n"
+            "Get-LocalGroupMember -SID 'S-1-5-32-544'\n"
             "\n"
             "# Remove a standing admin (replace with the account to remove)\n"
-            "Remove-LocalGroupMember -Group 'Administrators' -Member 'CORP\\svc_backup'"
+            "Remove-LocalGroupMember -SID 'S-1-5-32-544' -Member 'CORP\\svc_backup'"
         ),
     )]
 
 
 def _check_password_policy() -> list[CheckResult]:
-    """Check local password policy via net accounts and secedit."""
-    results: list[CheckResult] = []
-
-    # --- net accounts: length and lockout ---
+    """Check local password policy via secedit (locale-neutral INF keys)."""
     try:
-        net_output = run_powershell(_PS_NET_ACCOUNTS)
+        inf_text = run_powershell(_PS_SECEDIT)
     except ApotropeError as exc:
         return [_error("Password Policy", str(exc))]
 
-    policy = _parse_net_accounts(net_output)
+    policy = _parse_secedit_inf(inf_text)
+    return [
+        _eval_min_length(policy),
+        _eval_lockout(policy),
+        _eval_complexity(policy),
+    ]
 
-    # Minimum password length
-    min_len_str = policy.get("minimum password length", "0")
+
+def _eval_min_length(policy: dict[str, str]) -> CheckResult:
+    name = "Password Policy — Minimum Length"
+    raw = policy.get("minimumpasswordlength")
+    if raw is None:
+        return _error(name, "MinimumPasswordLength missing from the exported security policy.")
     try:
-        min_len = int(min_len_str)
+        min_len = int(raw)
     except ValueError:
-        min_len = 0
+        return _error(name, f"MinimumPasswordLength is not an integer: {raw!r}.")
 
     if min_len < _MIN_PW_FAIL:
-        results.append(CheckResult(
-            category=CATEGORY,
-            check_name="Password Policy — Minimum Length",
-            status=Status.FAIL,
-            severity=Severity.HIGH,
-            description=f"Minimum password length must be ≥{_MIN_PW_FAIL} (WARN if <{_MIN_PW_WARN}).",
-            details=f"Minimum password length: {min_len} characters.",
-            remediation=f"Require a minimum password length of {_MIN_PW_TARGET} characters.",
-            command=f"net accounts /minpwlen:{_MIN_PW_TARGET}",
-        ))
+        status, sev = Status.FAIL, Severity.HIGH
+        detail_suffix = ""
     elif min_len < _MIN_PW_WARN:
-        results.append(CheckResult(
-            category=CATEGORY,
-            check_name="Password Policy — Minimum Length",
-            status=Status.WARN,
-            severity=Severity.MEDIUM,
-            description=f"Minimum password length must be ≥{_MIN_PW_FAIL} (WARN if <{_MIN_PW_WARN}).",
-            details=f"Minimum password length: {min_len} characters (recommended: {_MIN_PW_TARGET}+).",
-            remediation=f"Require a minimum password length of {_MIN_PW_TARGET} characters.",
-            command=f"net accounts /minpwlen:{_MIN_PW_TARGET}",
-        ))
+        status, sev = Status.WARN, Severity.MEDIUM
+        detail_suffix = f" (recommended: {_MIN_PW_TARGET}+)"
     else:
-        results.append(CheckResult(
-            category=CATEGORY,
-            check_name="Password Policy — Minimum Length",
-            status=Status.PASS,
-            severity=Severity.MEDIUM,
-            description=f"Minimum password length must be ≥{_MIN_PW_FAIL} (WARN if <{_MIN_PW_WARN}).",
-            details=f"Minimum password length: {min_len} characters.",
-            remediation="",
-        ))
+        status, sev = Status.PASS, Severity.MEDIUM
+        detail_suffix = ""
 
-    # Account lockout
-    lockout_raw = policy.get("lockout threshold", "Never")
-    lockout_disabled = lockout_raw.lower() in ("never", "0", "none", "")
-    lockout_dur = policy.get("lockout duration (minutes)", "N/A")
-    results.append(CheckResult(
+    return CheckResult(
         category=CATEGORY,
-        check_name="Password Policy — Account Lockout",
+        check_name=name,
+        status=status,
+        severity=sev,
+        description=f"Minimum password length must be ≥{_MIN_PW_FAIL} (WARN if <{_MIN_PW_WARN}).",
+        details=f"Minimum password length: {min_len} characters{detail_suffix}.",
+        remediation=(
+            "" if status is Status.PASS else
+            f"Require a minimum password length of {_MIN_PW_TARGET} characters."
+        ),
+        command=(
+            "" if status is Status.PASS else f"net accounts /minpwlen:{_MIN_PW_TARGET}"
+        ),
+    )
+
+
+def _eval_lockout(policy: dict[str, str]) -> CheckResult:
+    name = "Password Policy — Account Lockout"
+    raw = policy.get("lockoutbadcount")
+    if raw is None:
+        return _error(name, "LockoutBadCount missing from the exported security policy.")
+    try:
+        threshold = int(raw)
+    except ValueError:
+        return _error(name, f"LockoutBadCount is not an integer: {raw!r}.")
+
+    lockout_disabled = threshold == 0  # INF 0 = no lockout (unambiguous)
+    duration = policy.get("lockoutduration", "N/A")
+    return CheckResult(
+        category=CATEGORY,
+        check_name=name,
         status=Status.WARN if lockout_disabled else Status.PASS,
         severity=Severity.MEDIUM,
         description="Checks whether account lockout is configured to deter brute-force attacks.",
         details=(
             "Account lockout is disabled — accounts are not locked after failed login attempts."
             if lockout_disabled else
-            f"Lockout threshold: {lockout_raw} attempt(s) | Duration: {lockout_dur} minute(s)."
+            f"Lockout threshold: {threshold} attempt(s) | Duration: {duration} minute(s)."
         ),
         remediation=(
             "" if not lockout_disabled else
@@ -269,65 +316,60 @@ def _check_password_policy() -> list[CheckResult]:
             "" if not lockout_disabled else
             "net accounts /lockoutthreshold:5 /lockoutduration:30"
         ),
-    ))
-
-    # --- secedit: password complexity ---
-    try:
-        complexity_val = run_powershell(_PS_COMPLEXITY).strip()
-    except ApotropeError as exc:
-        results.append(_error("Password Policy — Complexity", str(exc)))
-        return results
-
-    if complexity_val == "Unknown":
-        results.append(CheckResult(
-            category=CATEGORY,
-            check_name="Password Policy — Complexity",
-            status=Status.INFO,
-            severity=Severity.MEDIUM,
-            description="Checks whether password complexity requirements are enforced.",
-            details="Could not determine password complexity setting (secedit output unavailable).",
-            remediation="",
-        ))
-    else:
-        enabled = complexity_val.strip() == "1"
-        results.append(CheckResult(
-            category=CATEGORY,
-            check_name="Password Policy — Complexity",
-            status=Status.PASS if enabled else Status.FAIL,
-            severity=Severity.MEDIUM,
-            description="Checks whether password complexity requirements are enforced.",
-            details=f"Password complexity requirement: {'enabled' if enabled else 'disabled'}.",
-            remediation=(
-                "" if enabled else
-                "Enable the password complexity requirement so passwords must mix "
-                "character types."
-            ),
-            command=(
-                "" if enabled else
-                "# Enable the password-complexity policy via secedit (no reboot needed).\n"
-                "$inf = \"$env:TEMP\\pwcomplexity.inf\"\n"
-                "@'\n"
-                "[Unicode]\n"
-                "Unicode=yes\n"
-                "[Version]\n"
-                "signature=\"$CHICAGO$\"\n"
-                "[System Access]\n"
-                "PasswordComplexity = 1\n"
-                "'@ | Set-Content -Path $inf -Encoding Unicode\n"
-                "secedit /configure /db \"$env:TEMP\\pwcomplexity.sdb\" "
-                "/cfg $inf /areas SECURITYPOLICY"
-            ),
-        ))
-
-    return results
+    )
 
 
-def _parse_net_accounts(output: str) -> dict[str, str]:
-    """Parse 'net accounts' text output into a lowercase key → value dict."""
+def _eval_complexity(policy: dict[str, str]) -> CheckResult:
+    name = "Password Policy — Complexity"
+    raw = policy.get("passwordcomplexity")
+    if raw not in ("0", "1"):
+        return _error(
+            name,
+            f"PasswordComplexity missing or unrecognized in the security policy: {raw!r}.",
+        )
+
+    enabled = raw == "1"
+    return CheckResult(
+        category=CATEGORY,
+        check_name=name,
+        status=Status.PASS if enabled else Status.FAIL,
+        severity=Severity.MEDIUM,
+        description="Checks whether password complexity requirements are enforced.",
+        details=f"Password complexity requirement: {'enabled' if enabled else 'disabled'}.",
+        remediation=(
+            "" if enabled else
+            "Enable the password complexity requirement so passwords must mix "
+            "character types."
+        ),
+        command=(
+            "" if enabled else
+            "# Enable the password-complexity policy via secedit (no reboot needed).\n"
+            "$inf = \"$env:TEMP\\pwcomplexity.inf\"\n"
+            "@'\n"
+            "[Unicode]\n"
+            "Unicode=yes\n"
+            "[Version]\n"
+            "signature=\"$CHICAGO$\"\n"
+            "[System Access]\n"
+            "PasswordComplexity = 1\n"
+            "'@ | Set-Content -Path $inf -Encoding Unicode\n"
+            "secedit /configure /db \"$env:TEMP\\pwcomplexity.sdb\" "
+            "/cfg $inf /areas SECURITYPOLICY"
+        ),
+    )
+
+
+def _parse_secedit_inf(text: str) -> dict[str, str]:
+    """Parse ``Key = Value`` lines from a secedit INF into a lowercase-key dict.
+
+    INF keys (MinimumPasswordLength, LockoutBadCount, PasswordComplexity, …) are
+    locale-neutral template identifiers, unlike ``net accounts`` display labels.
+    """
     result: dict[str, str] = {}
-    for line in output.splitlines():
-        if ":" in line:
-            key, _, val = line.partition(":")
+    for line in text.splitlines():
+        s = line.strip()
+        if "=" in s and not s.startswith("["):
+            key, _, val = s.partition("=")
             result[key.strip().lower()] = val.strip()
     return result
 

--- a/tests/test_checks/test_accounts.py
+++ b/tests/test_checks/test_accounts.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import pytest
-
+from apotrope import cis_map
 from apotrope.checks import accounts
 from apotrope.exceptions import ApotropeError
 from apotrope.models import CheckResult, Status, Severity
@@ -251,6 +250,45 @@ class TestCheckPasswordPolicy:
                    side_effect=ApotropeError("secedit denied")):
             results = accounts._check_password_policy()
         assert any(r.status == Status.ERROR for r in results)
+
+    def test_secedit_failure_degrades_every_control_separately(self):
+        # A single collapsed "Password Policy" result DELETED three CIS-mapped
+        # rows from the report rather than degrading them — the operator saw no
+        # Minimum Length / Account Lockout / Complexity row at all. Each control
+        # must survive the failure under its own name.
+        with patch("apotrope.checks.accounts.run_powershell",
+                   side_effect=ApotropeError("secedit denied")):
+            results = accounts._check_password_policy()
+        assert [r.check_name for r in results] == list(accounts._PW_POLICY_CHECKS)
+        assert all(r.status == Status.ERROR for r in results)
+
+    def test_secedit_failure_names_stay_cis_mapped(self):
+        # These check_name strings key cis_map.py, --compare and
+        # profile.disabled_checks; a renamed result silently loses all three.
+        with patch("apotrope.checks.accounts.run_powershell",
+                   side_effect=ApotropeError("secedit denied")):
+            results = accounts._check_password_policy()
+        for r in results:
+            assert cis_map.lookup(r.check_name), f"{r.check_name!r} has no CIS reference"
+
+    def test_secedit_failure_points_at_elevation(self):
+        # secedit exports from a database readable only by SYSTEM and
+        # Administrators, so the documented non-elevated invocation always lands
+        # here. Say so — a bare stderr string is not actionable.
+        with patch("apotrope.checks.accounts.run_powershell",
+                   side_effect=ApotropeError("secedit denied")):
+            results = accounts._check_password_policy()
+        for r in results:
+            assert "Administrator" in r.remediation
+            assert "Administrators" in r.details
+
+    def test_success_and_failure_paths_agree_on_names(self):
+        # If the two paths ever disagree, a --compare diff reads the mismatch as
+        # one control vanishing and another appearing.
+        with patch("apotrope.checks.accounts.run_powershell",
+                   return_value=self._inf()):
+            ok = accounts._check_password_policy()
+        assert [r.check_name for r in ok] == list(accounts._PW_POLICY_CHECKS)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_checks/test_accounts.py
+++ b/tests/test_checks/test_accounts.py
@@ -1,113 +1,108 @@
-"""Tests for apotrope.checks.accounts."""
+"""Tests for apotrope.checks.accounts (SID-based identification)."""
 
 from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
 
 from apotrope.checks import accounts
 from apotrope.exceptions import ApotropeError
 from apotrope.models import CheckResult, Status, Severity
 
 
+def _user(name: str, enabled: bool, rid: str) -> dict:
+    return {"Name": name, "Enabled": enabled, "SID": f"S-1-5-21-1-2-3-{rid}"}
+
+
 # ---------------------------------------------------------------------------
-# _check_guest_account
+# _check_guest_account (RID-501, not name)
 # ---------------------------------------------------------------------------
 
 class TestCheckGuestAccount:
+    def _run(self, users):
+        with patch("apotrope.checks.accounts.run_powershell_json", return_value=users):
+            return accounts._check_guest_account()
+
     def test_guest_disabled_is_pass(self):
-        with patch("apotrope.checks.accounts.run_powershell", return_value="False"):
-            results = accounts._check_guest_account()
-        assert len(results) == 1
-        r = results[0]
+        r = self._run([_user("Guest", False, "501")])[0]
         assert r.status == Status.PASS
         assert r.severity == Severity.HIGH
 
     def test_guest_enabled_is_fail(self):
-        with patch("apotrope.checks.accounts.run_powershell", return_value="True"):
-            results = accounts._check_guest_account()
-        r = results[0]
+        r = self._run([_user("Guest", True, "501")])[0]
         assert r.status == Status.FAIL
         assert "enabled" in r.details.lower()
-        assert "Disable-LocalUser" in r.command
+        assert "Disable-LocalUser -SID" in r.command
 
-    def test_guest_not_found_is_info(self):
-        with patch("apotrope.checks.accounts.run_powershell", return_value=""):
-            results = accounts._check_guest_account()
-        r = results[0]
+    def test_renamed_enabled_guest_still_fails(self):
+        # SID beats name: a renamed-but-enabled guest (e.g. localized) must FAIL,
+        # where the old name-based lookup produced a reassuring "not found".
+        r = self._run([_user("Visitor", True, "501")])[0]
+        assert r.status == Status.FAIL
+
+    def test_no_rid501_is_info(self):
+        # Successful enumeration lacking RID-501 → genuinely absent → INFO.
+        r = self._run([_user("Administrator", True, "500")])[0]
         assert r.status == Status.INFO
-        assert "not found" in r.details.lower()
+        assert "not present" in r.details.lower()
 
-    def test_powershell_error_returns_error(self):
-        with patch("apotrope.checks.accounts.run_powershell",
-                   side_effect=ApotropeError("boom")):
-            results = accounts._check_guest_account()
-        assert results[0].status == Status.ERROR
+    def test_query_failure_is_error(self):
+        with patch("apotrope.checks.accounts.run_powershell_json",
+                   side_effect=ApotropeError("access denied")):
+            r = accounts._check_guest_account()[0]
+        assert r.status == Status.ERROR
 
 
 # ---------------------------------------------------------------------------
-# _check_builtin_admin
+# _check_builtin_admin (RID-500; renamed-enabled WARN branch is now live)
 # ---------------------------------------------------------------------------
 
 class TestCheckBuiltinAdmin:
-    def _run(self, data):
-        with patch("apotrope.checks.accounts.run_powershell_json", return_value=data):
+    def _run(self, users):
+        with patch("apotrope.checks.accounts.run_powershell_json", return_value=users):
             return accounts._check_builtin_admin()
 
     def test_enabled_default_name_is_fail(self):
-        results = self._run({"Name": "Administrator", "Enabled": True})
-        r = results[0]
+        r = self._run([_user("Administrator", True, "500")])[0]
         assert r.status == Status.FAIL
         assert r.severity == Severity.MEDIUM
+        assert "Disable-LocalUser -SID" in r.command
 
-    def test_enabled_renamed_is_warn(self):
-        results = self._run({"Name": "sysadmin", "Enabled": True})
-        r = results[0]
+    def test_renamed_enabled_is_warn(self):
+        r = self._run([_user("CorpAdmin", True, "500")])[0]
         assert r.status == Status.WARN
         assert r.severity == Severity.LOW
-        assert "sysadmin" in r.details
+        assert "CorpAdmin" in r.details
 
     def test_disabled_is_pass(self):
-        results = self._run({"Name": "Administrator", "Enabled": False})
-        r = results[0]
+        r = self._run([_user("Administrator", False, "500")])[0]
         assert r.status == Status.PASS
 
     def test_disabled_renamed_is_pass(self):
-        results = self._run({"Name": "sysadmin", "Enabled": False})
-        r = results[0]
+        r = self._run([_user("CorpAdmin", False, "500")])[0]
         assert r.status == Status.PASS
-        assert "sysadmin" in r.details
+        assert "CorpAdmin" in r.details
 
-    def test_empty_data_returns_info(self):
-        results = self._run(None)
-        r = results[0]
+    def test_no_rid500_is_info(self):
+        r = self._run([_user("Guest", False, "501")])[0]
         assert r.status == Status.INFO
-        assert "not found" in r.details.lower()
+        assert "not present" in r.details.lower()
 
-    def test_renamed_admin_empty_stdout_is_info(self):
-        # Regression: a renamed/absent Administrator produces empty PowerShell
-        # stdout. Exercise the REAL run_powershell_json (patch the lower-level
-        # run_powershell) to prove empty output surfaces as INFO "not found",
-        # not a confusing Status.ERROR. This failed before the empty-output fix.
-        with patch("apotrope.utils.run_powershell", return_value=""):
-            results = accounts._check_builtin_admin()
-        r = results[0]
+    def test_rid1500_not_mistaken_for_500(self):
+        # Hyphen-anchored suffix: -1500 must not match -500.
+        r = self._run([_user("Weird", True, "1500")])[0]
         assert r.status == Status.INFO
-        assert "not found" in r.details.lower()
 
-    def test_list_data_uses_first_element(self):
-        results = self._run([{"Name": "Administrator", "Enabled": False}])
-        assert results[0].status == Status.PASS
-
-    def test_error_returns_error_result(self):
+    def test_query_failure_is_error(self):
         with patch("apotrope.checks.accounts.run_powershell_json",
                    side_effect=ApotropeError("access denied")):
-            results = accounts._check_builtin_admin()
-        assert results[0].status == Status.ERROR
+            r = accounts._check_builtin_admin()[0]
+        assert r.status == Status.ERROR
 
 
 # ---------------------------------------------------------------------------
-# _check_admin_count
+# _check_admin_count (SID-544; empty → ERROR, never a false "0 admins" PASS)
 # ---------------------------------------------------------------------------
 
 class TestCheckAdminCount:
@@ -116,148 +111,144 @@ class TestCheckAdminCount:
             return accounts._check_admin_count()
 
     def test_one_admin_is_pass(self):
-        results = self._run([{"Name": "MACHINE\\Admin", "PrincipalSource": "Local", "ObjectClass": "User"}])
-        assert results[0].status == Status.PASS
+        r = self._run([{"Name": "MACHINE\\Admin"}])[0]
+        assert r.status == Status.PASS
 
     def test_two_admins_is_pass(self):
-        members = [
-            {"Name": "MACHINE\\Admin", "PrincipalSource": "Local", "ObjectClass": "User"},
-            {"Name": "MACHINE\\Domain Admins", "PrincipalSource": "ActiveDirectory", "ObjectClass": "Group"},
-        ]
-        results = self._run(members)
-        assert results[0].status == Status.PASS
+        r = self._run([{"Name": "MACHINE\\Admin"}, {"Name": "MACHINE\\Domain Admins"}])[0]
+        assert r.status == Status.PASS
 
     def test_three_admins_is_warn(self):
-        members = [
-            {"Name": "MACHINE\\Admin1"},
-            {"Name": "MACHINE\\Admin2"},
-            {"Name": "MACHINE\\Admin3"},
-        ]
-        results = self._run(members)
-        r = results[0]
+        members = [{"Name": f"MACHINE\\Admin{i}"} for i in range(1, 4)]
+        r = self._run(members)[0]
         assert r.status == Status.WARN
         assert "3" in r.details
 
     def test_domain_prefix_stripped_from_display(self):
-        results = self._run([{"Name": "MACHINE\\Alice"}])
-        assert "Alice" in results[0].details
-        assert "MACHINE" not in results[0].details
+        r = self._run([{"Name": "MACHINE\\Alice"}])[0]
+        assert "Alice" in r.details
+        assert "MACHINE" not in r.details
 
     def test_single_dict_wrapped(self):
-        results = self._run({"Name": "MACHINE\\Admin"})
-        assert results[0].status == Status.PASS
+        r = self._run({"Name": "MACHINE\\Admin"})[0]
+        assert r.status == Status.PASS
 
-    def test_error_returns_error(self):
+    def test_empty_members_is_error(self):
+        # The built-in group always has >=1 member; empty == failed enumeration.
+        r = self._run([])[0]
+        assert r.status == Status.ERROR
+
+    def test_query_uses_well_known_sid(self):
+        assert accounts._ADMINISTRATORS_SID == "S-1-5-32-544"
+        assert "S-1-5-32-544" in accounts._PS_ADMINS
+
+    def test_query_failure_is_error(self):
         with patch("apotrope.checks.accounts.run_powershell_json",
                    side_effect=ApotropeError("denied")):
-            results = accounts._check_admin_count()
-        assert results[0].status == Status.ERROR
+            r = accounts._check_admin_count()[0]
+        assert r.status == Status.ERROR
 
 
 # ---------------------------------------------------------------------------
-# _parse_net_accounts helper
+# _parse_secedit_inf helper
 # ---------------------------------------------------------------------------
 
-class TestParseNetAccounts:
+class TestParseSeceditInf:
     _SAMPLE = (
-        "Force user logoff how long after time expires?: Never\n"
-        "Minimum password age (days): 0\n"
-        "Maximum password age (days): 42\n"
-        "Minimum password length: 7\n"
-        "Length of password history maintained: None\n"
-        "Lockout threshold: Never\n"
-        "Lockout duration (minutes): 30\n"
-        "Lockout observation window (minutes): 30\n"
-        "Computer role: WORKSTATION\n"
-        "The command completed successfully.\n"
+        "[Unicode]\n"
+        "Unicode=yes\n"
+        "[System Access]\n"
+        "MinimumPasswordLength = 14\n"
+        "LockoutBadCount = 5\n"
+        "PasswordComplexity = 1\n"
+        "[Version]\n"
+        "signature=\"$CHICAGO$\"\n"
     )
 
-    def test_parses_min_length(self):
-        parsed = accounts._parse_net_accounts(self._SAMPLE)
-        assert parsed["minimum password length"] == "7"
+    def test_parses_and_lowercases_keys(self):
+        parsed = accounts._parse_secedit_inf(self._SAMPLE)
+        assert parsed["minimumpasswordlength"] == "14"
+        assert parsed["lockoutbadcount"] == "5"
+        assert parsed["passwordcomplexity"] == "1"
 
-    def test_parses_lockout_threshold(self):
-        parsed = accounts._parse_net_accounts(self._SAMPLE)
-        assert parsed["lockout threshold"] == "Never"
-
-    def test_keys_are_lowercase(self):
-        parsed = accounts._parse_net_accounts(self._SAMPLE)
-        assert "minimum password age (days)" in parsed
+    def test_section_headers_ignored(self):
+        parsed = accounts._parse_secedit_inf(self._SAMPLE)
+        assert "[system access]" not in parsed
 
     def test_empty_output(self):
-        assert accounts._parse_net_accounts("") == {}
+        assert accounts._parse_secedit_inf("") == {}
 
 
 # ---------------------------------------------------------------------------
-# _check_password_policy (integration-level unit tests)
+# _check_password_policy (secedit INF, locale-neutral)
 # ---------------------------------------------------------------------------
 
 class TestCheckPasswordPolicy:
-    _NET_GOOD = (
-        "Minimum password length: 14\n"
-        "Lockout threshold: 5\n"
-        "Lockout duration (minutes): 30\n"
-    )
-    _NET_SHORT = (
-        "Minimum password length: 6\n"
-        "Lockout threshold: 5\n"
-        "Lockout duration (minutes): 30\n"
-    )
-    _NET_WARN_LEN = (
-        "Minimum password length: 10\n"
-        "Lockout threshold: 5\n"
-        "Lockout duration (minutes): 30\n"
-    )
-    _NET_NO_LOCKOUT = (
-        "Minimum password length: 14\n"
-        "Lockout threshold: Never\n"
-        "Lockout duration (minutes): 30\n"
-    )
+    def _inf(self, *, min_len="14", lockout="5", complexity="1"):
+        lines = ["[System Access]"]
+        if min_len is not None:
+            lines.append(f"MinimumPasswordLength = {min_len}")
+        if lockout is not None:
+            lines.append(f"LockoutBadCount = {lockout}")
+        lines.append("LockoutDuration = 30")
+        if complexity is not None:
+            lines.append(f"PasswordComplexity = {complexity}")
+        return "\n".join(lines) + "\n"
 
-    def _run(self, net_output, complexity_val):
-        with (
-            patch("apotrope.checks.accounts.run_powershell",
-                  side_effect=[net_output, complexity_val]),
-        ):
+    def _run(self, inf_text):
+        with patch("apotrope.checks.accounts.run_powershell", return_value=inf_text):
             return accounts._check_password_policy()
 
+    def _by_name(self, results, needle):
+        return next(r for r in results if needle in r.check_name)
+
     def test_all_good_returns_passes(self):
-        results = self._run(self._NET_GOOD, "1")
-        statuses = {r.check_name: r.status for r in results}
-        assert statuses["Password Policy — Minimum Length"] == Status.PASS
-        assert statuses["Password Policy — Account Lockout"] == Status.PASS
-        assert statuses["Password Policy — Complexity"] == Status.PASS
+        results = self._run(self._inf())
+        assert self._by_name(results, "Length").status == Status.PASS
+        assert self._by_name(results, "Lockout").status == Status.PASS
+        assert self._by_name(results, "Complexity").status == Status.PASS
 
     def test_short_password_is_fail(self):
-        results = self._run(self._NET_SHORT, "1")
-        r = next(r for r in results if "Length" in r.check_name)
+        r = self._by_name(self._run(self._inf(min_len="6")), "Length")
         assert r.status == Status.FAIL
         assert r.severity == Severity.HIGH
 
     def test_warn_length_is_warn(self):
-        results = self._run(self._NET_WARN_LEN, "1")
-        r = next(r for r in results if "Length" in r.check_name)
+        r = self._by_name(self._run(self._inf(min_len="10")), "Length")
         assert r.status == Status.WARN
 
     def test_no_lockout_is_warn(self):
-        results = self._run(self._NET_NO_LOCKOUT, "1")
-        r = next(r for r in results if "Lockout" in r.check_name)
+        r = self._by_name(self._run(self._inf(lockout="0")), "Lockout")
         assert r.status == Status.WARN
         assert "net accounts" in r.command
 
     def test_complexity_disabled_is_fail(self):
-        results = self._run(self._NET_GOOD, "0")
-        r = next(r for r in results if "Complexity" in r.check_name)
+        r = self._by_name(self._run(self._inf(complexity="0")), "Complexity")
         assert r.status == Status.FAIL
 
-    def test_complexity_unknown_is_info(self):
-        results = self._run(self._NET_GOOD, "Unknown")
-        r = next(r for r in results if "Complexity" in r.check_name)
-        assert r.status == Status.INFO
+    def test_missing_min_length_is_error(self):
+        r = self._by_name(self._run(self._inf(min_len=None)), "Length")
+        assert r.status == Status.ERROR
 
-    def test_net_accounts_error_returns_error(self):
+    def test_missing_lockout_is_error(self):
+        r = self._by_name(self._run(self._inf(lockout=None)), "Lockout")
+        assert r.status == Status.ERROR
+
+    def test_missing_complexity_is_error(self):
+        r = self._by_name(self._run(self._inf(complexity=None)), "Complexity")
+        assert r.status == Status.ERROR
+
+    def test_non_integer_min_length_is_error(self):
+        r = self._by_name(self._run(self._inf(min_len="lots")), "Length")
+        assert r.status == Status.ERROR
+
+    def test_non_integer_lockout_is_error(self):
+        r = self._by_name(self._run(self._inf(lockout="lots")), "Lockout")
+        assert r.status == Status.ERROR
+
+    def test_secedit_error_returns_error(self):
         with patch("apotrope.checks.accounts.run_powershell",
-                   side_effect=ApotropeError("denied")):
+                   side_effect=ApotropeError("secedit denied")):
             results = accounts._check_password_policy()
         assert any(r.status == Status.ERROR for r in results)
 
@@ -268,53 +259,21 @@ class TestCheckPasswordPolicy:
 
 class TestRun:
     def test_run_returns_list_of_check_results(self):
-        net_output = (
-            "Minimum password length: 14\n"
-            "Lockout threshold: 5\n"
-            "Lockout duration (minutes): 30\n"
+        users = [_user("Administrator", False, "500"), _user("Guest", False, "501")]
+        admins = [{"Name": "MACHINE\\Admin"}]
+        inf = (
+            "[System Access]\n"
+            "MinimumPasswordLength = 14\n"
+            "LockoutBadCount = 5\n"
+            "LockoutDuration = 30\n"
+            "PasswordComplexity = 1\n"
         )
         with (
-            patch("apotrope.checks.accounts.run_powershell",
-                  side_effect=["False", "1", net_output, "1"]),
+            # guest -> users, admin -> users, admin_count -> admins
             patch("apotrope.checks.accounts.run_powershell_json",
-                  side_effect=[
-                      {"Name": "Administrator", "Enabled": False},
-                      [{"Name": "MACHINE\\Admin"}],
-                  ]),
+                  side_effect=[users, users, admins]),
+            patch("apotrope.checks.accounts.run_powershell", return_value=inf),
         ):
             results = accounts.run()
         assert all(isinstance(r, CheckResult) for r in results)
         assert len(results) >= 6
-
-
-# ---------------------------------------------------------------------------
-# Password policy parse fallback and complexity error path
-# ---------------------------------------------------------------------------
-
-class TestPasswordPolicyFallbacks:
-    _NET_BAD_LEN = (
-        "Minimum password length: None\n"
-        "Lockout threshold: 5\n"
-        "Lockout duration (minutes): 30\n"
-    )
-
-    def test_non_numeric_min_length_treated_as_zero(self):
-        with patch("apotrope.checks.accounts.run_powershell",
-                   side_effect=[self._NET_BAD_LEN, "1"]):
-            results = accounts._check_password_policy()
-        length = next(r for r in results if "Length" in r.check_name)
-        assert length.status == Status.FAIL
-        assert "0" in length.details
-
-    def test_complexity_query_error_appends_error_result(self):
-        net_good = (
-            "Minimum password length: 14\n"
-            "Lockout threshold: 5\n"
-            "Lockout duration (minutes): 30\n"
-        )
-        with patch("apotrope.checks.accounts.run_powershell",
-                   side_effect=[net_good, ApotropeError("secedit denied")]):
-            results = accounts._check_password_policy()
-        complexity = next(r for r in results if "Complexity" in r.check_name)
-        assert complexity.status == Status.ERROR
-        assert "secedit denied" in complexity.details


### PR DESCRIPTION
The account checks identified the built-in Administrator/Guest and the Administrators group by their **English display name**.

## Why

- A **renamed** built-in account — itself a recommended hardening step — or a **non-English** install makes the name lookup find nothing. An enabled, renamed Guest account was reported as a reassuring "not found" rather than a FAIL.
- A **failed or denied** query was indistinguishable from an empty result. An empty Administrators lookup was reported as a clean "0 administrators" PASS. That group always has at least one member, so empty means the enumeration failed.
- Password policy was parsed out of localized `net accounts` text, so a non-English machine produced **fabricated defaults**: minimum length 0 (a false FAIL) and lockout "Never" (a false WARN).

## What changed

- **Identify by SID.** Built-in Administrator and Guest by RID suffix `-500` / `-501`, hyphen-anchored so `-1500` is never mistaken for `-500`; the Administrators group by its well-known SID `S-1-5-32-544`.
- **Failure is not emptiness.** Every query uses `-ErrorAction Stop` and exits non-zero, so a denial surfaces as ERROR. A *successful* empty result is handled separately: an absent RID is INFO, and an empty Administrators group is an ERROR rather than a false PASS. The "renamed and enabled Administrator" WARN branch is now reachable — it was dead code before.
- **Locale-neutral password policy.** One `secedit /export` INF, parsed by stable keys (`MinimumPasswordLength`, `LockoutBadCount`, `PasswordComplexity`). Missing or malformed keys are an ERROR, not a fabricated default.
- **A failed export degrades per control.** Collapsing the three password-policy results into a single differently-named one removed three CIS-mapped rows from the report instead of degrading them — the operator saw no Minimum Length, Account Lockout or Complexity row at all, and a baseline diff read the disappearance as lost coverage on both sides. Each control now returns its own correctly-named ERROR.
- Remediation commands target accounts by `-SID`. `check_name` strings are unchanged, since they key the CIS map.

## Known limitation

`secedit` reads a database readable only by SYSTEM and Administrators, so a **non-elevated scan reports the three password-policy controls as "requires Administrator" rather than evaluating them.** On an English host that is a step back from the previous behaviour, which did produce a verdict.

It is a deliberate trade. The old path fabricated a *wrong* verdict on every non-English install, and a missing verdict is better than a confidently wrong one — the same fail-closed principle the rest of this PR applies. The controls are reported explicitly rather than silently dropped, so the gap is visible in the report. Restoring unprivileged evaluation through a locale-neutral API (rather than localized text) is tracked as follow-up work.

## Tests

892 pass, with `accounts.py` at **100% line and branch coverage** — including renamed enabled Guest and Administrator, `-1500` not matched as `-500`, absent RID, query failure, empty Administrators group, the INF parse across good/short/missing/non-integer values, and the failure path returning all three controls under their real names.

**Wants real-Windows validation:** that `Get-LocalUser`/`Get-LocalGroupMember` expose `.SID.Value`; RID and SID resolution on localized and renamed installs; the `secedit` INF keys; and that `-ErrorAction Stop` plus a non-zero exit converts access-denied into an ERROR. This change is deliberately isolated to two files because it carries the largest blast radius of the series.
