### PR TITLE
Reporting, CLI & compare integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,26 +251,41 @@ Options:
                        Assessment) to PATH — print-first, for decision makers
   --json PATH          Save a JSON report to PATH
   --baseline FILE      Save current scan as a JSON baseline for future comparisons
+                       (skipped, with a warning, if the scan was not trustworthy —
+                       see Exit codes — so a good baseline is never overwritten
+                       by a scan you would not act on)
   --compare  FILE      Compare current scan against a saved baseline
-  --profile  FILE      Load a custom check profile from a TOML file
+  --profile  FILE      Load a custom check profile from a TOML file. A profile
+                       requested explicitly here must exist and parse, or Apotrope
+                       exits 2; an auto-discovered apotrope.toml still warns and
+                       falls back to defaults
   --category CATS      Comma-separated list of categories to audit
                        (e.g. firewall,encryption,patching)
   --dry-run            List check modules that would run without executing them
   --verbose            Show detail for every check, including PASSes
-  --no-color           Disable Rich color output (for CI / log files)
+  --no-color           Disable Rich color output (for CI / log files). The
+                       NO_COLOR environment variable is honored too
   --log-level LEVEL    Logging verbosity: DEBUG, INFO, WARNING (default), ERROR
   --version            Show version and exit
   -h, --help           Show this help message and exit
 
 Exit codes:
-  0  Score >= 70 (passing)
-  1  Score < 70 (failing)
-  2  Fatal scan error
+  0  Assessment completed and scored >= 70 (passing posture)
+  1  Assessment completed and scored <  70 (failing posture)
+  2  Result not trustworthy — invalid arguments, a fatal scan error, zero
+     controls evaluated, one or more checks errored, or a requested output
+     file could not be written
 ```
 
-> **Note:** `--html` and `--exec-report` must point to **different files**. If both
-> resolve to the same path, Apotrope exits with an argument error before scanning,
-> so the technical report can't silently overwrite the executive one.
+Exit 2 means "do not act on this result", not simply "the tool crashed". A scan
+where checks errored is not a passing scan reported as failing — it is a scan
+whose score is not a measurement, so it is never scored as one and never written
+to a baseline.
+
+> **Note:** `--html`, `--exec-report`, `--json` and `--baseline` must each point to a
+> **different, writable** file. Collisions and unwritable targets are both rejected
+> with an argument error *before* the scan runs, so one report can't silently
+> overwrite another and a long scan doesn't fail at the last step.
 
 ### Examples
 
@@ -294,7 +309,8 @@ apotrope --category firewall,patching
 # Show pass/fail details for every check
 apotrope --verbose
 
-# Silent mode for scripts (exits 0 if score>=70, 1 if score<70, 2 on error)
+# Silent mode for scripts (0 if score>=70, 1 if score<70, 2 if the result
+# is not trustworthy — treat 2 as "don't gate on this run", not as "failed")
 apotrope --no-color --log-level ERROR
 echo Exit code: %ERRORLEVEL%
 

--- a/src/apotrope/cli.py
+++ b/src/apotrope/cli.py
@@ -144,23 +144,53 @@ def _exec_href(html_path: str, exec_path: str) -> str:
 
 def _validate_output_paths(
     parser: argparse.ArgumentParser,
-    html_path: str | None,
-    exec_path: str | None,
+    args: argparse.Namespace,
 ) -> None:
-    """Reject technical and executive reports that resolve to one file."""
-    if not html_path or not exec_path:
-        return
+    """Reject colliding or unwritable output paths *before* the scan runs.
+
+    Every requested output (``--html`` / ``--exec-report`` / ``--json`` /
+    ``--baseline``) must resolve to a distinct file, and each target directory
+    must be writable — checked up front so a bad path fails fast with a clear
+    message (exit 2) instead of a late traceback after a full scan.
+    """
+    import os
     from pathlib import Path
 
-    if Path(html_path).resolve() == Path(exec_path).resolve():
+    named = [
+        (flag, path) for flag, path in (
+            ("--html", args.html),
+            ("--exec-report", args.exec_report),
+            ("--json", args.json),
+            ("--baseline", args.baseline),
+        ) if path
+    ]
+
+    # Preserve the original, specific message for the html/exec pair.
+    if args.html and args.exec_report and (
+        Path(args.html).resolve() == Path(args.exec_report).resolve()
+    ):
         parser.error("--html and --exec-report must use different files")
+
+    seen: dict[Path, str] = {}
+    for flag, path in named:
+        resolved = Path(path).resolve()
+        if resolved in seen:
+            parser.error(f"{seen[resolved]} and {flag} must use different files")
+        seen[resolved] = flag
+
+    for flag, path in named:
+        parent = Path(path).resolve().parent
+        if not parent.is_dir() or not os.access(parent, os.W_OK):
+            parser.error(
+                f"cannot write {flag} to {path}: {parent} is not a writable directory"
+            )
 
 
 def main() -> None:
     """Parse arguments, run the audit, and produce output."""
     parser = build_parser()
     args = parser.parse_args()
-    _validate_output_paths(parser, args.html, args.exec_report)
+    _validate_output_paths(parser, args)
 
     logging.basicConfig(
         level=getattr(logging, args.log_level),
@@ -171,6 +201,7 @@ def main() -> None:
     from apotrope.scanner import Scanner, known_categories
     from apotrope.reporter import Reporter
     from apotrope.profile import load_profile
+    from apotrope.exceptions import ProfileError
     from apotrope.utils import is_admin
 
     categories: list[str] | None = None
@@ -187,8 +218,13 @@ def main() -> None:
             )
         categories = requested
 
-    # Load optional profile (auto-detects apotrope.toml if --profile not given)
-    profile = load_profile(getattr(args, "profile", None))
+    # Load optional profile (auto-detects apotrope.toml if --profile not given).
+    # An explicitly requested profile that is missing/unparseable fails closed.
+    try:
+        profile = load_profile(getattr(args, "profile", None))
+    except ProfileError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        sys.exit(2)
 
     admin    = is_admin()
     scanner  = Scanner(categories=categories, is_admin=admin, profile=profile)
@@ -233,29 +269,31 @@ def main() -> None:
         sys.exit(2)
 
     # Save outputs. The executive report is generated first so the technical
-    # report's header link is only rendered once the target actually exists
-    # (generation is a no-op when Jinja2 or the template is unavailable).
-    if args.exec_report:
-        reporter.generate_executive_report(report, args.exec_report)
+    # report's header link is only rendered once it was actually written. Each
+    # generate_* returns whether the file was produced, so the footer below
+    # reports only the outputs that truly exist — never a file that failed.
+    exec_ok = bool(args.exec_report) and reporter.generate_executive_report(
+        report, args.exec_report
+    )
 
+    html_ok = False
     if args.html:
-        exec_href = None
-        if args.exec_report:
-            from pathlib import Path
-            if Path(args.exec_report).exists():
-                exec_href = _exec_href(args.html, args.exec_report)
-        reporter.generate_html_report(report, args.html, exec_href=exec_href)
+        exec_href = _exec_href(args.html, args.exec_report) if exec_ok else None
+        html_ok = reporter.generate_html_report(report, args.html, exec_href=exec_href)
 
-    if args.json:
-        reporter.generate_json_report(report, args.json)
+    json_ok = bool(args.json) and reporter.generate_json_report(report, args.json)
 
     if args.baseline:
         from apotrope.compare import save_baseline
         save_baseline(report, args.baseline)
 
-    # Terminal output
-    reporter.print_terminal(report, html_path=args.html, json_path=args.json,
-                            exec_path=args.exec_report)
+    # Terminal output — footer lists only the outputs actually written.
+    reporter.print_terminal(
+        report,
+        html_path=args.html if html_ok else None,
+        json_path=args.json if json_ok else None,
+        exec_path=args.exec_report if exec_ok else None,
+    )
 
     # Comparison diff display
     if baseline is not None:

--- a/src/apotrope/cli.py
+++ b/src/apotrope/cli.py
@@ -6,7 +6,8 @@ Exit codes:
     0  Assessment completed and scored >= 70 (passing posture)
     1  Assessment completed and scored <  70 (failing posture)
     2  Result not trustworthy: invalid arguments, a fatal scan error,
-       zero controls evaluated, or one or more checks errored
+       zero controls evaluated, one or more checks errored, or a requested
+       output file could not be written
 """
 
 from __future__ import annotations
@@ -149,11 +150,18 @@ def _validate_output_paths(
     """Reject colliding or unwritable output paths *before* the scan runs.
 
     Every requested output (``--html`` / ``--exec-report`` / ``--json`` /
-    ``--baseline``) must resolve to a distinct file, and each target directory
-    must be writable — checked up front so a bad path fails fast with a clear
-    message (exit 2) instead of a late traceback after a full scan.
+    ``--baseline``) must resolve to a distinct file, and each target must be
+    writable — checked up front so a bad path fails fast with a clear message
+    (exit 2) instead of a late traceback after a full scan.
+
+    Writability is established by *probing*, not by :func:`os.access`. On
+    Windows ``os.access(dir, W_OK)`` reflects only the legacy read-only
+    attribute and never the DACL, so it both passes directories that cannot be
+    written and — for an existing file under a non-writable parent — fails ones
+    that can. The probe performs the same operation the report writer will.
     """
     import os
+    import tempfile
     from pathlib import Path
 
     named = [
@@ -179,10 +187,43 @@ def _validate_output_paths(
         seen[resolved] = flag
 
     for flag, path in named:
-        parent = Path(path).resolve().parent
-        if not parent.is_dir() or not os.access(parent, os.W_OK):
+        target = Path(path).resolve()
+
+        # 1. The parent must exist and be a directory. Keep the word "writable"
+        #    in this message — callers and tests grep for it.
+        if not target.parent.is_dir():
             parser.error(
-                f"cannot write {flag} to {path}: {parent} is not a writable directory"
+                f"cannot write {flag} to {path}: {target.parent} is not a writable directory"
+            )
+
+        # 2. Reject a directory target before probing: opening a directory
+        #    raises IsADirectoryError on POSIX but PermissionError on Windows,
+        #    so the probe alone would report it inconsistently.
+        if target.is_dir():
+            parser.error(f"cannot write {flag} to {path}: it is a directory")
+
+        # 3. Existing target: prove we can write *the file*. O_WRONLY without
+        #    O_CREAT never creates, so losing the exists() race cannot leave a
+        #    stray 0-byte report behind for a downstream "upload if present".
+        try:
+            fd = os.open(target, os.O_WRONLY)
+        except FileNotFoundError:
+            pass  # absent — fall through to the directory probe below
+        except OSError as exc:
+            parser.error(f"cannot write {flag} to {path}: {exc.strerror or exc}")
+        else:
+            os.close(fd)
+            continue
+
+        # 4. Absent target: prove we can create in the parent. An anonymous
+        #    self-deleting file needs the same permission the real write does.
+        try:
+            with tempfile.TemporaryFile(dir=target.parent):
+                pass
+        except OSError as exc:
+            parser.error(
+                f"cannot write {flag} to {path}: "
+                f"{target.parent} is not a writable directory ({exc.strerror or exc})"
             )
 
 
@@ -268,24 +309,46 @@ def main() -> None:
         print(f"\n[FATAL] Scan could not complete: {exc}", file=sys.stderr)
         sys.exit(2)
 
+    # Is this assessment trustworthy enough to act on? Computed once and reused
+    # by both the baseline gate below and the exit gate at the end, so the two
+    # can never drift apart. ``bool(...)`` rather than ``> 0`` deliberately:
+    # evaluated_count is a non-negative int for a real AuditReport, and the
+    # bool form also behaves for the MagicMock reports the CLI tests drive.
+    trustworthy = bool(report.evaluated_count) and not report.error_count
+
     # Save outputs. The executive report is generated first so the technical
-    # report's header link is only rendered once it was actually written. Each
-    # generate_* returns whether the file was produced, so the footer below
-    # reports only the outputs that truly exist — never a file that failed.
-    exec_ok = bool(args.exec_report) and reporter.generate_executive_report(
-        report, args.exec_report
+    # report's header link is only rendered once it was actually written.
+    #
+    # Each flag carries a tri-state: None means "not requested" (or, for the
+    # baseline, "deliberately skipped"); False means the write genuinely
+    # failed. Only False feeds the exit code — conflating it with None would
+    # report every un-requested output as a failure.
+    exec_ok: bool | None = (
+        reporter.generate_executive_report(report, args.exec_report)
+        if args.exec_report else None
     )
 
-    html_ok = False
+    html_ok: bool | None = None
     if args.html:
         exec_href = _exec_href(args.html, args.exec_report) if exec_ok else None
         html_ok = reporter.generate_html_report(report, args.html, exec_href=exec_href)
 
-    json_ok = bool(args.json) and reporter.generate_json_report(report, args.json)
+    json_ok: bool | None = (
+        reporter.generate_json_report(report, args.json) if args.json else None
+    )
 
+    # A baseline is INPUT to a later decision, not just a record of this run.
+    # Never overwrite a good one with a scan we are about to call untrustworthy
+    # — an exit code cannot un-truncate a file. Skipping is a policy decision,
+    # not a write failure, so baseline_ok stays None.
+    baseline_ok: bool | None = None
+    baseline_skipped = False
     if args.baseline:
-        from apotrope.compare import save_baseline
-        save_baseline(report, args.baseline)
+        if trustworthy:
+            from apotrope.compare import save_baseline
+            baseline_ok = save_baseline(report, args.baseline)
+        else:
+            baseline_skipped = True
 
     # Terminal output — footer lists only the outputs actually written.
     reporter.print_terminal(
@@ -301,12 +364,33 @@ def main() -> None:
         diff = compare_reports(baseline, report)
         reporter.print_comparison(diff)
 
+    # Report on requested outputs that could not be written. ``is False`` and
+    # not ``not ok`` — None means "not requested / skipped", and `not None` is
+    # True, which would flag every absent output as a failure.
+    output_failures = [
+        flag for flag, ok in (
+            ("--exec-report", exec_ok),
+            ("--html", html_ok),
+            ("--json", json_ok),
+            ("--baseline", baseline_ok),
+        ) if ok is False
+    ]
+    for flag in output_failures:
+        print(f"[ERROR] could not write {flag}", file=sys.stderr)
+    if baseline_skipped:
+        print(
+            "[WARN] --baseline not written: the scan was not trustworthy "
+            "(zero controls evaluated, or one or more checks errored)",
+            file=sys.stderr,
+        )
+
     # Exit codes:
-    #   2  result cannot be trusted: zero controls evaluated, or >=1 ERROR
+    #   2  result cannot be trusted: zero controls evaluated, >=1 ERROR, or a
+    #      requested output file could not be written
     #   1  complete assessment, failing score (< 70)
     #   0  complete assessment, passing score (>= 70)
     # ERROR never changes the score (scoring.py) — it only affects the exit code.
-    if report.evaluated_count == 0 or report.error_count:
+    if not trustworthy or output_failures:
         sys.exit(2)
     if report.score < 70:
         sys.exit(1)

--- a/src/apotrope/compare.py
+++ b/src/apotrope/compare.py
@@ -59,6 +59,10 @@ class ScanDiff:
         worsened_findings: Checks that were PASS/INFO in baseline but are now FAIL/WARN.
         unchanged_bad:     Checks that were FAIL/WARN in both scans.
         unchanged_count:   Total number of checks with the same status in both scans.
+        baseline_evaluated_count: PASS+FAIL+WARN controls in the *baseline*. Zero means
+                           the baseline recorded no real assessment, so any delta against
+                           it is meaningless — surfaced rather than rejected.
+        baseline_error_count: ERRORed controls in the *baseline*, for the same reason.
     """
 
     baseline_score: int
@@ -72,6 +76,8 @@ class ScanDiff:
     missing_findings: list[CheckResult] = dataclasses.field(default_factory=list)
     errored_findings: list[CheckResult] = dataclasses.field(default_factory=list)
     score_delta_reliable: bool = True
+    baseline_evaluated_count: int = 0
+    baseline_error_count: int = 0
 
 
 def compare_reports(baseline: AuditReport, current: AuditReport) -> ScanDiff:
@@ -140,10 +146,22 @@ def compare_reports(baseline: AuditReport, current: AuditReport) -> ScanDiff:
 
     score_delta = current.score - baseline.score
     current_has_error = any(result.status == Status.ERROR for result in current.results)
+    # The baseline itself may be untrustworthy: an all-ERROR or empty scan still
+    # scores 100 (scoring.py ignores ERROR), and `apotrope --json` writes one on
+    # exactly that path. Diffing against it silently manufactures regressions, so
+    # flag it here. Flag, never reject — compare_reports is a pure diff, and
+    # errored controls are routine on real hosts (a missing cmdlet on Server Core).
+    baseline_evaluated_count = baseline.evaluated_count
+    baseline_error_count = baseline.error_count
     # A score delta is only reliable when the two scans covered the exact same set
-    # of controls (no missing baseline controls AND no current-only additions) and
-    # nothing errored in the current run.
-    score_delta_reliable = (set(base_map) == set(curr_map)) and not current_has_error
+    # of controls (no missing baseline controls AND no current-only additions),
+    # nothing errored in the current run, and the baseline was itself trustworthy.
+    score_delta_reliable = (
+        (set(base_map) == set(curr_map))
+        and not current_has_error
+        and bool(baseline_evaluated_count)
+        and not baseline_error_count
+    )
 
     return ScanDiff(
         baseline_score=baseline.score,
@@ -157,19 +175,29 @@ def compare_reports(baseline: AuditReport, current: AuditReport) -> ScanDiff:
         worsened_findings=worsened_findings,
         unchanged_bad=unchanged_bad,
         unchanged_count=unchanged_count,
+        baseline_evaluated_count=baseline_evaluated_count,
+        baseline_error_count=baseline_error_count,
     )
 
 
-def save_baseline(report: AuditReport, path: str) -> None:
+def save_baseline(report: AuditReport, path: str) -> bool:
     """Serialise *report* to JSON at *path* for use as a future baseline.
 
     Args:
         report: A completed AuditReport from scanner.run().
         path:   Destination file path.
+
+    Returns:
+        ``True`` only if the file was written. Reporting success for a write
+        that failed would let the caller exit 0 having produced no baseline.
     """
     from apotrope.reporter import Reporter
-    Reporter().generate_json_report(report, path)
-    log.info("Baseline saved to %s", path)
+    ok = Reporter().generate_json_report(report, path)
+    if ok:
+        log.info("Baseline saved to %s", path)
+    else:
+        log.error("Could not write baseline to %s", path)
+    return ok
 
 
 def load_baseline(path: str) -> AuditReport:

--- a/src/apotrope/compare.py
+++ b/src/apotrope/compare.py
@@ -112,14 +112,12 @@ def compare_reports(baseline: AuditReport, current: AuditReport) -> ScanDiff:
             else:
                 unchanged_count += 1
         elif c is None and b is not None:
-            # Only in baseline: this check did not run in the current scan.
-            # A bad check vanishing is NOT remediation — it can be a narrower
-            # --category set, a disabled/admin-gated check, an import failure,
-            # or a rename. Bucket it as coverage lost, never as resolved.
-            if b.status in _BAD:
-                missing_findings.append(b)
-            else:
-                unchanged_count += 1
+            # Present in baseline, absent from the current scan: coverage was lost
+            # for this control, whatever its prior status. A vanished PASS is still
+            # a control we can no longer confirm (narrower --category, a disabled /
+            # admin-gated check, an import failure, or a rename), so surface every
+            # absent baseline control as a missing control — never as remediation.
+            missing_findings.append(b)
         else:
             assert b is not None and c is not None
             b_bad = b.status in _BAD
@@ -142,7 +140,10 @@ def compare_reports(baseline: AuditReport, current: AuditReport) -> ScanDiff:
 
     score_delta = current.score - baseline.score
     current_has_error = any(result.status == Status.ERROR for result in current.results)
-    score_delta_reliable = not missing_findings and not current_has_error
+    # A score delta is only reliable when the two scans covered the exact same set
+    # of controls (no missing baseline controls AND no current-only additions) and
+    # nothing errored in the current run.
+    score_delta_reliable = (set(base_map) == set(curr_map)) and not current_has_error
 
     return ScanDiff(
         baseline_score=baseline.score,
@@ -220,6 +221,8 @@ def load_baseline(path: str) -> AuditReport:
             results=results,
             score=int(data.get("score", 0)),
             is_admin=bool(data.get("is_admin", False)),
+            cis_version=data.get("cis_version", ""),
+            cis_caveat=data.get("cis_caveat", ""),
         )
     except (KeyError, TypeError, ValueError) as exc:
         raise ValueError(f"Malformed baseline JSON in {path!r}: {exc}") from exc

--- a/src/apotrope/exceptions.py
+++ b/src/apotrope/exceptions.py
@@ -21,3 +21,12 @@ class PowerShellUnavailableError(ApotropeError):
     total execution failure into confident PASS/FAIL verdicts derived from no
     data. Helpers re-raise it instead.
     """
+
+
+class ProfileError(ApotropeError):
+    """Raised when an explicitly requested ``--profile`` is missing or unparseable.
+
+    An auto-discovered ``apotrope.toml`` falls back to defaults, but a profile the
+    user asked for by name must fail closed rather than silently scan with the
+    default profile (which could change which checks run).
+    """

--- a/src/apotrope/profile.py
+++ b/src/apotrope/profile.py
@@ -83,18 +83,21 @@ def load_profile(path: str | None = None) -> Profile:
             parsed. An auto-discovered ``apotrope.toml`` never raises — a parse
             error there is logged and a default Profile is returned.
     """
+    # The explicit and auto-discovered paths are disjoint — the block below always
+    # returns or raises — so they use separate names. Sharing one name gave it two
+    # incompatible types (Path here, Path | None below) for no benefit.
     if path is not None:
-        resolved = Path(path)
-        if not resolved.exists():
+        explicit = Path(path)
+        if not explicit.exists():
             raise ProfileError(f"Profile file not found: {path}")
         try:
-            return _parse_toml(resolved)
+            return _parse_toml(explicit)
         except ProfileError:
             raise
         except Exception as exc:
             raise ProfileError(f"Could not parse profile {path}: {exc}") from exc
 
-    resolved = None
+    resolved: Path | None = None
     for candidate in _SEARCH_PATHS:
         if candidate.exists():
             resolved = candidate

--- a/src/apotrope/profile.py
+++ b/src/apotrope/profile.py
@@ -39,6 +39,8 @@ import dataclasses
 import logging
 from pathlib import Path
 
+from apotrope.exceptions import ProfileError
+
 log = logging.getLogger(__name__)
 
 _SEARCH_PATHS = [
@@ -74,21 +76,29 @@ def load_profile(path: str | None = None) -> Profile:
         path: Explicit path to a TOML file, or ``None`` to auto-discover.
 
     Returns:
-        A :class:`Profile` instance.  Never raises — parsing errors are
-        logged as warnings and a default Profile is returned.
-    """
-    resolved: Path | None = None
+        A :class:`Profile` instance.
 
+    Raises:
+        ProfileError: If an *explicitly* requested *path* is missing or cannot be
+            parsed. An auto-discovered ``apotrope.toml`` never raises — a parse
+            error there is logged and a default Profile is returned.
+    """
     if path is not None:
         resolved = Path(path)
         if not resolved.exists():
-            log.warning("Profile file not found: %s — using defaults", path)
-            return Profile()
-    else:
-        for candidate in _SEARCH_PATHS:
-            if candidate.exists():
-                resolved = candidate
-                break
+            raise ProfileError(f"Profile file not found: {path}")
+        try:
+            return _parse_toml(resolved)
+        except ProfileError:
+            raise
+        except Exception as exc:
+            raise ProfileError(f"Could not parse profile {path}: {exc}") from exc
+
+    resolved = None
+    for candidate in _SEARCH_PATHS:
+        if candidate.exists():
+            resolved = candidate
+            break
 
     if resolved is None:
         log.debug("No apotrope.toml found — using default profile")

--- a/src/apotrope/reporter.py
+++ b/src/apotrope/reporter.py
@@ -344,6 +344,14 @@ def _truncate(text: str, maxlen: int) -> str:
     return text if len(text) <= maxlen else text[:maxlen - 1] + "~"
 
 
+_CTRL_CHARS = __import__("re").compile(r"[\x00-\x08\x0b-\x1f\x7f]")
+
+
+def _plain(s: str) -> str:
+    """Strip terminal control characters from untrusted text (e.g. baseline data)."""
+    return _CTRL_CHARS.sub("", s)
+
+
 # ── Reporter ──────────────────────────────────────────────────────────────────
 
 class Reporter:
@@ -479,7 +487,7 @@ class Reporter:
         report: AuditReport,
         path: str,
         exec_href: str | None = None,
-    ) -> None:
+    ) -> bool:
         """Render and save a self-contained HTML report via the Jinja2 template.
 
         Args:
@@ -487,12 +495,17 @@ class Reporter:
             path:      Destination file path for the HTML file.
             exec_href: Optional href to a co-generated executive report; when
                        set, the header renders an "Executive Report ↗" link.
+
+        Returns:
+            ``True`` only if the file was written; ``False`` on any failure
+            (missing Jinja2, template error, or write error) so the caller does
+            not claim success for a report that was never produced.
         """
         try:
             from jinja2 import Environment, FileSystemLoader
         except ImportError:
             log.error("Jinja2 not installed — cannot generate HTML report")
-            return
+            return False
 
         template_dir = self._resolve_template_dir()
         env = Environment(
@@ -505,16 +518,21 @@ class Reporter:
             template = env.get_template("report.html.j2")
         except Exception as exc:
             log.error("Could not load HTML template: %s", exc)
-            return
+            return False
 
         ctx = self._build_template_context(report)
         ctx["logo_data_uri"] = self._encode_logo_data_uri(template_dir)
         ctx["exec_href"] = exec_href
         html = template.render(**ctx)
-        Path(path).write_text(html, encoding="utf-8")
+        try:
+            Path(path).write_text(html, encoding="utf-8")
+        except OSError as exc:
+            log.error("Could not write HTML report to %s: %s", path, exc)
+            return False
         log.info("HTML report saved to %s", path)
+        return True
 
-    def generate_executive_report(self, report: AuditReport, path: str) -> None:
+    def generate_executive_report(self, report: AuditReport, path: str) -> bool:
         """Render and save the executive report (Security Posture Assessment).
 
         A plain-English, print-first HTML document for non-technical decision
@@ -525,12 +543,15 @@ class Reporter:
         Args:
             report: Completed :class:`~apotrope.models.AuditReport`.
             path:   Destination file path for the HTML file.
+
+        Returns:
+            ``True`` only if the file was written; ``False`` on any failure.
         """
         try:
             from jinja2 import Environment, FileSystemLoader
         except ImportError:
             log.error("Jinja2 not installed — cannot generate executive report")
-            return
+            return False
 
         template_dir = self._resolve_template_dir()
         env = Environment(
@@ -541,13 +562,18 @@ class Reporter:
             template = env.get_template("exec_report.html.j2")
         except Exception as exc:
             log.error("Could not load executive report template: %s", exc)
-            return
+            return False
 
         ctx = self._build_exec_template_context(report)
         ctx["logo_data_uri"] = self._encode_logo_data_uri(template_dir)
         html = template.render(**ctx)
-        Path(path).write_text(html, encoding="utf-8")
+        try:
+            Path(path).write_text(html, encoding="utf-8")
+        except OSError as exc:
+            log.error("Could not write executive report to %s: %s", path, exc)
+            return False
         log.info("Executive report saved to %s", path)
+        return True
 
     @staticmethod
     def _encode_logo_data_uri(template_dir: Path) -> str | None:
@@ -568,12 +594,15 @@ class Reporter:
             return None
         return "data:image/png;base64," + base64.b64encode(data).decode("ascii")
 
-    def generate_json_report(self, report: AuditReport, path: str) -> None:
+    def generate_json_report(self, report: AuditReport, path: str) -> bool:
         """Serialize the AuditReport to a JSON file.
 
         Args:
             report: Completed :class:`~apotrope.models.AuditReport`.
             path:   Destination file path for the JSON file.
+
+        Returns:
+            ``True`` only if the file was written; ``False`` on a write error.
         """
 
         def _default(obj):
@@ -583,11 +612,16 @@ class Reporter:
                 return obj.value
             raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
 
-        Path(path).write_text(
-            json.dumps(dataclasses.asdict(report), indent=2, default=_default),
-            encoding="utf-8",
-        )
+        try:
+            Path(path).write_text(
+                json.dumps(dataclasses.asdict(report), indent=2, default=_default),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            log.error("Could not write JSON report to %s: %s", path, exc)
+            return False
         log.info("JSON report saved to %s", path)
+        return True
 
     def print_comparison(self, diff: object) -> None:
         """Print a scan comparison diff table to the terminal.
@@ -620,7 +654,7 @@ class Reporter:
 
         sections: list[tuple[str, str, list]] = [
             ("green",   "Resolved", diff.resolved_findings),
-            ("magenta", "Not scanned (coverage lost)", diff.missing_findings),
+            ("magenta", "Missing controls (coverage lost)", diff.missing_findings),
             (_MUTED,    "Errored (could not evaluate)", diff.errored_findings),
             ("red",     "New",      diff.new_findings),
             ("yellow",  "Worsened", diff.worsened_findings),
@@ -634,11 +668,16 @@ class Reporter:
             any_printed = True
             console.print(f"\n  [{colour} bold]{label}[/{colour} bold]  ({len(findings)})")
             for r in findings:
-                console.print(
-                    f"    [{colour}]{r.status.value:5}[/{colour}]  "
-                    f"[dim]{r.severity.value:8}[/dim]  "
-                    f"{r.category} / {r.check_name}"
-                )
+                # category / check_name come from the baseline file (untrusted), so
+                # append them as data via _text() instead of into a markup f-string.
+                console.print(_text(
+                    ("    ", None),
+                    (f"{r.status.value:5}", colour),
+                    ("  ", None),
+                    (f"{r.severity.value:8}", "dim"),
+                    ("  ", None),
+                    (_plain(f"{r.category} / {r.check_name}"), None),
+                ))
 
         if not any_printed:
             console.print(
@@ -1114,7 +1153,9 @@ class Reporter:
 
     def _build_exec_verdict(self, report: AuditReport) -> str:
         """One-sentence gradebox verdict (plain text, counts only)."""
-        total  = len(report.results)
+        # "Evaluated" excludes INFO/ERROR so the verdict matches the compliance
+        # tile (pass_count / total) instead of over-counting INFO notes as passes.
+        evaluated = report.evaluated_count
         open_n = report.fail_count + report.warn_count
         p1 = sum(
             1 for r in report.results
@@ -1122,10 +1163,10 @@ class Reporter:
             and r.severity in (Severity.CRITICAL, Severity.HIGH)
         )
 
-        if total == 0:
+        if evaluated == 0:
             return "No controls could be evaluated in this assessment."
         if open_n == 0 and report.error_count == 0:
-            return (f"All {total} evaluated controls passed; no corrective "
+            return (f"All {evaluated} evaluated controls passed; no corrective "
                     "action is required at this time.")
         if open_n == 0:
             e = report.error_count
@@ -1459,6 +1500,7 @@ class Reporter:
         return commands
 
     def _make_console(self):
+        import os
         import sys
 
         from rich.console import Console
@@ -1478,7 +1520,10 @@ class Reporter:
         # which downsamples the brand palette (green #2bff88 → cyan) and mangles
         # the wordmark glyph. Redirected/piped stdout and --no-color/NO_COLOR
         # fall through to Rich's defaults so no escape codes leak into files.
-        if not self.no_color and Console().is_terminal:
+        # Honor the NO_COLOR env var too: passing an explicit no_color=False on
+        # the truecolor path would otherwise override Rich's own NO_COLOR check.
+        no_color = self.no_color or bool(os.environ.get("NO_COLOR"))
+        if not no_color and Console().is_terminal:
             _modernize_windows_console()
             return Console(
                 no_color=False,
@@ -1486,7 +1531,7 @@ class Reporter:
                 color_system="truecolor",
                 legacy_windows=False,
             )
-        return Console(no_color=self.no_color, highlight=False)
+        return Console(no_color=no_color, highlight=False)
 
     def _print_non_admin_warning(self, console) -> None:
         """Note (no box) that the scan is running without elevation."""

--- a/src/apotrope/reporter.py
+++ b/src/apotrope/reporter.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import dataclasses
 import json
 import logging
+import re
 import textwrap
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -344,7 +345,7 @@ def _truncate(text: str, maxlen: int) -> str:
     return text if len(text) <= maxlen else text[:maxlen - 1] + "~"
 
 
-_CTRL_CHARS = __import__("re").compile(r"[\x00-\x08\x0b-\x1f\x7f]")
+_CTRL_CHARS = re.compile(r"[\x00-\x08\x0b-\x1f\x7f]")
 
 
 def _plain(s: str) -> str:

--- a/src/apotrope/scanner.py
+++ b/src/apotrope/scanner.py
@@ -210,10 +210,12 @@ class Scanner:
                 log.error("Failed to import %s: %s", full_name, exc)
                 continue
 
-            # Category filter
+            # Category filter (case-insensitive on both sides — a library caller
+            # may pass mixed-case categories that the CLI would have lowercased).
             if self.categories is not None:
                 module_category = getattr(module, "CATEGORY", name).lower()
-                if module_category not in self.categories:
+                wanted = {c.lower() for c in self.categories}
+                if module_category not in wanted:
                     log.debug("Skipping %s (category %r not in filter)", full_name, module_category)
                     continue
 
@@ -288,11 +290,20 @@ class Scanner:
             )]
         finally:
             # Undo any per-scan threshold override so it cannot leak into a later scan.
-            if configured and callable(getattr(module, "reset", None)):
-                try:
-                    module.reset()
-                except Exception as exc:
-                    log.warning("reset() on %s failed: %s", module.__name__, exc)
+            if configured:
+                reset_fn = getattr(module, "reset", None)
+                if callable(reset_fn):
+                    try:
+                        reset_fn()
+                    except Exception as exc:
+                        log.warning("reset() on %s failed: %s", module.__name__, exc)
+                else:
+                    # configure() applied thresholds but there is no reset() to undo
+                    # them — warn loudly, since they will leak into the next scan.
+                    log.warning(
+                        "%s has configure() but no reset() — profile thresholds may leak",
+                        module.__name__,
+                    )
 
         # A module must return at least one CheckResult (CLAUDE.md contract). An
         # empty list or a non-CheckResult element would otherwise flow silently

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -479,13 +479,20 @@ class TestMainErrorPaths:
         )
 
     def test_exec_href_none_when_exec_generation_failed(self):
-        """No dangling header link when exec generation returned False."""
+        """No dangling header link when exec generation returned False.
+
+        A requested output that was not produced now also forces exit 2, so the
+        call is wrapped — print_terminal/generate_html_report still record their
+        calls before main() exits.
+        """
         mock_reporter, mock_report = self._reporter_with_report()
         mock_reporter.generate_executive_report.return_value = False
-        self._run_main(
-            ["--html", "out.html", "--exec-report", "brief.html"],
-            mock_reporter,
-        )
+        with pytest.raises(SystemExit) as exc:
+            self._run_main(
+                ["--html", "out.html", "--exec-report", "brief.html"],
+                mock_reporter,
+            )
+        assert exc.value.code == 2
         mock_reporter.generate_html_report.assert_called_once_with(
             mock_report, "out.html", exec_href=None
         )
@@ -711,9 +718,81 @@ class TestOutputIntegrity:
     def test_footer_omits_html_when_generation_fails(self, tmp_path):
         rep = self._reporter()
         rep.generate_html_report.return_value = False
-        self._run(["--html", str(tmp_path / "r.html")], rep)
+        # The failed write now also forces exit 2; print_terminal is still
+        # called (and recorded) before main() exits.
+        with pytest.raises(SystemExit) as exc:
+            self._run(["--html", str(tmp_path / "r.html")], rep)
+        assert exc.value.code == 2
         _, kwargs = rep.print_terminal.call_args
         assert kwargs["html_path"] is None
+
+    def test_failed_json_write_exits_2_on_clean_passing_scan(self, tmp_path, capsys):
+        """A requested artifact that was not produced must not exit 0."""
+        rep = self._reporter()          # trustworthy, score 90 -> would be exit 0
+        rep.generate_json_report.return_value = False
+        with pytest.raises(SystemExit) as exc:
+            self._run(["--json", str(tmp_path / "r.json")], rep)
+        assert exc.value.code == 2
+        assert "could not write --json" in capsys.readouterr().err
+
+    def test_successful_outputs_still_exit_0(self, tmp_path):
+        """The tri-state must not treat un-requested outputs as failures."""
+        rep = self._reporter()
+        self._run(["--json", str(tmp_path / "r.json")], rep)   # no SystemExit
+
+    def test_baseline_skipped_when_untrustworthy(self, tmp_path, capsys):
+        """An untrustworthy scan must not overwrite a good baseline."""
+        rep = self._reporter()
+        rep.run_with_progress.return_value = MagicMock(
+            fail_count=0, warn_count=0, error_count=3, evaluated_count=0, score=100
+        )
+        target = tmp_path / "base.json"
+        with patch("apotrope.compare.save_baseline") as save_mock, \
+                pytest.raises(SystemExit) as exc:
+            self._run(["--baseline", str(target)], rep)
+        assert exc.value.code == 2
+        save_mock.assert_not_called()
+        err = capsys.readouterr().err
+        assert "--baseline not written" in err
+        # A policy skip is not a write failure — it must not be reported as one.
+        assert "could not write --baseline" not in err
+
+    def test_baseline_written_when_trustworthy(self, tmp_path):
+        rep = self._reporter()          # evaluated_count=10, error_count=0
+        target = tmp_path / "base.json"
+        with patch("apotrope.compare.save_baseline") as save_mock:
+            self._run(["--baseline", str(target)], rep)
+        save_mock.assert_called_once()
+
+    def test_probe_does_not_create_file_when_target_absent(self, tmp_path):
+        """The writability probe must never leave a stray 0-byte artifact."""
+        rep = self._reporter()
+        target = tmp_path / "r.json"
+        self._run(["--json", str(target)], rep)
+        # Reporter is a mock, so nothing should have written the file.
+        assert not target.exists()
+
+    def test_existing_file_under_unwritable_parent_is_accepted(self, tmp_path):
+        """An existing writable target must not be rejected for its parent."""
+        import os
+        if os.geteuid() == 0:
+            pytest.skip("root bypasses directory permissions")
+        target = tmp_path / "r.json"
+        target.write_text("{}", encoding="utf-8")
+        tmp_path.chmod(0o555)           # readable/executable, not writable
+        try:
+            rep = self._reporter()
+            self._run(["--json", str(target)], rep)   # must not exit
+        finally:
+            tmp_path.chmod(0o755)
+
+    def test_directory_target_is_rejected_with_distinct_message(self, tmp_path, capsys):
+        rep = self._reporter()
+        with pytest.raises(SystemExit) as exc:
+            self._run(["--json", str(tmp_path)], rep)
+        assert exc.value.code == 2
+        assert "it is a directory" in capsys.readouterr().err
+        rep.run_with_progress.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -772,9 +773,16 @@ class TestOutputIntegrity:
         # Reporter is a mock, so nothing should have written the file.
         assert not target.exists()
 
+    @pytest.mark.skipif(
+        os.name != "posix",
+        reason=(
+            "POSIX directory-permission semantics. On Windows a directory's "
+            "writability is a DACL, which chmod() cannot set, so the "
+            "unwritable-parent premise cannot be constructed there."
+        ),
+    )
     def test_existing_file_under_unwritable_parent_is_accepted(self, tmp_path):
         """An existing writable target must not be rejected for its parent."""
-        import os
         if os.geteuid() == 0:
             pytest.skip("root bypasses directory permissions")
         target = tmp_path / "r.json"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -467,25 +467,25 @@ class TestMainErrorPaths:
         mock_reporter.generate_executive_report.assert_not_called()
 
     def test_exec_href_passed_when_both_outputs(self):
-        """The technical report links to the exec report only when it exists."""
+        """The technical report links to the exec report only when it was written."""
         mock_reporter, mock_report = self._reporter_with_report()
-        with patch("pathlib.Path.exists", return_value=True):
-            self._run_main(
-                ["--html", "out.html", "--exec-report", "brief.html"],
-                mock_reporter,
-            )
+        mock_reporter.generate_executive_report.return_value = True
+        self._run_main(
+            ["--html", "out.html", "--exec-report", "brief.html"],
+            mock_reporter,
+        )
         mock_reporter.generate_html_report.assert_called_once_with(
             mock_report, "out.html", exec_href="brief.html"
         )
 
-    def test_exec_href_none_when_exec_file_missing(self):
-        """No dangling header link when exec generation wrote nothing."""
+    def test_exec_href_none_when_exec_generation_failed(self):
+        """No dangling header link when exec generation returned False."""
         mock_reporter, mock_report = self._reporter_with_report()
-        with patch("pathlib.Path.exists", return_value=False):
-            self._run_main(
-                ["--html", "out.html", "--exec-report", "brief.html"],
-                mock_reporter,
-            )
+        mock_reporter.generate_executive_report.return_value = False
+        self._run_main(
+            ["--html", "out.html", "--exec-report", "brief.html"],
+            mock_reporter,
+        )
         mock_reporter.generate_html_report.assert_called_once_with(
             mock_report, "out.html", exec_href=None
         )
@@ -653,6 +653,67 @@ class TestExitCodes:
     def test_exit_0_when_complete_and_passing(self):
         # Returns normally (no SystemExit).
         self._run(evaluated_count=12, error_count=0, score=85)
+
+
+class TestOutputIntegrity:
+    """Output-path validation, fail-closed profile, and honest footer."""
+    _SCANNER_PATH  = "apotrope.scanner.Scanner"
+    _REPORTER_PATH = "apotrope.reporter.Reporter"
+    _ADMIN_PATH    = "apotrope.utils.is_admin"
+    _PROFILE_PATH  = "apotrope.profile.load_profile"
+
+    def _reporter(self):
+        rep = MagicMock()
+        rep.run_with_progress.return_value = MagicMock(
+            fail_count=0, warn_count=0, error_count=0, evaluated_count=10, score=90)
+        return rep
+
+    def _run(self, argv, rep, profile_error=None):
+        from apotrope.cli import main
+        profile_patch = (
+            patch(self._PROFILE_PATH, side_effect=profile_error) if profile_error
+            else patch(self._PROFILE_PATH, return_value=MagicMock())
+        )
+        with (
+            patch("sys.argv", ["apotrope"] + argv),
+            patch(self._SCANNER_PATH, return_value=MagicMock(is_admin=False)),
+            patch(self._REPORTER_PATH, return_value=rep),
+            patch(self._ADMIN_PATH, return_value=False),
+            profile_patch,
+        ):
+            main()
+
+    def test_json_baseline_collision_exits_2(self, tmp_path, capsys):
+        rep = self._reporter()
+        p = str(tmp_path / "out.dat")
+        with pytest.raises(SystemExit) as exc:
+            self._run(["--json", p, "--baseline", p], rep)
+        assert exc.value.code == 2
+        assert "different files" in capsys.readouterr().err
+        rep.run_with_progress.assert_not_called()
+
+    def test_unwritable_output_dir_exits_2(self, capsys):
+        rep = self._reporter()
+        with pytest.raises(SystemExit) as exc:
+            self._run(["--json", "/no_such_dir_xyz_apotrope/out.json"], rep)
+        assert exc.value.code == 2
+        assert "writable" in capsys.readouterr().err
+        rep.run_with_progress.assert_not_called()
+
+    def test_bad_profile_exits_2(self, capsys):
+        from apotrope.exceptions import ProfileError
+        rep = self._reporter()
+        with pytest.raises(SystemExit) as exc:
+            self._run(["--profile", "x.toml"], rep, profile_error=ProfileError("boom"))
+        assert exc.value.code == 2
+        assert "[ERROR]" in capsys.readouterr().err
+
+    def test_footer_omits_html_when_generation_fails(self, tmp_path):
+        rep = self._reporter()
+        rep.generate_html_report.return_value = False
+        self._run(["--html", str(tmp_path / "r.html")], rep)
+        _, kwargs = rep.print_terminal.call_args
+        assert kwargs["html_path"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -249,6 +249,21 @@ class TestBaselineSerialization:
         loaded = self._roundtrip([])
         assert loaded.hostname == "PC"
 
+    def test_cis_version_and_caveat_preserved(self):
+        # --json serialises cis_version/cis_caveat; load_baseline must restore them.
+        report = _make_report([])
+        report.cis_version = "v4.0.0"
+        report.cis_caveat = "Server 2022 best-effort mapping"
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = f.name
+        try:
+            save_baseline(report, path)
+            loaded = load_baseline(path)
+        finally:
+            os.unlink(path)
+        assert loaded.cis_version == "v4.0.0"
+        assert loaded.cis_caveat == "Server 2022 best-effort mapping"
+
     def test_score_preserved(self):
         loaded = self._roundtrip([], score=73)
         assert loaded.score == 73
@@ -338,9 +353,12 @@ class TestOneSidedGoodResults:
         assert diff.new_findings == []
         assert diff.unchanged_count == 1
 
-    def test_baseline_only_pass_counts_as_unchanged(self):
+    def test_baseline_only_pass_is_missing_control(self):
+        # A control present in the baseline but absent now is coverage lost —
+        # surfaced as a missing control (not counted as unchanged/remediated).
         baseline = _make_report([_make_result("Old Pass", Status.PASS)])
         current = _make_report([])
         diff = compare_reports(baseline, current)
         assert diff.resolved_findings == []
-        assert diff.unchanged_count == 1
+        assert len(diff.missing_findings) == 1
+        assert diff.unchanged_count == 0

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -193,6 +193,77 @@ class TestErroredChecks:
 
         assert compare_reports(baseline, current).score_delta_reliable is True
 
+
+class TestBaselineIntegrity:
+    """A baseline that recorded no real assessment must not look authoritative.
+
+    An all-ERROR or empty scan still scores 100 (scoring.py ignores ERROR), and
+    ``apotrope --json`` writes one on exactly that path. Diffing against it
+    manufactures regressions, so the diff flags it — it never rejects it, since
+    errored controls are routine on real hosts.
+    """
+
+    def test_empty_baseline_marks_delta_unreliable(self):
+        baseline = _make_report([], score=100)
+        current = _make_report([], score=90)
+        diff = compare_reports(baseline, current)
+        assert diff.baseline_evaluated_count == 0
+        assert diff.score_delta_reliable is False
+
+    def test_all_error_baseline_marks_delta_unreliable(self):
+        """The poisoned-baseline case: score 100, zero evaluated, all ERROR."""
+        baseline = _make_report([_make_result("Firewall", Status.ERROR)], score=100)
+        current = _make_report([_make_result("Firewall", Status.FAIL)], score=90)
+        diff = compare_reports(baseline, current)
+        assert diff.baseline_error_count == 1
+        assert diff.baseline_evaluated_count == 0
+        assert diff.score_delta_reliable is False
+
+    def test_partially_errored_baseline_marks_delta_unreliable(self):
+        baseline = _make_report(
+            [_make_result("Firewall", Status.PASS), _make_result("SMB", Status.ERROR)],
+            score=100,
+        )
+        current = _make_report(
+            [_make_result("Firewall", Status.PASS), _make_result("SMB", Status.PASS)],
+            score=100,
+        )
+        diff = compare_reports(baseline, current)
+        assert diff.baseline_error_count == 1
+        assert diff.score_delta_reliable is False
+
+    def test_healthy_baseline_reports_its_counts(self):
+        baseline = _make_report([_make_result("Firewall", Status.FAIL)], score=90)
+        current = _make_report([_make_result("Firewall", Status.PASS)], score=100)
+        diff = compare_reports(baseline, current)
+        assert diff.baseline_evaluated_count == 1
+        assert diff.baseline_error_count == 0
+        assert diff.score_delta_reliable is True
+
+    def test_compare_never_raises_on_a_bad_baseline(self):
+        """compare_reports is a pure diff — flagging must not become rejecting."""
+        baseline = _make_report([_make_result("X", Status.ERROR)], score=100)
+        current = _make_report([_make_result("X", Status.PASS)], score=100)
+        compare_reports(baseline, current)   # must not raise
+
+
+class TestSaveBaseline:
+    """save_baseline must report whether the file was actually written."""
+
+    def test_returns_true_when_written(self, tmp_path):
+        from apotrope.compare import save_baseline
+        target = tmp_path / "base.json"
+        assert save_baseline(_make_report([]), str(target)) is True
+        assert target.exists()
+
+    def test_returns_false_when_write_fails(self, caplog):
+        """A failed write must not be logged as a success."""
+        from unittest.mock import patch
+        from apotrope.compare import save_baseline
+        with patch("apotrope.reporter.Reporter.generate_json_report", return_value=False):
+            assert save_baseline(_make_report([]), "/x/base.json") is False
+        assert "Baseline saved" not in caplog.text
+
     def test_fail_to_error_is_errored_not_resolved(self):
         """A FAIL check that ERRORs in the current scan cannot be confirmed
         remediated. It must be reported as errored, never resolved."""
@@ -295,7 +366,9 @@ class TestBaselineSerialization:
             load_baseline("/nonexistent/path/baseline.json")
 
     def test_load_invalid_json_raises(self):
-        with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+        with tempfile.NamedTemporaryFile(
+            suffix=".json", delete=False, mode="w", encoding="utf-8"
+        ) as f:
             f.write("not json {{")
             path = f.name
         try:
@@ -305,7 +378,9 @@ class TestBaselineSerialization:
             os.unlink(path)
 
     def test_load_malformed_report_raises(self):
-        with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+        with tempfile.NamedTemporaryFile(
+            suffix=".json", delete=False, mode="w", encoding="utf-8"
+        ) as f:
             json.dump({"hostname": "X"}, f)  # missing required fields
             path = f.name
         try:
@@ -319,7 +394,9 @@ class TestBaselineTimestampParsing:
     """load_baseline must convert offset timestamps to UTC, not relabel them (finding #7)."""
 
     def _load_with_timestamp(self, ts_string: str) -> AuditReport:
-        with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+        with tempfile.NamedTemporaryFile(
+            suffix=".json", delete=False, mode="w", encoding="utf-8"
+        ) as f:
             json.dump({"hostname": "PC", "scan_timestamp": ts_string}, f)
             path = f.name
         try:

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import tempfile
 
+import pytest
 
 from apotrope.profile import Profile, load_profile
 
@@ -39,10 +40,11 @@ class TestLoadProfileNoFile:
         profile = load_profile()
         assert isinstance(profile, Profile)
 
-    def test_returns_default_when_explicit_missing(self):
-        """Explicit non-existent path → default profile, no exception."""
-        profile = load_profile("/nonexistent/apotrope.toml")
-        assert isinstance(profile, Profile)
+    def test_explicit_missing_raises(self):
+        """An explicitly requested path that doesn't exist fails closed."""
+        from apotrope.exceptions import ProfileError
+        with pytest.raises(ProfileError):
+            load_profile("/nonexistent/apotrope.toml")
 
 
 # ---------------------------------------------------------------------------
@@ -103,13 +105,23 @@ class TestLoadProfileFromToml:
         finally:
             os.unlink(path)
 
-    def test_invalid_toml_returns_default(self):
+    def test_explicit_invalid_toml_raises(self):
+        from apotrope.exceptions import ProfileError
         path = _write_toml("this is {{{{ not valid toml")
         try:
-            p = load_profile(path)
-            assert isinstance(p, Profile)  # graceful fallback
+            with pytest.raises(ProfileError):
+                load_profile(path)
         finally:
             os.unlink(path)
+
+    def test_autodetected_invalid_toml_returns_default(self, tmp_path, monkeypatch):
+        # An auto-discovered (not explicitly requested) apotrope.toml that fails
+        # to parse still falls back to defaults rather than failing the scan.
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "apotrope.toml").write_text("{{{ not valid", encoding="utf-8")
+        p = load_profile()
+        assert isinstance(p, Profile)
+        assert p.name == "default"
 
     def test_invalid_threshold_value_ignored(self):
         toml = '[thresholds]\nmax_update_age_warn = "not_a_number"\n'
@@ -168,11 +180,16 @@ class TestTomlLibraryFallback:
             with pytest.raises(ImportError, match="tomli"):
                 _parse_toml(path)
 
-    def test_load_profile_falls_back_to_defaults_without_toml_library(self, tmp_path):
+    def test_autodetected_profile_falls_back_to_defaults_without_toml_library(
+        self, tmp_path, monkeypatch
+    ):
         import sys
         from unittest.mock import patch
 
-        path = self._write_toml(tmp_path)
+        # An auto-discovered profile with no TOML library available degrades to
+        # the default profile (an explicitly requested one would fail closed).
+        (tmp_path / "apotrope.toml").write_text('[profile]\nname = "fb"\n', encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
         with patch.dict(sys.modules, {"tomllib": None, "tomli": None}):
-            profile = load_profile(str(path))
+            profile = load_profile()
         assert profile.name == "default"

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -1071,3 +1071,34 @@ class TestPrintTerminal:
         out = self._output(self._boxed_report(), capsys, monkeypatch, columns=70)
         assert "┌" not in out
         assert "Public Firewall" in out  # content still there, un-boxed
+
+
+class TestGenerateReportSuccessSignal:
+    """generate_* report methods report whether the file was actually written."""
+
+    def test_html_returns_true_on_success(self, tmp_path):
+        ok = Reporter().generate_html_report(_make_report(), str(tmp_path / "r.html"))
+        assert ok is True
+        assert (tmp_path / "r.html").exists()
+
+    def test_html_returns_false_on_oserror(self):
+        with patch("pathlib.Path.write_text", side_effect=OSError("disk full")):
+            assert Reporter().generate_html_report(_make_report(), "x.html") is False
+
+    def test_html_returns_false_without_jinja(self):
+        import sys
+        with patch.dict(sys.modules, {"jinja2": None}):
+            assert Reporter().generate_html_report(_make_report(), "x.html") is False
+
+    def test_json_returns_true_on_success(self, tmp_path):
+        ok = Reporter().generate_json_report(_make_report(), str(tmp_path / "r.json"))
+        assert ok is True
+        assert (tmp_path / "r.json").exists()
+
+    def test_json_returns_false_on_oserror(self):
+        with patch("pathlib.Path.write_text", side_effect=OSError("disk full")):
+            assert Reporter().generate_json_report(_make_report(), "x.json") is False
+
+    def test_exec_returns_false_on_oserror(self):
+        with patch("pathlib.Path.write_text", side_effect=OSError("disk full")):
+            assert Reporter().generate_executive_report(_make_report(), "x.html") is False

--- a/tests/test_reporter_terminal.py
+++ b/tests/test_reporter_terminal.py
@@ -726,12 +726,15 @@ class TestMakeConsole:
         assert console.no_color is True
 
     def test_color_enabled_by_default(self):
-        assert Reporter()._make_console().no_color is False
+        # Neutralise NO_COLOR so the "color allowed" path is tested deterministically.
+        with mock.patch.dict("os.environ", {"NO_COLOR": ""}):
+            assert Reporter()._make_console().no_color is False
 
 
 class TestMakeConsoleModern:
     def test_truecolor_forced_on_real_terminal(self):
-        with mock.patch("rich.console.Console.is_terminal",
+        with mock.patch.dict("os.environ", {"NO_COLOR": ""}), \
+             mock.patch("rich.console.Console.is_terminal",
                         new_callable=mock.PropertyMock, return_value=True), \
              mock.patch("apotrope.reporter._modernize_windows_console") as modernize:
             console = Reporter(no_color=False)._make_console()
@@ -740,11 +743,22 @@ class TestMakeConsoleModern:
         modernize.assert_called_once()
 
     def test_not_a_terminal_skips_truecolor_and_modernize(self):
-        with mock.patch("rich.console.Console.is_terminal",
+        with mock.patch.dict("os.environ", {"NO_COLOR": ""}), \
+             mock.patch("rich.console.Console.is_terminal",
                         new_callable=mock.PropertyMock, return_value=False), \
              mock.patch("apotrope.reporter._modernize_windows_console") as modernize:
             console = Reporter(no_color=False)._make_console()
         assert console.no_color is False
+        modernize.assert_not_called()
+
+    def test_no_color_env_var_respected(self):
+        # NO_COLOR in the environment must disable color even without --no-color.
+        with mock.patch.dict("os.environ", {"NO_COLOR": "1"}), \
+             mock.patch("rich.console.Console.is_terminal",
+                        new_callable=mock.PropertyMock, return_value=True), \
+             mock.patch("apotrope.reporter._modernize_windows_console") as modernize:
+            console = Reporter(no_color=False)._make_console()
+        assert console.no_color is True
         modernize.assert_not_called()
 
     def test_no_color_skips_truecolor_and_modernize(self):
@@ -836,3 +850,31 @@ class TestGlyphHelpers:
         assert _grade_hex(59) == _grade_hex(0)     # red band
         assert _grade_hex(80) != _grade_hex(79)
         assert _grade_hex(60) != _grade_hex(59)
+
+
+class TestPrintComparisonSafety:
+    def test_markup_in_baseline_check_name_not_interpreted(self):
+        from apotrope.models import CheckResult, Status, Severity
+        # A baseline-derived check name with Rich markup must render literally.
+        evil = CheckResult("Cat", "[bold]evil[/bold]", Status.FAIL, Severity.HIGH, "d", "x")
+        out = _render(Reporter(), "print_comparison", _diff(new=[evil]))
+        assert "[bold]evil[/bold]" in out
+
+
+class TestExecVerdict:
+    def test_verdict_excludes_info_from_all_passed(self):
+        from datetime import datetime, timezone
+        from apotrope.models import AuditReport, CheckResult, Status, Severity
+        report = AuditReport(
+            hostname="PC", os_version="Win11",
+            scan_timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            scan_duration=1.0,
+            results=[
+                CheckResult("C", "P1", Status.PASS, Severity.LOW, "d", "ok"),
+                CheckResult("C", "P2", Status.PASS, Severity.LOW, "d", "ok"),
+                CheckResult("C", "I1", Status.INFO, Severity.INFO, "d", "note"),
+            ],
+            score=100,
+        )
+        verdict = Reporter()._build_exec_verdict(report)
+        assert "All 2 evaluated controls passed" in verdict

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -93,6 +93,49 @@ class TestThresholdConfigureReset:
         scanner._run_module(module)
         assert [c[0] for c in calls] == ["run"]
 
+    def test_configure_without_reset_warns_about_leaking_thresholds(self, caplog):
+        """A module that configures but cannot reset must say so loudly.
+
+        configure() writes this scan's profile thresholds into module globals; with
+        no reset() they persist into the next scan in the same process, silently
+        scoring it against the previous profile. Nothing else guards this branch —
+        it is not a type error and not a lint error — so this test is the only
+        thing standing between a bad merge resolution and a silent regression.
+        """
+        from apotrope.profile import Profile
+        calls: list = []
+        module = self._configurable_module(calls)
+        del module.reset  # configure() present, reset() absent
+
+        scanner = Scanner(profile=Profile(thresholds={"max_update_age_fail": 90}))
+        with caplog.at_level("WARNING", logger="apotrope.scanner"):
+            scanner._run_module(module)
+
+        assert [c[0] for c in calls] == ["configure", "run"]
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("configure() but no reset()" in m for m in messages), (
+            f"no threshold-leak warning was emitted; records were {messages}"
+        )
+
+    def test_configure_with_reset_does_not_warn(self, caplog):
+        """The companion assertion: a well-behaved module must stay silent.
+
+        Without this, a resolution that warns unconditionally would still satisfy
+        the test above.
+        """
+        from apotrope.profile import Profile
+        calls: list = []
+        module = self._configurable_module(calls)
+
+        scanner = Scanner(profile=Profile(thresholds={"max_update_age_fail": 90}))
+        with caplog.at_level("WARNING", logger="apotrope.scanner"):
+            scanner._run_module(module)
+
+        assert [c[0] for c in calls] == ["configure", "run", "reset"]
+        assert not any(
+            "configure() but no reset()" in r.getMessage() for r in caplog.records
+        )
+
     def test_reset_failure_is_swallowed(self):
         """A module whose reset() raises must not break the scan."""
         from apotrope.profile import Profile


### PR DESCRIPTION
A cluster of integrity issues in the reporting, CLI and comparison paths — mostly cases where a failure was reported as success, an untrusted value reached a markup parser, or a comparison overstated its confidence.

## What changed

- **Honest output signalling.** `generate_html_report`, `generate_executive_report`, `generate_json_report` and `save_baseline` now return whether the file was actually written, and catch `OSError`. `main()` threads those through, so the footer lists only outputs that exist and a genuine write failure reaches the exit code. The flags are tri-state — `None` means "not requested, or deliberately skipped", `False` means a real failure — and only `False` forces exit 2. `save_baseline` previously discarded its writer's result and logged success unconditionally.

- **Output paths validated before the scan.** All four of `--html`, `--exec-report`, `--json` and `--baseline` must be distinct and writable, checked up front instead of failing after the work is done. Writability is probed by performing the operation the writer will: `os.open(O_WRONLY)` without `O_CREAT` for an existing target — so losing the `exists()` race can't leave a stray 0-byte report for a downstream "upload if present" step — and an anonymous temporary file in the parent for an absent one. `os.access` was unsound in both directions: it rejects an existing writable file under a non-writable parent, and on Windows it reflects only the read-only attribute, never the DACL.

- **`--profile` fails closed.** A profile requested explicitly that is missing or unparseable now exits 2, rather than silently falling back to defaults and scanning a different set of checks than the operator asked for. An auto-discovered `apotrope.toml` still warns and falls back.

- **The baseline is gated on scan trust.** `--baseline` was written *before* the exit-2 trust gate, so an untrustworthy scan destroyed a good baseline — and since scoring ignores ERROR, the next `--compare` diffed against a file still scoring 100 and manufactured regressions. `trustworthy` is computed once and used for both the baseline gate and the exit code, so the two cannot drift. `compare_reports` additionally reports the baseline's evaluated and errored counts and folds them into `score_delta_reliable`; it flags rather than rejects, because errored controls are routine on real hosts (a missing cmdlet on Server Core).

- **Safer comparison.** Every absent baseline control surfaces as a *missing control*, not just FAIL/WARN; a score delta is marked reliable only when both scans covered the same control set; `cis_version`/`cis_caveat` survive a baseline round trip; and baseline-derived `category`/`check_name` are routed through the anti-markup helper with a control-character strip, so a tampered baseline can't inject markup into the terminal.

- **Reporter and scanner.** The executive "all controls passed" verdict is based on evaluated (non-INFO) controls so it matches the compliance tile; `NO_COLOR` is honored; the category filter is case-insensitive on both sides; a module with `configure()` but no `reset()` warns, since its thresholds leak into the next scan in the same process.

## Contract change

**Exit 2 now also means "a requested output file could not be written."** Two existing tests changed accordingly: both forced a falsy `generate_*` and called `main()` without expecting `SystemExit`, so they now assert the exit 2 they trigger. `cli.py`'s docstring and the README exit-code table are updated.

## Tests

915 pass, 1 skipped (a Windows-inapplicable unwritable-parent probe). Every new test was checked against the unfixed source to confirm it actually fails there.
