### PR TITLE
Check correctness & fail-closed verdicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ scan time.
 | Firewall       | Firewall — Domain Profile Enabled      | Checks whether Windows Firewall is enabled for domain networks                     |
 | Firewall       | Firewall — Private Default Inbound Action | Checks that the Private profile does not explicitly allow all inbound connections |
 | Firewall       | Firewall — Private Profile Enabled     | Checks whether Windows Firewall is enabled for private networks                    |
+| Firewall       | Firewall — Profiles Present            | Verifies all three profiles were reported — a missing one is an ERROR, not a silent gap |
 | Firewall       | Firewall — Public Default Inbound Action | Checks that the Public profile does not explicitly allow all inbound connections  |
 | Firewall       | Firewall — Public Profile Enabled      | Checks whether Windows Firewall is enabled for public networks                     |
 | Hardening      | Audit Policy                           | Checks that key subcategories (Logon, Lockout, etc.) log success/failure events    |

--- a/src/apotrope/checks/encryption.py
+++ b/src/apotrope/checks/encryption.py
@@ -27,6 +27,34 @@ _PS_BITLOCKER = (
 # ProtectionStatus values from Get-BitLockerVolume
 _PROTECTION_ON = 1
 
+# PowerShell 5.1 serialises these enums as integers; PowerShell 7 as strings.
+_VOLUME_TYPE_NAMES = {0: "OperatingSystem", 1: "FixedData", 2: "Removable"}
+_VOLUME_STATUS_NAMES = {
+    0: "FullyDecrypted", 1: "FullyEncrypted", 2: "EncryptionInProgress",
+    3: "DecryptionInProgress", 4: "EncryptionPaused", 5: "DecryptionPaused",
+}
+
+
+def _enum_name(raw: object, table: dict[int, str]) -> str:
+    """Map a PS 5.1 integer enum to its name; pass a PS 7 string enum through."""
+    if isinstance(raw, bool) or raw is None:
+        return "Unknown"
+    if isinstance(raw, int):
+        return table.get(raw, str(raw))
+    return str(raw)
+
+
+def _coerce_int(raw: object) -> int:
+    """Best-effort int from an int or numeric string; None/unparseable -> 0."""
+    if isinstance(raw, bool):
+        return int(raw)
+    if isinstance(raw, int):
+        return raw
+    try:
+        return int(str(raw).split(".")[0])
+    except (TypeError, ValueError):
+        return 0
+
 
 def run() -> list[CheckResult]:
     """Return BitLocker encryption status checks.
@@ -90,18 +118,19 @@ def run() -> list[CheckResult]:
 def _check_volume(vol: dict) -> list[CheckResult]:
     """Evaluate a single BitLocker volume dict and return a CheckResult."""
     mount = str(vol.get("MountPoint", "?:"))
-    vol_type = str(vol.get("VolumeType") or "Unknown")
-    vol_status = str(vol.get("VolumeStatus") or "Unknown")
-    protection = int(vol.get("ProtectionStatus") or 0)
+    vol_type = _enum_name(vol.get("VolumeType"), _VOLUME_TYPE_NAMES)
+    vol_status = _enum_name(vol.get("VolumeStatus"), _VOLUME_STATUS_NAMES)
     method = str(vol.get("EncryptionMethod") or "None")
-    pct = int(vol.get("EncryptionPercentage") or 0)
+    pct = _coerce_int(vol.get("EncryptionPercentage"))
 
     # Identify OS drive by VolumeType; fall back to drive letter heuristic
     is_os = "OperatingSystem" in vol_type or mount.upper().startswith("C:")
-    is_protected = protection == _PROTECTION_ON
+    # ProtectionStatus is 1/On when protectors are active — accept PS5 int and PS7 string.
+    is_protected = str(vol.get("ProtectionStatus")).lower() in ("1", "on")
+    is_full = pct >= 100 or vol_status.replace(" ", "").lower() == "fullyencrypted"
     severity = Severity.HIGH if is_os else Severity.MEDIUM
 
-    if is_protected:
+    if is_protected and is_full:
         return [CheckResult(
             category=CATEGORY,
             check_name=f"BitLocker — {mount}",
@@ -114,6 +143,24 @@ def _check_volume(vol: dict) -> list[CheckResult]:
                 f"Encrypted: {pct}% | Protection: On"
             ),
             remediation="",
+        )]
+
+    if is_protected and not is_full:
+        # Protection is on but encryption has not finished — the drive is not yet
+        # fully protected, so this is not a PASS.
+        return [CheckResult(
+            category=CATEGORY,
+            check_name=f"BitLocker — {mount}",
+            status=Status.WARN,
+            severity=severity,
+            description=f"Checks BitLocker encryption status for drive {mount}.",
+            details=(
+                f"Drive: {mount} | Type: {vol_type} | "
+                f"Status: {vol_status} | Method: {method} | "
+                f"Encrypted: {pct}% | Protection: On (encryption in progress — "
+                "not yet fully protected)"
+            ),
+            remediation="Leave BitLocker encryption running until the drive reports 100%.",
         )]
 
     return [CheckResult(

--- a/src/apotrope/checks/firewall.py
+++ b/src/apotrope/checks/firewall.py
@@ -64,7 +64,7 @@ def run() -> list[CheckResult]:
             remediation="Ensure Get-NetFirewallProfile is available. Run with --log-level DEBUG.",
         )]
 
-    profiles = data if isinstance(data, list) else [data]
+    profiles = data if isinstance(data, list) else ([data] if data else [])
     results: list[CheckResult] = []
 
     for profile in profiles:
@@ -93,10 +93,12 @@ def run() -> list[CheckResult]:
 
         # --- Check 2: default inbound action ---
         # "NotConfigured" inherits from Group Policy; the Windows built-in default
-        # is Block, so it is NOT treated as a finding.  Only explicit "Allow" warns.
+        # is Block, so it PASSes. Everything else — an explicit "Allow" or an
+        # unknown/unreadable value — fails closed to WARN rather than silently PASS.
         inbound_lower = inbound.lower()
-        inbound_explicit_allow = inbound_lower == "allow"
-        inbound_status = Status.WARN if inbound_explicit_allow else Status.PASS
+        inbound_ok = inbound_lower in ("block", "notconfigured")
+        inbound_needs_fix = not inbound_ok
+        inbound_status = Status.PASS if inbound_ok else Status.WARN
         results.append(CheckResult(
             category=CATEGORY,
             check_name=f"Firewall — {name} Default Inbound Action",
@@ -112,12 +114,34 @@ def run() -> list[CheckResult]:
                 f"DefaultOutboundAction: {outbound}"
             ),
             remediation=(
-                "" if not inbound_explicit_allow else
+                "" if not inbound_needs_fix else
                 f"Set the {name} firewall profile to block inbound connections by default."
             ),
             command=(
-                "" if not inbound_explicit_allow else
+                "" if not inbound_needs_fix else
                 f"Set-NetFirewallProfile -Profile {name} -DefaultInboundAction Block"
+            ),
+        ))
+
+    # All three profiles must be reported; a missing profile means the query was
+    # incomplete (e.g. elevation required), so surface an ERROR rather than let the
+    # whole Firewall category silently vanish from the report.
+    present = {str(p.get("Name", "")).strip() for p in profiles}
+    missing = {"Domain", "Private", "Public"} - present
+    if missing:
+        results.append(CheckResult(
+            category=CATEGORY,
+            check_name="Firewall — Profiles Present",
+            status=Status.ERROR,
+            severity=Severity.HIGH,
+            description="Verifies all three Windows Firewall profiles are reported.",
+            details=(
+                f"Missing profile(s): {', '.join(sorted(missing))}. Firewall status "
+                "could not be fully assessed (elevation may be required)."
+            ),
+            remediation=(
+                "Run Apotrope as Administrator and ensure the Windows Firewall "
+                "service is running."
             ),
         ))
 

--- a/src/apotrope/checks/misc.py
+++ b/src/apotrope/checks/misc.py
@@ -22,6 +22,25 @@ _PS_AUTOPLAY = (
     "-ErrorAction SilentlyContinue).NoDriveTypeAutoRun; "
     "if ($null -eq $v) { 'NOTSET' } else { [string]$v }"
 )
+# Create the policy key first: Set-ItemProperty -Force does NOT create a missing
+# key, and the NOTSET finding fires precisely when that key is absent.
+_CMD_AUTOPLAY_DISABLE = (
+    f"New-Item -Path '{_AUTOPLAY_KEY}' -Force | Out-Null\n"
+    f"Set-ItemProperty -Path '{_AUTOPLAY_KEY}' -Name NoDriveTypeAutoRun -Value 255 "
+    "-Type DWord -Force"
+)
+
+# The five security-relevant audit subcategories Apotrope requires (order fixed
+# for deterministic "missing" reporting).
+_EXPECTED_AUDIT = (
+    "Logon", "Account Lockout", "Logoff",
+    "Credential Validation", "Sensitive Privilege Use",
+)
+
+# Machine-wide inactivity lock policy (applies even without a per-user screensaver).
+_MACHINE_INACTIVITY_KEY = (
+    "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System"
+)
 
 _PS_WINRM = "(Get-Service -Name WinRM -ErrorAction SilentlyContinue).Status"
 
@@ -50,10 +69,12 @@ _PS_AUDIT = (
 _SCREEN_KEY = "HKCU:\\Control Panel\\Desktop"
 _PS_SCREEN = (
     f"$d = Get-ItemProperty -LiteralPath '{_SCREEN_KEY}' -ErrorAction SilentlyContinue; "
+    f"$m = Get-ItemProperty -LiteralPath '{_MACHINE_INACTIVITY_KEY}' -ErrorAction SilentlyContinue; "
     "@{ "
     "Active=$d.ScreenSaveActive; "
     "Secure=$d.ScreenSaverIsSecure; "
-    "Timeout=$d.ScreenSaveTimeOut "
+    "Timeout=$d.ScreenSaveTimeOut; "
+    "MachineInactivity=$m.InactivityTimeoutSecs "
     "} | ConvertTo-Json -Compress"
 )
 
@@ -103,10 +124,7 @@ def _check_autoplay() -> list[CheckResult]:
                 "Configuration → Administrative Templates → Windows Components → AutoPlay "
                 "Policies → Turn off AutoPlay → Enabled."
             ),
-            command=(
-                f"Set-ItemProperty -Path '{_AUTOPLAY_KEY}' "
-                "-Name NoDriveTypeAutoRun -Value 255 -Type DWord -Force"
-            ),
+            command=_CMD_AUTOPLAY_DISABLE,
         )]
 
     try:
@@ -144,10 +162,7 @@ def _check_autoplay() -> list[CheckResult]:
                 "Disable AutoPlay for all drive types so the remaining drive types "
                 "can no longer auto-execute content."
             ),
-            command=(
-                f"Set-ItemProperty -Path '{_AUTOPLAY_KEY}' "
-                "-Name NoDriveTypeAutoRun -Value 255 -Type DWord -Force"
-            ),
+            command=_CMD_AUTOPLAY_DISABLE,
         )]
 
     return [CheckResult(
@@ -158,10 +173,7 @@ def _check_autoplay() -> list[CheckResult]:
         description="Checks whether AutoPlay is disabled for all drive types.",
         details=f"AutoPlay may be enabled (NoDriveTypeAutoRun = {val}).",
         remediation="Disable AutoPlay for all drive types so removable media cannot auto-execute content.",
-        command=(
-            f"Set-ItemProperty -Path '{_AUTOPLAY_KEY}' "
-            "-Name NoDriveTypeAutoRun -Value 255 -Type DWord -Force"
-        ),
+        command=_CMD_AUTOPLAY_DISABLE,
     )]
 
 
@@ -297,15 +309,19 @@ def _check_audit_policy() -> list[CheckResult]:
     entries = data if isinstance(data, list) else ([data] if data else [])
 
     if not entries:
+        # auditpol needs elevation (and its subcategory names are localized), so an
+        # empty result on a default non-admin run does not mean auditing is off.
+        # Report INFO (score-neutral), not a WARN that penalises a healthy machine.
         return [CheckResult(
             category=CATEGORY,
             check_name="Audit Policy",
-            status=Status.WARN,
-            severity=Severity.MEDIUM,
+            status=Status.INFO,
+            severity=Severity.INFO,
             description="Checks that key audit policy subcategories log Success/Failure events.",
             details=(
-                "Could not retrieve audit policy (auditpol may require elevation). "
-                "Key events like logon failures may not be recorded."
+                "Could not retrieve audit policy (auditpol typically requires "
+                "Administrator, or subcategory names are localized). Key events may "
+                "not be assessed."
             ),
             remediation="Run Apotrope as Administrator to check audit policy.",
         )]
@@ -318,9 +334,11 @@ def _check_audit_policy() -> list[CheckResult]:
         if name:
             audit_map[name] = setting
 
-    no_audit = [name for name, setting in audit_map.items() if setting == "No Auditing"]
+    no_audit = [name for name in _EXPECTED_AUDIT if audit_map.get(name) == "No Auditing"]
+    missing = [name for name in _EXPECTED_AUDIT if name not in audit_map]
 
-    if no_audit:
+    if no_audit or missing:
+        problem = no_audit + [f"{name} (not reported)" for name in missing]
         return [CheckResult(
             category=CATEGORY,
             check_name="Audit Policy",
@@ -328,27 +346,24 @@ def _check_audit_policy() -> list[CheckResult]:
             severity=Severity.MEDIUM,
             description="Checks that key audit policy subcategories log Success/Failure events.",
             details=(
-                f"The following subcategories have auditing disabled: "
-                f"{', '.join(no_audit)}. "
-                "Security-relevant events may not be recorded."
+                "Not all expected audit subcategories are confirmed logging: "
+                f"{', '.join(problem)}. Security-relevant events may not be recorded."
             ),
             remediation=(
-                "Enable audit logging for the key subcategories that currently have "
-                "auditing disabled so security-relevant events are recorded. This can "
-                "also be configured via Group Policy (secpol.msc → Advanced Audit Policy "
-                "Configuration)."
+                "Enable audit logging for the listed subcategories so security-relevant "
+                "events are recorded. This can also be configured via Group Policy "
+                "(secpol.msc → Advanced Audit Policy Configuration)."
             ),
             command="auditpol /set /subcategory:'Logon' /success:enable /failure:enable",
         )]
 
-    checked = ", ".join(audit_map.keys()) if audit_map else "none found"
     return [CheckResult(
         category=CATEGORY,
         check_name="Audit Policy",
         status=Status.PASS,
         severity=Severity.MEDIUM,
         description="Checks that key audit policy subcategories log Success/Failure events.",
-        details=f"Auditing is configured for checked subcategories: {checked}.",
+        details=f"Auditing is configured for all expected subcategories: {', '.join(_EXPECTED_AUDIT)}.",
         remediation="",
     )]
 
@@ -369,6 +384,27 @@ def _check_screen_lock() -> list[CheckResult]:
 
     screensaver_active = active == "1"
     password_on_resume = secure == "1"
+
+    # A machine-wide inactivity limit locks the console even without a per-user
+    # screensaver, so a properly hardened machine should not be WARNed here.
+    machine_raw = data.get("MachineInactivity")
+    try:
+        machine_secs = int(machine_raw) if machine_raw is not None else 0
+    except (TypeError, ValueError):
+        machine_secs = 0
+    if 0 < machine_secs <= _LOCK_WARN_SECS:
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="Screen Lock Timeout",
+            status=Status.PASS,
+            severity=Severity.MEDIUM,
+            description=f"Checks that the screen automatically locks within {_LOCK_WARN_SECS // 60} minutes.",
+            details=(
+                f"Machine inactivity limit is set to {machine_secs // 60} minute(s); "
+                "the machine locks automatically on inactivity."
+            ),
+            remediation="",
+        )]
 
     if not screensaver_active:
         return [CheckResult(

--- a/src/apotrope/checks/misc.py
+++ b/src/apotrope/checks/misc.py
@@ -24,8 +24,20 @@ _PS_AUTOPLAY = (
 )
 # Create the policy key first: Set-ItemProperty -Force does NOT create a missing
 # key, and the NOTSET finding fires precisely when that key is absent.
+# `Set-ItemProperty -Force` cannot create a missing key, so the NOTSET branch
+# genuinely needs a New-Item — but on the *registry* provider `New-Item -Force`
+# REPLACES an existing key, deleting every value and subkey under it. This key is
+# shared with unrelated Explorer policies (NoRecentDocsHistory, NoActiveDesktop,
+# ForceActiveDesktopOn, ...), and the two other branches that emit this command
+# are only reachable when a value was read back, i.e. when the key already
+# exists. Unguarded, the paste would destroy those neighbouring policies.
+#
+# Kept as one module-level string so tools/command_audit.py still resolves it
+# statically; a wrapper it cannot resolve collapses the command to "{expr}" and
+# drops it from the lint inventory.
 _CMD_AUTOPLAY_DISABLE = (
-    f"New-Item -Path '{_AUTOPLAY_KEY}' -Force | Out-Null\n"
+    f"if (-not (Test-Path '{_AUTOPLAY_KEY}')) "
+    f"{{ New-Item -Path '{_AUTOPLAY_KEY}' -Force | Out-Null }}\n"
     f"Set-ItemProperty -Path '{_AUTOPLAY_KEY}' -Name NoDriveTypeAutoRun -Value 255 "
     "-Type DWord -Force"
 )

--- a/src/apotrope/checks/network.py
+++ b/src/apotrope/checks/network.py
@@ -66,6 +66,30 @@ _CMD_NETBIOS_DISABLE = (
     "-Arguments @{ TcpipNetbiosOptions = 2 } | Out-Null }"
 )
 
+# Port 3389. Two deliberate choices here:
+#
+# -Group '@FirewallAPI.dll,-28752' rather than -DisplayGroup 'Remote Desktop':
+# DisplayGroup is the resolved MUI string, so it matches nothing on non-English
+# Windows and the cmdlet no-ops with a non-terminating error the operator will
+# not notice.
+#
+# The scoping line is COMMENTED OUT and carries no default scope. Making the
+# selector locale-neutral is exactly what makes an active scoping line
+# dangerous: 'LocalSubnet' locks out any operator connected from another subnet
+# — a jump host, a VPN pool, a different VLAN — which is the normal enterprise
+# case and the very outcome the NLA-not-block choice was meant to avoid. The
+# operator must supply their own management network.
+_CMD_RDP_EXPOSED = (
+    "# Require Network Level Authentication for RDP:\n"
+    "Set-ItemProperty -Path "
+    "'HKLM:\\System\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp' "
+    "-Name 'UserAuthentication' -Value 1\n"
+    "# Then restrict who can reach 3389. Replace the range below with YOUR\n"
+    "# management network, and confirm it contains the address you are\n"
+    "# connected from before running it — this can end your own RDP session:\n"
+    "# Set-NetFirewallRule -Group '@FirewallAPI.dll,-28752' -RemoteAddress 10.0.0.0/8"
+)
+
 
 def run() -> list[CheckResult]:
     """Return network exposure checks.
@@ -125,20 +149,15 @@ def _check_listening_ports() -> list[CheckResult]:
         elif port == 3389:
             # The finding is "RDP exposed; ensure NLA" — so the command must enforce
             # NLA and scope access, NOT blindly block 3389 (which would sever the
-            # operator's own RDP session mid-audit).
+            # operator's own RDP session mid-audit). See _CMD_RDP_EXPOSED for why
+            # the scoping step ships commented and without a default scope.
             remediation = (
                 "RDP is exposed. Require Network Level Authentication and restrict who "
                 "can reach 3389 (firewall scope or a VPN / RD gateway) rather than "
-                "blocking it outright."
+                "blocking it outright. If the RDP settings are managed by Group Policy, "
+                "change them in the GPO — a local registry edit is reverted on refresh."
             )
-            command = (
-                "# Require Network Level Authentication for RDP:\n"
-                "Set-ItemProperty -Path "
-                "'HKLM:\\System\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp' "
-                "-Name 'UserAuthentication' -Value 1\n"
-                "# Restrict RDP to the local subnet (adjust the scope as needed):\n"
-                "Set-NetFirewallRule -DisplayGroup 'Remote Desktop' -RemoteAddress LocalSubnet"
-            )
+            command = _CMD_RDP_EXPOSED
         else:
             remediation = (
                 f"Stop the service behind port {port} ({service}) and block the port in Windows Firewall."

--- a/src/apotrope/checks/network.py
+++ b/src/apotrope/checks/network.py
@@ -18,7 +18,10 @@ _PS_TCP_LISTEN = (
     "Get-Process -ErrorAction SilentlyContinue | ForEach-Object { $procs[$_.Id] = $_.ProcessName }; "
     "Get-NetTCPConnection -State Listen -ErrorAction SilentlyContinue "
     "| Select-Object LocalPort, LocalAddress, "
-    "@{N='ProcessName';E={if($procs[$_.OwningProcess]){$procs[$_.OwningProcess]}else{'Unknown'}}} "
+    # OwningProcess is a UInt32 but the hashtable is keyed by Get-Process.Id
+    # (Int32); cast the lookup key so the boxed-numeric types match (otherwise
+    # every port resolves to 'Unknown').
+    "@{N='ProcessName';E={if($procs[[int]$_.OwningProcess]){$procs[[int]$_.OwningProcess]}else{'Unknown'}}} "
     "| ConvertTo-Json -Compress"
 )
 
@@ -119,6 +122,23 @@ def _check_listening_ports() -> list[CheckResult]:
                 "    Disable-WindowsOptionalFeature -Online -FeatureName TelnetServer -NoRestart\n"
                 "}"
             )
+        elif port == 3389:
+            # The finding is "RDP exposed; ensure NLA" — so the command must enforce
+            # NLA and scope access, NOT blindly block 3389 (which would sever the
+            # operator's own RDP session mid-audit).
+            remediation = (
+                "RDP is exposed. Require Network Level Authentication and restrict who "
+                "can reach 3389 (firewall scope or a VPN / RD gateway) rather than "
+                "blocking it outright."
+            )
+            command = (
+                "# Require Network Level Authentication for RDP:\n"
+                "Set-ItemProperty -Path "
+                "'HKLM:\\System\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp' "
+                "-Name 'UserAuthentication' -Value 1\n"
+                "# Restrict RDP to the local subnet (adjust the scope as needed):\n"
+                "Set-NetFirewallRule -DisplayGroup 'Remote Desktop' -RemoteAddress LocalSubnet"
+            )
         else:
             remediation = (
                 f"Stop the service behind port {port} ({service}) and block the port in Windows Firewall."
@@ -203,7 +223,11 @@ def _check_netbios() -> list[CheckResult]:
     except ApotropeError as exc:
         return [_error("NetBIOS over TCP/IP", str(exc))]
 
-    options = data if isinstance(data, list) else ([data] if data else [])
+    # A single IP-enabled adapter with TcpipNetbiosOptions=0 (the DHCP default)
+    # serialises as the bare scalar 0. Do NOT use `[data] if data else []` here:
+    # 0 is falsy and would be dropped, making a DHCP adapter look like "no
+    # adapters". The empty-stdout case already arrives as [] (a list).
+    options = data if isinstance(data, list) else [data]
     # Normalise to plain ints
     opt_ints = []
     for o in options:

--- a/src/apotrope/checks/os_info.py
+++ b/src/apotrope/checks/os_info.py
@@ -108,6 +108,11 @@ def _channel_for(product_type: int | None, build: int) -> str:
     return "client"
 
 
+# Max build gap for the nearest-lower-base EOL fallback: a cumulative update sits
+# a few hundred builds above its base, but a larger gap is a different release.
+_FALLBACK_MAX_DELTA = 500
+
+
 def _lookup_eol(
     build: int,
     product_type: int | None = None,
@@ -131,6 +136,13 @@ def _lookup_eol(
     base = max((b for b in known if b <= build), default=None)
     if base is None:
         return None
+    # Post-GA cumulative updates sit just above their base build, but an unknown
+    # build far above the nearest base is a *different* release (e.g. a Server
+    # annual-channel build between two LTSC entries). Don't inherit the base's
+    # EOL date in that case — treat it as unknown so the caller WARNs instead of
+    # reporting a dead build as supported.
+    if build - base > _FALLBACK_MAX_DELTA:
+        return None
     rel = _RELEASES[(channel, base)]
     return (rel.name, rel.eol_date())
 
@@ -150,11 +162,21 @@ _PS_DOMAIN = (
     "| Select-Object PartOfDomain, Domain, Workgroup "
     "| ConvertTo-Json -Compress"
 )
-_PS_SECUREBOOT = "try { Confirm-SecureBootUEFI } catch { 'UNSUPPORTED' }"
+# Distinguish access-denied (non-admin) from a genuinely unsupported platform
+# (legacy BIOS): the generic catch defaults to ACCESSDENIED so an unexpected
+# error is treated as "could not determine" (INFO), never a false legacy-BIOS WARN.
+_PS_SECUREBOOT = (
+    "try { [string](Confirm-SecureBootUEFI) } "
+    "catch [System.PlatformNotSupportedException] { 'UNSUPPORTED' } "
+    "catch [System.UnauthorizedAccessException] { 'ACCESSDENIED' } "
+    "catch { 'ACCESSDENIED' }"
+)
 _PS_TPM = (
     "try { Get-Tpm | Select-Object TpmPresent, TpmReady, ManufacturerVersion "
     "| ConvertTo-Json -Compress } "
-    "catch { '{\"TpmPresent\":false,\"TpmReady\":false,\"ManufacturerVersion\":null}' }"
+    # null (not false) on failure: a thrown Get-Tpm means "could not determine",
+    # which must not be reported as "no TPM present".
+    "catch { '{\"TpmPresent\":null,\"TpmReady\":null,\"ManufacturerVersion\":null}' }"
 )
 
 
@@ -363,6 +385,19 @@ def _check_secure_boot() -> list[CheckResult]:
     except ApotropeError as exc:
         return [_error("Secure Boot", str(exc))]
 
+    if output.upper() == "ACCESSDENIED":
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="Secure Boot",
+            status=Status.INFO,
+            severity=Severity.INFO,
+            description="Checks whether UEFI Secure Boot is enabled.",
+            details="Could not determine Secure Boot state (Confirm-SecureBootUEFI "
+                    "requires Administrator / elevation).",
+            remediation="",
+            command="Confirm-SecureBootUEFI",
+        )]
+
     if output.upper() == "UNSUPPORTED":
         return [CheckResult(
             category=CATEGORY,
@@ -415,7 +450,24 @@ def _check_tpm() -> list[CheckResult]:
     if isinstance(data, list):
         data = data[0] if data else {}
 
-    present = bool(data.get("TpmPresent", False))
+    raw_present = data.get("TpmPresent")
+    if raw_present is None:
+        # Non-admin Get-Tpm returns TpmPresent=null (it does not throw), and the
+        # catch fallback emits null too. Either way the state is unknown — report
+        # INFO, never a false "No TPM chip detected" WARN on a machine that has one.
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="TPM Status",
+            status=Status.INFO,
+            severity=Severity.INFO,
+            description="Checks whether a TPM chip is present and functional.",
+            details="Could not determine TPM state (Get-Tpm returned no value; this "
+                    "typically requires Administrator privileges).",
+            remediation="",
+            command="Get-Tpm",
+        )]
+
+    present = bool(raw_present)
     ready = bool(data.get("TpmReady", False))
     # Get-Tpm's ManufacturerVersion can carry trailing NUL bytes from the
     # firmware WMI string; strip them so they don't leak into report output.

--- a/src/apotrope/checks/powershell.py
+++ b/src/apotrope/checks/powershell.py
@@ -207,7 +207,7 @@ def _check_psv2() -> list[CheckResult]:
             ),
         )]
 
-    if state in ("disabled", "unavailable"):
+    if state == "disabled":
         return [CheckResult(
             category=CATEGORY,
             check_name="PowerShell v2",
@@ -217,6 +217,9 @@ def _check_psv2() -> list[CheckResult]:
             details="PowerShell v2 is not installed or disabled.",
             remediation="",
         )]
+    # 'UNAVAILABLE' is the query-failure sentinel (e.g. Get-WindowsOptionalFeature
+    # needs elevation) — NOT proof v2 is absent. Fall through to the INFO branch
+    # below rather than claiming a secure state we could not confirm.
 
     # State could not be determined (e.g. non-Windows or missing module)
     return [CheckResult(

--- a/src/apotrope/checks/rdp.py
+++ b/src/apotrope/checks/rdp.py
@@ -14,14 +14,18 @@ CATEGORY = "Remote Access"
 
 _RDP_DEFAULT_PORT = 3389
 
-# Fetch all RDP-relevant registry values in one PS call.
+# Fetch all RDP-relevant registry values in one PS call. The Group Policy keys
+# under ...\Policies\... override the Terminal Server values, so they are read too.
 _PS_RDP = (
     "$ts  = 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server'; "
     "$rdp = 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp'; "
+    "$pol = 'HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services'; "
     "@{ "
-    "fDenyTSConnections  = (Get-ItemProperty $ts  -ErrorAction SilentlyContinue).fDenyTSConnections; "
-    "UserAuthentication  = (Get-ItemProperty $rdp -ErrorAction SilentlyContinue).UserAuthentication; "
-    "PortNumber          = (Get-ItemProperty $rdp -ErrorAction SilentlyContinue).PortNumber "
+    "fDenyTSConnections       = (Get-ItemProperty $ts  -ErrorAction SilentlyContinue).fDenyTSConnections; "
+    "UserAuthentication       = (Get-ItemProperty $rdp -ErrorAction SilentlyContinue).UserAuthentication; "
+    "PortNumber               = (Get-ItemProperty $rdp -ErrorAction SilentlyContinue).PortNumber; "
+    "PolicyDenyTSConnections  = (Get-ItemProperty $pol -ErrorAction SilentlyContinue).fDenyTSConnections; "
+    "PolicyUserAuthentication = (Get-ItemProperty $pol -ErrorAction SilentlyContinue).UserAuthentication "
     "} | ConvertTo-Json -Compress"
 )
 
@@ -65,21 +69,34 @@ def _check_rdp_enabled(data: dict) -> tuple[list[CheckResult], bool]:
     fDenyTSConnections = 0 → RDP enabled
     fDenyTSConnections = 1 (or absent) → RDP disabled
     """
-    raw = data.get("fDenyTSConnections")
+    # Group Policy overrides the Terminal Server value, so it wins when present.
+    policy_raw = data.get("PolicyDenyTSConnections")
+    system_raw = data.get("fDenyTSConnections")
+    effective = policy_raw if policy_raw is not None else system_raw
 
-    if raw is None:
-        # Key absent typically means RDP is disabled (default on desktop SKUs)
+    if effective is None:
+        # Neither value was readable. Do NOT assume RDP is disabled — a fail-open
+        # PASS here would hide an exposed RDP service on a machine we couldn't read.
         return ([CheckResult(
             category=CATEGORY,
             check_name="RDP Enabled",
-            status=Status.PASS,
+            status=Status.WARN,
             severity=Severity.HIGH,
             description="Checks whether Remote Desktop is enabled.",
-            details="RDP is disabled (fDenyTSConnections key not found — default disabled state).",
-            remediation="",
+            details=(
+                "Could not determine RDP state (neither the Terminal Server value nor "
+                "the policy override was readable). Not assuming RDP is disabled."
+            ),
+            remediation="Verify the RDP state and disable it if it is not required.",
+            command=(
+                "# Disable Remote Desktop if it is not required:\n"
+                "Set-ItemProperty -Path "
+                "'HKLM:\\System\\CurrentControlSet\\Control\\Terminal Server' "
+                "-Name 'fDenyTSConnections' -Value 1"
+            ),
         )], False)
 
-    rdp_enabled = int(raw) == 0   # 0 = connections allowed
+    rdp_enabled = int(effective) == 0   # 0 = connections allowed
 
     if rdp_enabled:
         result = CheckResult(
@@ -120,7 +137,10 @@ def _check_rdp_enabled(data: dict) -> tuple[list[CheckResult], bool]:
 
 def _check_rdp_nla(data: dict) -> list[CheckResult]:
     """Check whether Network Level Authentication is required for RDP."""
-    raw = data.get("UserAuthentication")
+    # Policy value overrides the per-listener value when present.
+    raw = data.get("PolicyUserAuthentication")
+    if raw is None:
+        raw = data.get("UserAuthentication")
 
     if raw is None:
         return [CheckResult(

--- a/src/apotrope/checks/rdp.py
+++ b/src/apotrope/checks/rdp.py
@@ -63,16 +63,82 @@ def run() -> list[CheckResult]:
     return results
 
 
+# Remediation commands, hoisted to module level so the policy-aware
+# `A if policy_managed else B` conditionals below keep the IfExp at the *root*
+# of the command= value. tools/command_audit.py expands both arms of a root
+# IfExp but collapses a concatenation or f-string wrapper to the literal token
+# "{expr}", which would drop these commands from the lint inventory and then
+# fail tools/verify_commands.py on the Windows job.
+#
+# The firewall selector is the locale-neutral group ID, not -DisplayGroup:
+# DisplayGroup is the resolved MUI string ("Remotedesktop" on de-DE), so it
+# matches nothing on non-English Windows and the cmdlet no-ops with a
+# non-terminating error.
+_CMD_DISABLE_RDP = (
+    "# Disable Remote Desktop (skip this if RDP is intentionally in use)\n"
+    "Set-ItemProperty -Path "
+    "'HKLM:\\System\\CurrentControlSet\\Control\\Terminal Server' "
+    "-Name 'fDenyTSConnections' -Value 1\n"
+    "Disable-NetFirewallRule -Group '@FirewallAPI.dll,-28752'"
+)
+
+_CMD_REQUIRE_NLA = (
+    "Set-ItemProperty -Path "
+    "'HKLM:\\System\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp' "
+    "-Name 'UserAuthentication' -Value 1"
+)
+
+# When Group Policy owns the value, a local registry write is not merely
+# ineffective — the policy is re-applied on every refresh (~90 min by default),
+# and during the rewrite window the local value briefly governs, which is the
+# documented cause of periodic RDP session drops (KB2083411). So the
+# policy-managed branches emit no command at all and point at the GPO instead.
+_GPO_ROOT = (
+    "Computer Configuration > Administrative Templates > Windows Components > "
+    "Remote Desktop Services > Remote Desktop Session Host"
+)
+_REMEDIATION_RDP_ENABLED_BY_POLICY = (
+    "Remote Desktop is enabled by Group Policy; editing the local registry value "
+    "has no effect while the policy is set (and is reverted on every refresh). "
+    "Change it in the winning GPO: " + _GPO_ROOT + " > Connections > "
+    "'Allow users to connect remotely by using Remote Desktop Services' -> Disabled. "
+    "Run 'gpresult /h rsop.html' to identify the winning GPO."
+)
+_REMEDIATION_NLA_BY_POLICY = (
+    "Network Level Authentication is controlled by Group Policy; editing the local "
+    "registry value has no effect while the policy is set. Change it in the winning "
+    "GPO: " + _GPO_ROOT + " > Security > 'Require user authentication for remote "
+    "connections by using Network Level Authentication' -> Enabled. "
+    "Run 'gpresult /h rsop.html' to identify the winning GPO."
+)
+
+
+def _effective_value(
+    data: dict, policy_name: str, local_name: str
+) -> tuple[object | None, bool]:
+    """Return ``(winning_value, policy_managed)`` for a policy-backed setting.
+
+    The Group Policy value under ``...\\Policies\\...`` overrides the local
+    Terminal Server value, so it wins when present. The second element records
+    *which source won*, because that decides whether a local ``Set-ItemProperty``
+    remediation would actually take effect — the caller must not have to
+    re-derive it after the winner has been collapsed into one variable.
+    """
+    policy_raw = data.get(policy_name)
+    if policy_raw is not None:
+        return policy_raw, True
+    return data.get(local_name), False
+
+
 def _check_rdp_enabled(data: dict) -> tuple[list[CheckResult], bool]:
     """Return (results, rdp_is_enabled) for the RDP enabled/disabled state.
 
     fDenyTSConnections = 0 → RDP enabled
     fDenyTSConnections = 1 (or absent) → RDP disabled
     """
-    # Group Policy overrides the Terminal Server value, so it wins when present.
-    policy_raw = data.get("PolicyDenyTSConnections")
-    system_raw = data.get("fDenyTSConnections")
-    effective = policy_raw if policy_raw is not None else system_raw
+    effective, policy_managed = _effective_value(
+        data, "PolicyDenyTSConnections", "fDenyTSConnections"
+    )
 
     if effective is None:
         # Neither value was readable. Do NOT assume RDP is disabled — a fail-open
@@ -106,20 +172,21 @@ def _check_rdp_enabled(data: dict) -> tuple[list[CheckResult], bool]:
             severity=Severity.HIGH,
             description="Checks whether Remote Desktop is enabled.",
             details=(
+                "Remote Desktop is enabled by Group Policy (fDenyTSConnections = 0)."
+                if policy_managed else
                 "Remote Desktop is enabled (fDenyTSConnections = 0). "
                 "Ensure access is restricted by firewall and NLA is required."
             ),
             remediation=(
+                _REMEDIATION_RDP_ENABLED_BY_POLICY
+                if policy_managed else
                 "If RDP isn't needed, disable it. If it is required, keep NLA required "
                 "and restrict access by firewall scope or a VPN / RD gateway."
             ),
-            command=(
-                "# Disable Remote Desktop (skip this if RDP is intentionally in use)\n"
-                "Set-ItemProperty -Path "
-                "'HKLM:\\System\\CurrentControlSet\\Control\\Terminal Server' "
-                "-Name 'fDenyTSConnections' -Value 1\n"
-                "Disable-NetFirewallRule -DisplayGroup 'Remote Desktop'"
-            ),
+            # Empty when policy-managed: handing the operator a paste that cannot
+            # work is worse than handing them none. Empty command= is already a
+            # first-class state here (see the NLA PASS branch below).
+            command=("" if policy_managed else _CMD_DISABLE_RDP),
         )
     else:
         result = CheckResult(
@@ -137,10 +204,9 @@ def _check_rdp_enabled(data: dict) -> tuple[list[CheckResult], bool]:
 
 def _check_rdp_nla(data: dict) -> list[CheckResult]:
     """Check whether Network Level Authentication is required for RDP."""
-    # Policy value overrides the per-listener value when present.
-    raw = data.get("PolicyUserAuthentication")
-    if raw is None:
-        raw = data.get("UserAuthentication")
+    raw, policy_managed = _effective_value(
+        data, "PolicyUserAuthentication", "UserAuthentication"
+    )
 
     if raw is None:
         return [CheckResult(
@@ -151,11 +217,9 @@ def _check_rdp_nla(data: dict) -> list[CheckResult]:
             description="Checks whether NLA is required for RDP connections.",
             details="Could not determine NLA setting (UserAuthentication key not found).",
             remediation="Require Network Level Authentication for RDP.",
-            command=(
-                "Set-ItemProperty -Path "
-                "'HKLM:\\System\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp' "
-                "-Name 'UserAuthentication' -Value 1"
-            ),
+            # Unconditional: this branch is reached only when *neither* source was
+            # readable, so policy_managed is False by construction.
+            command=_CMD_REQUIRE_NLA,
         )]
 
     nla_required = int(raw) == 1
@@ -174,13 +238,13 @@ def _check_rdp_nla(data: dict) -> list[CheckResult]:
         ),
         remediation=(
             "" if nla_required else
+            _REMEDIATION_NLA_BY_POLICY if policy_managed else
             "Require Network Level Authentication for RDP."
         ),
+        # No local command when the policy owns the value — it would be reverted
+        # at the next refresh. See _REMEDIATION_NLA_BY_POLICY.
         command=(
-            "" if nla_required else
-            "Set-ItemProperty -Path "
-            "'HKLM:\\System\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp' "
-            "-Name 'UserAuthentication' -Value 1"
+            "" if (nla_required or policy_managed) else _CMD_REQUIRE_NLA
         ),
     )]
 

--- a/src/apotrope/checks/uac.py
+++ b/src/apotrope/checks/uac.py
@@ -159,6 +159,23 @@ def _check_admin_behavior(data: dict) -> list[CheckResult]:
             ),
         )]
 
+    if level not in _ADMIN_BEHAVIOR:
+        # Only known, explicitly-safe values (1–5, all of which prompt) PASS.
+        # An unrecognized value is not proof of a secure config — report INFO
+        # rather than silently passing whatever is set.
+        return [CheckResult(
+            category=CATEGORY,
+            check_name="UAC Admin Consent Behavior",
+            status=Status.INFO,
+            severity=Severity.HIGH,
+            description="Checks the UAC consent prompt behavior for administrator accounts.",
+            details=(
+                f"ConsentPromptBehaviorAdmin = {level}: unrecognized value. "
+                "Verify this is an intended UAC configuration."
+            ),
+            remediation="",
+        )]
+
     return [CheckResult(
         category=CATEGORY,
         check_name="UAC Admin Consent Behavior",

--- a/src/apotrope/checks/updates.py
+++ b/src/apotrope/checks/updates.py
@@ -68,7 +68,7 @@ _PS_WU_SERVICE = (
 _PS_PENDING = (
     "try { "
     "$s = New-Object -ComObject Microsoft.Update.Session; "
-    "$r = $s.CreateUpdateSearcher().Search(\"IsInstalled=0 and Type='Software'\"); "
+    "$r = $s.CreateUpdateSearcher().Search(\"IsInstalled=0 and IsHidden=0 and Type='Software'\"); "
     "$r.Updates.Count "
     "} catch { 'UNAVAILABLE' }"
 )

--- a/tests/test_checks/test_encryption.py
+++ b/tests/test_checks/test_encryption.py
@@ -176,3 +176,34 @@ class TestEncryptionRunMultipleDrives:
             results = encryption.run()
         assert len(results) == 1
         assert results[0].status == Status.FAIL  # ProtectionStatus None → 0 → Off
+
+
+class TestEncryptionFixes:
+    def _run(self, vol):
+        with patch("apotrope.checks.encryption.run_powershell_json", return_value=[vol]):
+            return encryption.run()
+
+    def test_protected_but_partial_is_warn_not_pass(self):
+        # Protection On but only 55% encrypted → not yet fully protected → WARN.
+        vol = _vol("C:", "OperatingSystem", "EncryptionInProgress", protection=1, pct=55)
+        r = self._run(vol)[0]
+        assert r.status == Status.WARN
+        assert "55%" in r.details
+
+    def test_integer_enums_mapped_in_details(self):
+        # PS 5.1 serialises the enums as integers; they must render as names.
+        vol = {"MountPoint": "C:", "VolumeType": 0, "VolumeStatus": 1,
+               "ProtectionStatus": 1, "EncryptionMethod": "XtsAes256",
+               "EncryptionPercentage": 100}
+        r = self._run(vol)[0]
+        assert r.status == Status.PASS
+        assert "OperatingSystem" in r.details
+        assert "FullyEncrypted" in r.details
+
+    def test_ps7_string_protection_status_handled(self):
+        # PS 7 may serialise ProtectionStatus/percentage as strings; int() would crash.
+        vol = {"MountPoint": "C:", "VolumeType": "OperatingSystem",
+               "VolumeStatus": "FullyEncrypted", "ProtectionStatus": "On",
+               "EncryptionMethod": "XtsAes256", "EncryptionPercentage": "100"}
+        r = self._run(vol)[0]
+        assert r.status == Status.PASS

--- a/tests/test_checks/test_firewall.py
+++ b/tests/test_checks/test_firewall.py
@@ -98,7 +98,11 @@ class TestFirewallRunHappyPath:
         with patch("apotrope.checks.firewall.run_powershell_json",
                    return_value=_PROFILE_GOOD):
             results = firewall.run()
-        assert len(results) == 2
+        # Two results for the Domain profile, plus a "Profiles Present" ERROR
+        # because Private/Public were not reported (can't silently vanish).
+        assert len(results) == 3
+        assert any(r.status == Status.ERROR and "Profiles Present" in r.check_name
+                   for r in results)
 
 
 # ---------------------------------------------------------------------------
@@ -179,3 +183,23 @@ class TestParseActionFallback:
 
     def test_unintable_object_does_not_raise(self):
         assert firewall._parse_action(object()).startswith("Unknown(")
+
+
+class TestFirewallFailClosed:
+    def test_unknown_inbound_action_is_warn(self):
+        profiles = [
+            {"Name": "Domain", "Enabled": True, "DefaultInboundAction": 99, "DefaultOutboundAction": 2},
+            {"Name": "Private", "Enabled": True, "DefaultInboundAction": 4, "DefaultOutboundAction": 2},
+            {"Name": "Public", "Enabled": True, "DefaultInboundAction": 4, "DefaultOutboundAction": 2},
+        ]
+        with patch("apotrope.checks.firewall.run_powershell_json", return_value=profiles):
+            results = firewall.run()
+        inbound = next(r for r in results if "Domain Default Inbound" in r.check_name)
+        assert inbound.status == Status.WARN
+
+    def test_empty_profiles_returns_error_not_empty(self):
+        # The whole Firewall category must not silently vanish on an empty result.
+        with patch("apotrope.checks.firewall.run_powershell_json", return_value=[]):
+            results = firewall.run()
+        assert results
+        assert any(r.status == Status.ERROR for r in results)

--- a/tests/test_checks/test_misc.py
+++ b/tests/test_checks/test_misc.py
@@ -295,6 +295,27 @@ class TestMiscFixes:
             r = misc._check_autoplay()[0]
         assert "New-Item" in r.command
 
+    def test_autoplay_new_item_is_guarded_by_test_path(self):
+        # `New-Item -Force` on the registry provider REPLACES an existing key,
+        # deleting the unrelated Explorer policies that share it. Assert the
+        # guard wraps the New-Item rather than merely appearing somewhere in the
+        # block — an unguarded create on a later line would still be destructive.
+        with patch("apotrope.checks.misc.run_powershell", return_value="NOTSET"):
+            r = misc._check_autoplay()[0]
+        guard = r.command.splitlines()[0]
+        assert guard.startswith("if (-not (Test-Path ")
+        assert "New-Item" in guard
+        assert "New-Item" not in "\n".join(r.command.splitlines()[1:])
+
+    def test_autoplay_remediation_guarded_on_every_branch(self):
+        # 158 -> "partially disabled" WARN; 0 and an unparseable value -> the
+        # AutoPlay-enabled branch. Both read a value back, so the key provably
+        # exists — precisely the case an unguarded New-Item -Force would wipe.
+        for output in ("158", "0", "notanint"):
+            with patch("apotrope.checks.misc.run_powershell", return_value=output):
+                r = misc._check_autoplay()[0]
+            assert "Test-Path" in r.command, f"unguarded New-Item for output {output!r}"
+
     def test_machine_inactivity_policy_is_pass(self):
         # A machine-wide inactivity lock counts even without a per-user screensaver.
         with patch("apotrope.checks.misc.run_powershell_json",

--- a/tests/test_checks/test_misc.py
+++ b/tests/test_checks/test_misc.py
@@ -133,12 +133,15 @@ class TestCheckAuditPolicy:
             return misc._check_audit_policy()
 
     def test_all_audited_is_pass(self):
-        entries = [
-            self._entry("Logon", "Success and Failure"),
-            self._entry("Credential Validation", "Failure"),
-        ]
+        # PASS requires ALL expected subcategories present and auditing.
+        entries = [self._entry(name) for name in misc._EXPECTED_AUDIT]
         r = self._run(entries)[0]
         assert r.status == Status.PASS
+
+    def test_partial_subset_is_warn(self):
+        # A nonempty subset that omits expected subcategories must not PASS.
+        r = self._run([self._entry("Logon")])[0]
+        assert r.status == Status.WARN
 
     def test_no_auditing_entry_is_warn(self):
         entries = [
@@ -149,9 +152,11 @@ class TestCheckAuditPolicy:
         assert r.status == Status.WARN
         assert "Logon" in r.details
 
-    def test_empty_list_is_warn(self):
+    def test_empty_list_is_info_not_warn(self):
+        # Non-admin / localized auditpol returns nothing; that is "could not
+        # assess" (INFO), not a scored WARN penalising a healthy machine.
         r = self._run([])[0]
-        assert r.status == Status.WARN
+        assert r.status == Status.INFO
 
     def test_warn_has_remediation(self):
         r = self._run([self._entry("Logon", "No Auditing")])[0]
@@ -280,3 +285,20 @@ class TestScreenLockPayloadShapes:
             r = misc._check_screen_lock()[0]
         assert r.status == Status.WARN
         assert "0 or unset" in r.details
+
+
+class TestMiscFixes:
+    def test_autoplay_command_creates_key(self):
+        # Set-ItemProperty -Force does not create a missing key; the command must
+        # New-Item it first (the NOTSET finding fires when the key is absent).
+        with patch("apotrope.checks.misc.run_powershell", return_value="NOTSET"):
+            r = misc._check_autoplay()[0]
+        assert "New-Item" in r.command
+
+    def test_machine_inactivity_policy_is_pass(self):
+        # A machine-wide inactivity lock counts even without a per-user screensaver.
+        with patch("apotrope.checks.misc.run_powershell_json",
+                   return_value={"Active": "0", "Secure": "0", "Timeout": 0,
+                                 "MachineInactivity": 600}):
+            r = misc._check_screen_lock()[0]
+        assert r.status == Status.PASS

--- a/tests/test_checks/test_network.py
+++ b/tests/test_checks/test_network.py
@@ -237,3 +237,35 @@ class TestNetworkFixes:
         r = next(r for r in results if "3389" in r.check_name)
         assert "Action Block" not in r.command
         assert "UserAuthentication" in r.command
+
+
+class TestRdpPortRemediationSafety:
+    """The port-3389 remediation must not lock the operator out of their own box."""
+
+    @staticmethod
+    def _rdp_command():
+        from apotrope.checks import network
+        return network._CMD_RDP_EXPOSED
+
+    @staticmethod
+    def _active_lines(cmd):
+        return [ln for ln in cmd.splitlines() if not ln.lstrip().startswith("#")]
+
+    def test_localsubnet_is_not_shipped_at_all(self):
+        # Making the selector locale-neutral is exactly what makes an active
+        # scoping line dangerous: it now matches everywhere, so a LocalSubnet
+        # default would cut off any operator on another subnet.
+        assert "LocalSubnet" not in self._rdp_command()
+
+    def test_scoping_line_is_commented_out(self):
+        active = "\n".join(self._active_lines(self._rdp_command()))
+        assert "Set-NetFirewallRule" not in active
+
+    def test_nla_line_is_active(self):
+        active = "\n".join(self._active_lines(self._rdp_command()))
+        assert "UserAuthentication" in active
+
+    def test_uses_locale_neutral_group_id(self):
+        cmd = self._rdp_command()
+        assert "@FirewallAPI.dll,-28752" in cmd
+        assert "-DisplayGroup" not in cmd

--- a/tests/test_checks/test_network.py
+++ b/tests/test_checks/test_network.py
@@ -206,3 +206,34 @@ class TestIpv6ErrorFallback:
             r = network._check_ipv6()[0]
         assert r.status == Status.INFO
         assert "not active" in r.details
+
+
+class TestNetworkFixes:
+    def _ports(self, conns):
+        with patch("apotrope.checks.network.run_powershell_json", return_value=conns):
+            return network._check_listening_ports()
+
+    def _netbios(self, value):
+        with patch("apotrope.checks.network.run_powershell_json", return_value=value):
+            return network._check_netbios()
+
+    def test_process_lookup_casts_to_int(self):
+        # Int32 (Get-Process.Id) vs UInt32 (OwningProcess) mismatch made every
+        # port resolve to "Unknown" until the lookup key is cast to [int].
+        assert "[int]$_.OwningProcess" in network._PS_TCP_LISTEN
+
+    def test_single_dhcp_netbios_scalar_zero_is_warn(self):
+        # A lone DHCP adapter serialises as the bare scalar 0 and must not be dropped.
+        r = self._netbios(0)[0]
+        assert r.status == Status.WARN
+        assert r.severity == Severity.LOW
+
+    def test_single_disabled_netbios_scalar_two_is_pass(self):
+        r = self._netbios(2)[0]
+        assert r.status == Status.PASS
+
+    def test_rdp_port_command_enforces_nla_not_block(self):
+        results = self._ports([_conn(3389)])
+        r = next(r for r in results if "3389" in r.check_name)
+        assert "Action Block" not in r.command
+        assert "UserAuthentication" in r.command

--- a/tests/test_checks/test_os_info.py
+++ b/tests/test_checks/test_os_info.py
@@ -477,3 +477,37 @@ class TestListShapedPayloads:
 class TestNowHelper:
     def test_now_returns_utc_aware_datetime(self):
         assert os_info._now().tzinfo is timezone.utc
+
+
+class TestOsInfoFailClosed:
+    def test_tpm_null_present_is_info(self):
+        # Non-admin Get-Tpm returns TpmPresent=null (does not throw) — "unknown",
+        # not "no TPM".
+        with patch("apotrope.checks.os_info.run_powershell_json",
+                   return_value={"TpmPresent": None, "TpmReady": None,
+                                 "ManufacturerVersion": None}):
+            r = os_info._check_tpm()[0]
+        assert r.status == Status.INFO
+
+    def test_tpm_genuine_absent_still_warns(self):
+        with patch("apotrope.checks.os_info.run_powershell_json",
+                   return_value={"TpmPresent": False, "TpmReady": False,
+                                 "ManufacturerVersion": None}):
+            r = os_info._check_tpm()[0]
+        assert r.status == Status.WARN
+
+    def test_secure_boot_access_denied_is_info(self):
+        with patch("apotrope.checks.os_info.run_powershell", return_value="ACCESSDENIED"):
+            r = os_info._check_secure_boot()[0]
+        assert r.status == Status.INFO
+
+    def test_secure_boot_unsupported_still_warns(self):
+        with patch("apotrope.checks.os_info.run_powershell", return_value="UNSUPPORTED"):
+            r = os_info._check_secure_boot()[0]
+        assert r.status == Status.WARN
+
+    def test_eol_fallback_bounded_for_distant_build(self):
+        # Build 25398 (a server annual-channel build) sits ~5000 builds above the
+        # nearest base 20348 but below 26100 — it must NOT inherit 20348's EOL
+        # date (which would report a dead build as supported).
+        assert os_info._lookup_eol(25398, product_type=3) is None

--- a/tests/test_checks/test_powershell.py
+++ b/tests/test_checks/test_powershell.py
@@ -166,9 +166,11 @@ class TestCheckPsv2:
         r = self._run("Disabled")[0]
         assert r.status == Status.PASS
 
-    def test_unavailable_is_pass(self):
+    def test_unavailable_is_info_not_pass(self):
+        # 'UNAVAILABLE' is a query-failure sentinel (needs elevation), not proof
+        # v2 is absent — it must not be reported as a secure PASS.
         r = self._run("UNAVAILABLE")[0]
-        assert r.status == Status.PASS
+        assert r.status == Status.INFO
 
     def test_unknown_state_is_info(self):
         r = self._run("SomeOtherState")[0]

--- a/tests/test_checks/test_rdp.py
+++ b/tests/test_checks/test_rdp.py
@@ -43,10 +43,23 @@ class TestCheckRdpEnabled:
         results, _ = rdp._check_rdp_enabled(_data(deny=0))
         assert "fDenyTSConnections" in results[0].command
 
-    def test_key_absent_treated_as_disabled(self):
+    def test_both_keys_absent_is_warn_not_pass(self):
+        # Fail-closed: with neither the Terminal Server value nor the policy
+        # override readable, do NOT assume RDP is disabled.
         results, enabled = rdp._check_rdp_enabled({})
-        assert results[0].status == Status.PASS
+        assert results[0].status == Status.WARN
         assert enabled is False
+
+    def test_policy_override_enables_rdp(self):
+        # The GPO key overrides the Terminal Server value.
+        results, enabled = rdp._check_rdp_enabled(
+            {"fDenyTSConnections": 1, "PolicyDenyTSConnections": 0}
+        )
+        assert enabled is True
+
+    def test_policy_nla_override_fails(self):
+        r = rdp._check_rdp_nla({"UserAuthentication": 1, "PolicyUserAuthentication": 0})[0]
+        assert r.status == Status.FAIL
 
     def test_returns_tuple(self):
         result = rdp._check_rdp_enabled(_data())

--- a/tests/test_checks/test_rdp.py
+++ b/tests/test_checks/test_rdp.py
@@ -56,10 +56,45 @@ class TestCheckRdpEnabled:
             {"fDenyTSConnections": 1, "PolicyDenyTSConnections": 0}
         )
         assert enabled is True
+        # A local Set-ItemProperty is reverted at the next policy refresh, so
+        # the verdict source must decide the remediation: point at the GPO and
+        # hand over no command that cannot work.
+        assert results[0].command == ""
+        assert "Group Policy" in results[0].remediation
+        assert "gpresult" in results[0].remediation
+
+    def test_non_policy_enabled_rdp_still_has_a_command(self):
+        results, enabled = rdp._check_rdp_enabled({"fDenyTSConnections": 0})
+        assert enabled is True
+        assert "fDenyTSConnections" in results[0].command
 
     def test_policy_nla_override_fails(self):
         r = rdp._check_rdp_nla({"UserAuthentication": 1, "PolicyUserAuthentication": 0})[0]
         assert r.status == Status.FAIL
+        assert r.command == ""
+        assert "Group Policy" in r.remediation
+        assert "Network Level Authentication" in r.remediation
+
+    def test_non_policy_nla_fail_still_has_a_command(self):
+        r = rdp._check_rdp_nla({"UserAuthentication": 0})[0]
+        assert r.status == Status.FAIL
+        assert "UserAuthentication" in r.command
+
+    def test_unreadable_nla_still_has_a_command(self):
+        """Neither source readable -> policy_managed is False by construction."""
+        r = rdp._check_rdp_nla({})[0]
+        assert r.status == Status.WARN
+        assert "UserAuthentication" in r.command
+
+
+class TestLocaleNeutralFirewallSelector:
+    """-DisplayGroup is a localized MUI string and matches nothing on de-DE/ja-JP."""
+
+    def test_disable_uses_group_id_not_displaygroup(self):
+        results, _ = rdp._check_rdp_enabled({"fDenyTSConnections": 0})
+        cmd = results[0].command
+        assert "@FirewallAPI.dll,-28752" in cmd
+        assert "-DisplayGroup" not in cmd
 
     def test_returns_tuple(self):
         result = rdp._check_rdp_enabled(_data())

--- a/tests/test_checks/test_uac.py
+++ b/tests/test_checks/test_uac.py
@@ -173,3 +173,15 @@ class TestRun:
             results = uac.run()
         statuses = {r.check_name: r.status for r in results}
         assert statuses["UAC Enabled"] == Status.FAIL
+
+
+class TestUacUnknownConsent:
+    def test_unknown_admin_consent_value_is_info_not_pass(self):
+        # An unrecognized ConsentPromptBehaviorAdmin value is not proof of a safe
+        # config — it must not silently PASS.
+        r = uac._check_admin_behavior(_data(admin_behavior=99))[0]
+        assert r.status == Status.INFO
+
+    def test_known_admin_consent_value_still_passes(self):
+        r = uac._check_admin_behavior(_data(admin_behavior=5))[0]
+        assert r.status == Status.PASS

--- a/tests/test_checks/test_updates.py
+++ b/tests/test_checks/test_updates.py
@@ -251,3 +251,8 @@ class TestNowHelper:
     def test_now_returns_utc_aware_datetime(self):
         now = updates._now()
         assert now.tzinfo is timezone.utc
+
+
+def test_pending_query_excludes_hidden_updates():
+    # Admin-hidden updates must not be counted as pending (false FAIL otherwise).
+    assert "IsHidden=0" in updates._PS_PENDING

--- a/tests/test_remediation_commands.py
+++ b/tests/test_remediation_commands.py
@@ -64,3 +64,46 @@ def test_commented_reboot_is_not_flagged_destructive() -> None:
     # A reboot kept as a comment is safe — the lint only inspects active lines.
     ok = [Command("fake.py", 1, "Set-ItemProperty -Path X -Name Y -Value 1\n# Restart-Computer")]
     assert not [v for v in lint_commands(ok) if v.rule == "destructive-command"]
+
+
+class TestLocalizedFirewallSelectorRule:
+    """Regression guard: -DisplayGroup must never come back."""
+
+    def test_rule_flags_displaygroup_selectors(self):
+        planted = [
+            Command("fake.py", 1, "Disable-NetFirewallRule -DisplayGroup 'Remote Desktop'"),
+            Command("fake.py", 2,
+                    "Set-NetFirewallRule -DisplayGroup 'Remote Desktop' -RemoteAddress LocalSubnet"),
+        ]
+        hits = [v for v in lint_commands(planted) if v.rule == "localized-firewall-selector"]
+        assert len(hits) == 2
+
+    def test_group_indirect_string_is_accepted(self):
+        ok = [Command("fake.py", 1, "Disable-NetFirewallRule -Group '@FirewallAPI.dll,-28752'")]
+        assert not [v for v in lint_commands(ok) if v.rule == "localized-firewall-selector"]
+
+    def test_new_rule_displayname_is_not_flagged(self):
+        """-DisplayName *names* a rule being created; it is not a localized selector."""
+        ok = [Command("fake.py", 1,
+                      "New-NetFirewallRule -DisplayName 'Block inbound TCP 21 (Apotrope)' "
+                      "-Direction Inbound -LocalPort 21 -Protocol TCP -Action Block")]
+        assert not [v for v in lint_commands(ok) if v.rule == "localized-firewall-selector"]
+
+    def test_commented_selector_is_ignored(self):
+        ok = [Command("fake.py", 1, "# Set-NetFirewallRule -DisplayGroup 'Remote Desktop'")]
+        assert not [v for v in lint_commands(ok) if v.rule == "localized-firewall-selector"]
+
+
+class TestUnresolvedExpressionRule:
+    """A '{expr}' in collected text means the real command was never linted."""
+
+    def test_rule_flags_unresolved_expression(self):
+        planted = [Command("fake.py", 1, "Set-ItemProperty -Path 'X'\n{expr}")]
+        hits = [v for v in lint_commands(planted) if v.rule == "unresolved-expression"]
+        assert len(hits) == 1
+
+    def test_real_inventory_has_no_unresolved_expressions(self):
+        """Guards the policy-aware `A if cond else B` conditionals in rdp.py."""
+        bad = [v for v in lint_commands(collect_commands())
+               if v.rule == "unresolved-expression"]
+        assert not bad, bad

--- a/tools/command_audit.py
+++ b/tools/command_audit.py
@@ -177,6 +177,25 @@ _ANGLE_PLACEHOLDER = re.compile(r"(?<!\?)<[A-Za-z_][\w -]*>")
 _DESTRUCTIVE = re.compile(
     r"\b(Clear-Tpm|Restart-Computer|Stop-Computer)\b|-AllowClear\b|-AllowPhysicalPresence\b"
 )
+# -DisplayGroup selects an EXISTING firewall rule by its resolved MUI string
+# ('Remote Desktop' is @FirewallAPI.dll,-28752 rendered in the display
+# language), so it matches nothing on non-English Windows and the cmdlet
+# no-ops with a non-terminating error — the worst outcome for a copy-paste
+# block, since the earlier lines did run and the operator sees no failure.
+# Select by the locale-neutral -Group indirect resource string instead.
+#
+# -DisplayName is deliberately NOT flagged: on New-NetFirewallRule it *names*
+# the rule being created (and is mandatory — see firewall-rule-no-displayname),
+# and it is also the correct way to manage a rule Apotrope itself created.
+_LOCALIZED_FW_SELECTOR = re.compile(
+    r"\b(?:Get|Set|Enable|Disable|Remove|Copy|Rename|Show)-NetFirewallRule\b"
+    r"[^\n|]*?\s-DisplayGroup\b"
+)
+# A literal "{expr}" in collected text is always an extraction failure, never a
+# real command: _resolve could not statically resolve the expression, so the
+# lint rules below (and tools/verify_commands.py) are inspecting a placeholder
+# rather than the command that actually ships.
+_UNRESOLVED_EXPR = re.compile(r"\{expr\}")
 
 
 def _uncommented_lines(text: str) -> list[str]:
@@ -219,6 +238,24 @@ def lint_commands(commands: list[Command]) -> list[Violation]:
                 cmd.module, cmd.line, "destructive-command",
                 "destructive/unattended command (TPM clear or bare reboot) must be a "
                 "commented manual step, not copy-paste",
+                text,
+            ))
+        if _LOCALIZED_FW_SELECTOR.search(active):
+            violations.append(Violation(
+                cmd.module, cmd.line, "localized-firewall-selector",
+                "-DisplayGroup selects an existing firewall rule by its localized MUI "
+                "string — it matches nothing on non-English Windows and silently no-ops; "
+                "use -Group '@FirewallAPI.dll,-NNNNN' or a stable -Name rule ID",
+                text,
+            ))
+        # Checked against the raw text, not `active`: an extraction failure in a
+        # commented line is still an extraction failure.
+        if _UNRESOLVED_EXPR.search(text):
+            violations.append(Violation(
+                cmd.module, cmd.line, "unresolved-expression",
+                "command text contains the literal '{expr}' — the AST extractor could "
+                "not resolve this expression, so the real command is unlinted. Keep any "
+                "conditional as `A if cond else B` at the root of the command= value",
                 text,
             ))
     return violations


### PR DESCRIPTION
> Stacked on #92. GitHub retargets this to `main` once #92 merges.

Two problems across the check modules: on a **non-admin run** — the most common invocation — several checks turned "could not determine" into a confident wrong verdict; and several produced plainly incorrect results.

## Fail closed on uncertainty

Unreadable, denied or null state now reports INFO or a score-neutral ERROR — never PASS, and never a scored WARN that penalises a healthy machine.

| Check | Before | After |
|---|---|---|
| TPM | null `Get-Tpm` under non-admin → "No TPM chip detected" | INFO |
| Secure Boot | access denied indistinguishable from legacy BIOS | INFO, distinguished |
| PowerShell v2 | `UNAVAILABLE` sentinel → PASS | INFO |
| Audit policy | empty result → scored WARN; PASS on any subset | INFO; PASS requires all expected subcategories |
| UAC | unknown `ConsentPromptBehaviorAdmin` → PASS | INFO |
| RDP | unreadable state assumed "disabled" | ERROR; GPO override keys consulted and win |
| Firewall | a missing profile silently vanished | unknown inbound → WARN, missing profile → ERROR |

## Correctness fixes

- **network** — an `[int]` cast fixes the Int32/UInt32 join, so listening ports report a real process name instead of always "Unknown"; a lone DHCP adapter's bare `0` is no longer dropped.
- **encryption** — PASS requires protection on *and* fully encrypted (mid-encryption is a WARN); integer enums render as names; PowerShell 7 string enums are coerced instead of crashing.
- **misc** — screen lock honors the machine inactivity policy; the AutoPlay remediation creates the key it writes to, since `Set-ItemProperty -Force` does not.
- **os_info** — the end-of-life nearest-lower fallback is bounded, so a build far above the table is not reported supported.
- **updates** — `IsHidden=0` excludes admin-hidden updates from the pending count.

## Remediation safety

- **Policy-managed RDP findings name the controlling GPO** instead of writing the local registry value the policy overrides. Per KB2083411 those policy values are rewritten on every refresh (~90 min), and the local value governs in between — so a pasted `fDenyTSConnections=1` on a GPO-managed host hardens nothing and reproduces Microsoft's documented periodic session drop indefinitely.
- **Locale-neutral firewall selectors** — `-Group '@FirewallAPI.dll,-28752'` replaces `-DisplayGroup 'Remote Desktop'`, which is a resolved MUI string and matches nothing on non-English Windows, no-opping with a non-terminating error after the earlier lines already ran.
- **The AutoPlay `New-Item` is guarded by `Test-Path`.** On the registry provider `New-Item -Force` *replaces* an existing key, deleting every value and subkey under it — and that key is shared with unrelated Explorer policies (`NoRecentDocsHistory`, `NoActiveDesktop`, …).
- **The port-3389 scoping step ships commented out**, with no default scope. `-RemoteAddress LocalSubnet` severs any operator connected from another subnet — a jump host, a VPN pool, a different VLAN. Fixing the localized selector above makes this *more* dangerous, not less, so the two had to land together.

## Deferred

Edition-aware end-of-life dates need a validated `OperatingSystemSKU` mapping on real Windows. An unvalidated heuristic would be worse than the current bounded fallback.

## Tests

949 pass. The five tests that encoded the old behaviour were updated, and each new behaviour has targeted coverage.

**Wants real-Windows validation:** TPM/Secure Boot exception types, the network process-name resolution, RDP policy-key precedence, and BitLocker's PS5-int vs PS7-string serialization.
