### PR TITLE
CI/packaging hardening: lint+type+hermeticity gates, publish gating, single-sourced version

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,6 +9,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
+  id-token: write
 
 jobs:
   claude:
@@ -18,6 +20,8 @@ jobs:
     if: github.event.comment.author_association == 'OWNER'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,12 +79,42 @@ jobs:
       - name: Install the built wheel and smoke-test it
         # Tests run against the editable install; this proves the *packaged*
         # wheel actually installs and runs on Windows before it ships.
+        #
+        # `--dry-run` alone is not a gate: it prints "0 module(s) would run" and
+        # returns 0, so a wheel that shipped no check modules and no templates
+        # passed it. The probes below assert instead. This job does no checkout,
+        # so the only importable `apotrope` is the one pip just installed —
+        # every assertion is necessarily about the shipped artifact, which is
+        # also why they must be inline `python -c` rather than a tools/ script.
         shell: bash
         run: |
           python -m pip install --upgrade pip
           pip install "$(ls dist/*.whl)"
           apotrope --version
           apotrope --dry-run --no-color
+          python -c "
+          import apotrope.checks as c
+          from apotrope.scanner import Scanner
+          # Compare the IMPORTABLE set against the registry. Counting
+          # len(c.MODULES) would prove nothing: it is a hand-written list whose
+          # length is 14 whether or not the modules made it into the wheel.
+          got = {n.rsplit('.', 1)[1] for n in Scanner().dry_run()}
+          want = set(c.MODULES)
+          assert want, 'MODULES registry is empty'
+          assert got == want, ('check modules missing from the wheel', want ^ got)
+          print(f'ok: {len(got)} check modules importable from the wheel')
+          "
+          python -c "
+          import pathlib, apotrope.reporter as r
+          # Probe the real loader path (FileSystemLoader over __file__'s parent),
+          # not importlib.resources: packages.find uses non-namespace discovery,
+          # so apotrope.templates is not a package.
+          d = pathlib.Path(r.__file__).parent / 'templates'
+          want = {'report.html.j2', 'exec_report.html.j2'}
+          have = {p.name for p in d.iterdir()} if d.is_dir() else set()
+          assert want <= have, ('templates missing from the wheel', want - have)
+          print(f'ok: templates present ({sorted(have)})')
+          "
 
   publish:
     name: Publish to PyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,17 @@ jobs:
       - name: Install package and dev dependencies
         run: pip install -e ".[dev]"
 
+      - name: Verify tag matches package version
+        shell: bash
+        run: |
+          want="${GITHUB_REF_NAME#v}"
+          got="$(python -c "import tomllib,pathlib;print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")"
+          echo "tag=$want pyproject=$got"
+          if [ "$want" != "$got" ]; then
+            echo "::error::tag $GITHUB_REF_NAME does not match pyproject version $got"
+            exit 1
+          fi
+
       - name: Run tests
         # Gate publication on the tagged commit passing tests. test.yml does
         # NOT run on tags, so without this gate a v* tag could publish untested
@@ -47,9 +58,37 @@ jobs:
           name: dist
           path: dist/
 
+  validate-wheel:
+    name: Validate built wheel (Windows)
+    needs: build
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install the built wheel and smoke-test it
+        # Tests run against the editable install; this proves the *packaged*
+        # wheel actually installs and runs on Windows before it ships.
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install "$(ls dist/*.whl)"
+          apotrope --version
+          apotrope --dry-run --no-color
+
   publish:
     name: Publish to PyPI
-    needs: build
+    needs: [build, validate-wheel]
     runs-on: ubuntu-latest
     # The environment must match the one named in the PyPI trusted publisher.
     environment:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,13 @@ jobs:
       - name: Smoke-test exe (--dry-run)
         run: .\dist\apotrope.exe --dry-run --no-color
 
+      - name: Verify remediation commands (PowerShell parse + cmdlet resolution)
+        # tools/verify_commands.py's own docstring says to run this on a real
+        # Windows box before tagging a release — Linux CI cannot parse
+        # PowerShell. This is that box: the exe built here is what hands users
+        # copy-paste remediation, and the tag path ran none of this before.
+        run: python tools/verify_commands.py
+
       - name: Check exe version matches tag
         if: startsWith(github.ref, 'refs/tags/v')
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Install package and dev dependencies
         run: pip install -e ".[dev]"
 
+      - name: Lint (ruff)
+        run: ruff check src tests tools
+
+      - name: Type-check (mypy)
+        run: mypy src/apotrope tools
+
       - name: Run tests with coverage
         # Branch coverage is enabled in pyproject.toml ([tool.coverage.run]).
         # The threshold can only ratchet up — raise it as coverage improves.
@@ -65,6 +71,9 @@ jobs:
 
       - name: Verify exe --dry-run
         run: .\dist\apotrope.exe --dry-run --no-color
+
+      - name: Verify remediation commands (PowerShell parse + cmdlet resolution)
+        run: python tools/verify_commands.py
 
       - name: Upload exe artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,17 @@ on:
   push:
     branches: ["main", "feat/**", "fix/**"]
   pull_request:
-    branches: ["main"]
+    # No branch filter: a stacked PR (base = another fix/** branch, as when
+    # these PRs are chained) produced no pull_request-triggered run at all, so
+    # it was never checked against its merge preview and offered no check
+    # context a branch-protection rule could require.
+
+# One run per ref. Without this the push and pull_request triggers both fire on
+# every push to an open PR branch, duplicating a 4-leg matrix (two of them
+# Windows) and leaving superseded runs to finish.
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,88 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+### Security
+
+- **Removed two machine-damaging remediations from copy-paste output.** The "TPM
+  present but not ready" finding shipped `Initialize-Tpm -AllowClear
+  -AllowPhysicalPresence`, where `-AllowClear` can wipe the TPM, invalidate
+  BitLocker protectors and force recovery; it is now a read-only `Get-Tpm`. The
+  uptime and `EnableLUA` remediations ended in a bare `Restart-Computer`, so
+  pasting either block restarted the machine unattended; both are now commented
+  manual steps. A new `destructive-command` lint rule in `tools/command_audit.py`
+  fails the build if any of them come back.
+- **`powershell.exe` is resolved by absolute path.** Invoking it by bare name let
+  Windows search the application directory and CWD first, so an elevated
+  `apotrope.exe` sitting beside a malicious `powershell.exe` would execute
+  attacker code elevated. The path now comes from `GetSystemWindowsDirectoryW`
+  (not `%SystemRoot%`, which the parent process controls), and `SystemRoot`,
+  `windir` and `PATH` are pinned in the child environment.
+- **The AutoPlay remediation no longer destroys unrelated policy.** It led with
+  `New-Item -Path '...\Policies\Explorer' -Force`, which on the registry provider
+  replaces the key and deletes every value under it — including
+  `NoRecentDocsHistory`, `NoActiveDesktop` and friends. The create is now guarded
+  by `Test-Path`.
+
+### Changed
+
+- **Exit code 2 now means "the result is not trustworthy"**, not merely "a fatal
+  scan error". It additionally covers zero controls evaluated, one or more checks
+  errored, and a requested output file that could not be written. Treat 2 as *do
+  not gate on this run* rather than as a failing posture.
+- **`--profile` fails closed.** A profile requested explicitly that is missing or
+  unparseable now exits 2 instead of silently falling back to defaults and
+  scanning a different set of checks than asked for. An auto-discovered
+  `apotrope.toml` still warns and falls back.
+- **`--baseline` is skipped, with a warning, when the scan was not trustworthy**,
+  so a good baseline is never overwritten by a scan we are about to reject.
+- **All four output paths are validated before the scan**, for collisions and for
+  writability, instead of failing after the work is done.
+- **Password policy is reported per control when it cannot be read.** A failed
+  `secedit` export previously collapsed Minimum Length, Account Lockout and
+  Complexity into one differently-named result, which removed three CIS-mapped
+  rows from the report instead of degrading them to ERROR.
+
+### Fixed
+
+- **Security principals are identified by SID, not by localized display name.**
+  The built-in Administrator/Guest are matched on RID suffix (`-500`/`-501`) and
+  the Administrators group by `S-1-5-32-544`, so a renamed account or a
+  non-English install is no longer reported as "not found". An empty
+  Administrators group is an ERROR rather than a reassuring "0 administrators"
+  PASS, since that group always has at least one member.
+- **Checks fail closed on uncertainty.** Unreadable or access-denied state across
+  TPM, Secure Boot, PowerShell v2, audit policy, UAC, RDP and firewall now
+  reports INFO or ERROR instead of a confident PASS or a scored WARN that
+  penalises a healthy machine.
+- **Firewall profiles cannot silently vanish** — a missing profile is a
+  HIGH-severity ERROR (`Firewall — Profiles Present`) rather than an absent row.
+- **Policy-managed RDP findings point at the controlling GPO** instead of emitting
+  a local-registry command the policy overrides on its next refresh.
+- **Locale-neutral firewall selectors** — `-Group '@FirewallAPI.dll,-28752'`
+  replaces the localized `-DisplayGroup 'Remote Desktop'`, which matched nothing
+  on non-English Windows and no-opped without a visible error.
+- Duplicate entries in the `checks.MODULES` registry were imported twice and
+  their FAIL/WARN results double-deducted from the score.
+- Several verdict bugs: BitLocker mid-encryption is a WARN rather than a PASS,
+  the Int32/UInt32 join that made every listening port report "Unknown", a
+  dropped DHCP adapter, and an unbounded OS end-of-life fallback.
+
+### Dev/CI
+
+- `ruff` and `mypy` are now enforced CI gates, at exact pinned versions rather
+  than floors, with a repo-owned rule set so upstream default churn cannot turn
+  the build red without a code change.
+- Tests are hermetic: an autouse guard fails any test that reaches the real
+  `subprocess` boundary (opt out with `@pytest.mark.allow_subprocess`). The
+  mocked suite dropped from ~22s to ~4s.
+- Publishing is gated on the tag matching `pyproject`'s version and on a Windows
+  job that installs the built wheel and smoke-tests it against the check registry
+  and the packaged templates.
+
+---
+
 ## [0.1.12] - 2026-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -490,7 +490,22 @@ python build_exe.py --no-icon
 1. Fork the repo and create a branch: `git checkout -b feat/my-change`
 2. Make your changes — each check module is self-contained in `src/apotrope/checks/`
 3. Add or update tests in `tests/`
-4. Run `pytest tests/ -q` — all tests must pass
+4. Run the three gates CI enforces — all must be clean:
+
+   ```bash
+   pytest tests/ -q --cov --cov-fail-under=95   # tests + coverage floor
+   ruff check src tests tools                   # lint
+   mypy src/apotrope tools                      # types
+   ```
+
+   A bare `pytest -q` runs the tests but *not* the coverage floor — that
+   threshold is passed on the CI command line, so pass it locally too or you will
+   find out on the PR.
+
+   `pip install -e ".[dev]"` installs `ruff` and `mypy` at the exact versions CI
+   pins. Run them at those versions — both add rules in minor releases, so a
+   newer one reports failures CI will not, and an older one misses failures it
+   will.
 5. Open a pull request into `main`
 
 ### Adding a New Check Module
@@ -516,7 +531,15 @@ def run() -> list[CheckResult]:
     )]
 ```
 
-The scanner auto-discovers all modules in `checks/` — no registration needed.
+Then add `"mycheck"` to `MODULES` in `src/apotrope/checks/__init__.py`, keeping
+the list alphabetically sorted.
+
+Running from source, the scanner discovers modules with `pkgutil`, so a new file
+is picked up on its own — but the frozen `.exe` cannot traverse its own archive
+and uses the explicit `MODULES` registry instead. A module missing from that list
+therefore works everywhere you test it and silently vanishes from the shipped
+executable. `tests/test_checks_registry.py` fails CI when the two disagree, in
+either direction, so you will hear about it before release rather than after.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,7 +7,8 @@ name = "apotrope"
 version = "0.1.12"
 description = "A portable Windows security posture auditor"
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.12"
 authors = [{ name = "Apotrope Contributors" }]
 keywords = ["windows", "security", "audit", "posture", "hardening"]
@@ -15,7 +16,6 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",
     "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
@@ -40,6 +40,8 @@ dev = [
     "pillow>=12.0",  # test_brand_assets.py uses Image.get_flattened_data (12+)
     "build>=1.0",
     "twine>=5.0",
+    "ruff>=0.6",
+    "mypy>=1.11",
 ]
 
 [project.scripts]
@@ -54,6 +56,12 @@ apotrope = ["templates/*.j2", "templates/*.png"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-v"
+markers = [
+    "allow_subprocess: test may reach the real subprocess boundary (opt out of the hermeticity guard)",
+]
+
+[tool.mypy]
+python_version = "3.12"
 
 [tool.coverage.run]
 source = ["src/apotrope"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,10 @@ classifiers = [
     "Topic :: System :: Systems Administration",
 ]
 dependencies = [
-    "rich>=13.7",
-    "jinja2>=3.1",
+    # Upper-bounded for the same reason the dev tools are pinned: an unbounded
+    # floor lets a future major change behaviour under a released artifact.
+    "rich>=13.7,<15",
+    "jinja2>=3.1,<4",
 ]
 
 [project.urls]
@@ -40,8 +42,14 @@ dev = [
     "pillow>=12.0",  # test_brand_assets.py uses Image.get_flattened_data (12+)
     "build>=1.0",
     "twine>=5.0",
-    "ruff>=0.6",
-    "mypy>=1.11",
+    # EXACT pins, not floors. `ruff>=0.6` resolved to 0.16.0, whose default rule
+    # set grew from 59 rules to 413 and turned this gate red with no code
+    # change. A required gate must not have its rule set chosen by whatever pip
+    # resolves that morning. Bump either pin in its own PR that absorbs the
+    # resulting delta. mypy is pinned to the 1.x this tree was verified against;
+    # `mypy>=1.11` now resolves to 2.x, which has never run here.
+    "ruff==0.16.0",
+    "mypy==1.19.1",
 ]
 
 [project.scripts]
@@ -60,8 +68,66 @@ markers = [
     "allow_subprocess: test may reach the real subprocess boundary (opt out of the hermeticity guard)",
 ]
 
+[tool.ruff]
+target-version = "py312"
+line-length = 120        # only meaningful because E501 is selected below
+
+[tool.ruff.lint]
+# `select` REPLACES ruff's default rule set (`extend-select` would merge with
+# it). That is what stops this gate moving under us: ruff 0.16.0 grew its
+# default set from 59 rules to 413, which turned a green branch red with no
+# code change. The rule set is now the repo's decision.
+#
+# `select` alone is not sufficient, though — most entries below are family
+# PREFIXES, and a prefix silently absorbs any rule ruff later promotes out of
+# preview. The exact `ruff==0.16.0` pin in the dev extra is what holds the
+# count steady; bump it in a dedicated PR that absorbs the delta.
+#
+# Every family here was measured against this tree. The expensive ones are
+# selected by exact code, and must NOT be "tidied" into prefixes:
+#   "S"   -> 1398 (S101 alone is 1379: every pytest assert)
+#   "PL"  ->  264      "D" -> 1055      "PTH" -> 46      "RUF" -> 43
+select = [
+    "E4", "E7", "E9",     # pycodestyle errors (ruff's pre-0.16 default core)
+    "E501",               # line-too-long, at the line-length above
+    "F",                  # pyflakes (ruff's pre-0.16 default core)
+    "W",                  # pycodestyle warnings
+    "B",                  # flake8-bugbear
+    "BLE",                # blind-except — see below
+    "C4", "A", "DTZ",     # comprehensions / builtin shadowing / naive datetimes
+    "G",                  # logging format
+    "PIE",                # flake8-pie
+    "PLE", "PLW",         # pylint error+warning — NEVER bare "PL"
+    "S110",               # try-except-pass — NEVER bare "S"
+    "RUF059", "RUF100",   # NEVER bare "RUF"
+]
+# BLE is deliberately ON despite CLAUDE.md requiring that check modules never
+# raise. The two do not conflict: BLE001 objects to swallowing an exception
+# without recording a traceback, not to catching Exception. scanner._run_module's
+# handler — the one that implements that contract — does not trip it, because it
+# already passes exc_info. So the rule pushes toward the architecture, not away.
+
 [tool.mypy]
 python_version = "3.12"
+check_untyped_defs = true
+warn_return_any = true
+no_implicit_optional = true
+strict_equality = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+# NOT set — `warn_unreachable`: 3 errors on ubuntu and 0 on windows, because
+# this package is full of `if sys.platform != "win32": return` guards and mypy
+# resolves sys.platform against the host. It would make the matrix permanently
+# and confusingly red. `warn_unused_ignores` is likewise off: its verdict
+# depends on which optional third-party stubs happen to resolve.
+
+[[tool.mypy.overrides]]
+# reporter.py has ~20 unannotated nested Rich helpers. Annotating them is a real
+# refactor, not part of a CI-hardening change; without this override
+# disallow_untyped_defs costs 20 extra annotations in that one file.
+module = "apotrope.reporter"
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
 
 [tool.coverage.run]
 source = ["src/apotrope"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ markupsafe==2.1.5
 # Dev / test dependencies
 pytest==9.0.3
 pytest-cov==5.0.0
+pillow==12.0.0   # test_brand_assets.py imports PIL; matches pyproject [dev] pillow>=12.0

--- a/src/apotrope/checks/network.py
+++ b/src/apotrope/checks/network.py
@@ -189,7 +189,10 @@ def _check_listening_ports() -> list[CheckResult]:
         status=Status.INFO,
         severity=Severity.INFO,
         description="Enumerates all TCP ports in LISTEN state.",
-        details=f"{len(unique_ports)} listening port(s): {port_summary}" if unique_ports else "No listening TCP ports found.",
+        details=(
+            f"{len(unique_ports)} listening port(s): {port_summary}"
+            if unique_ports else "No listening TCP ports found."
+        ),
         remediation="",
     ))
 

--- a/src/apotrope/checks/rdp.py
+++ b/src/apotrope/checks/rdp.py
@@ -115,7 +115,7 @@ _REMEDIATION_NLA_BY_POLICY = (
 
 def _effective_value(
     data: dict, policy_name: str, local_name: str
-) -> tuple[object | None, bool]:
+) -> tuple[int | str | None, bool]:
     """Return ``(winning_value, policy_managed)`` for a policy-backed setting.
 
     The Group Policy value under ``...\\Policies\\...`` overrides the local

--- a/src/apotrope/checks/services.py
+++ b/src/apotrope/checks/services.py
@@ -150,7 +150,7 @@ def _check_unquoted_paths() -> list[CheckResult]:
 
     names = [str(i.get("Name") or "Unknown") for i in items]
     paths = [str(i.get("PathName") or "") for i in items]
-    detail_lines = "; ".join(f"{n}: {p}" for n, p in zip(names, paths))
+    detail_lines = "; ".join(f"{n}: {p}" for n, p in zip(names, paths, strict=True))
 
     return [CheckResult(
         category=CATEGORY,

--- a/src/apotrope/cli.py
+++ b/src/apotrope/cli.py
@@ -18,6 +18,8 @@ import sys
 
 from apotrope import __version__
 
+log = logging.getLogger(__name__)
+
 
 def build_parser() -> argparse.ArgumentParser:
     """Build and return the argument parser."""
@@ -304,8 +306,7 @@ def main() -> None:
     try:
         report = reporter.run_with_progress(scanner)
     except Exception as exc:
-        _log = logging.getLogger(__name__)
-        _log.critical("Fatal scan error: %s", exc, exc_info=True)
+        log.critical("Fatal scan error: %s", exc, exc_info=True)
         print(f"\n[FATAL] Scan could not complete: {exc}", file=sys.stderr)
         sys.exit(2)
 

--- a/src/apotrope/profile.py
+++ b/src/apotrope/profile.py
@@ -109,8 +109,8 @@ def load_profile(path: str | None = None) -> Profile:
 
     try:
         return _parse_toml(resolved)
-    except Exception as exc:
-        log.warning("Could not parse profile %s: %s — using defaults", resolved, exc)
+    except Exception:
+        log.exception("Could not parse profile %s — using defaults", resolved)
         return Profile()
 
 

--- a/src/apotrope/reporter.py
+++ b/src/apotrope/reporter.py
@@ -319,8 +319,8 @@ def _modernize_windows_console() -> None:
             return  # redirected / no console attached
         kernel32.SetConsoleMode(handle, mode.value | enable_vt_processing)
         kernel32.SetConsoleOutputCP(65001)
-    except Exception:
-        return
+    except (AttributeError, OSError):
+        return  # no console / non-Windows ctypes surface
 
 
 def _text(*segments):
@@ -517,8 +517,8 @@ class Reporter:
         )
         try:
             template = env.get_template("report.html.j2")
-        except Exception as exc:
-            log.error("Could not load HTML template: %s", exc)
+        except Exception:
+            log.exception("Could not load HTML template")
             return False
 
         ctx = self._build_template_context(report)
@@ -561,8 +561,8 @@ class Reporter:
         )
         try:
             template = env.get_template("exec_report.html.j2")
-        except Exception as exc:
-            log.error("Could not load executive report template: %s", exc)
+        except Exception:
+            log.exception("Could not load executive report template")
             return False
 
         ctx = self._build_exec_template_context(report)
@@ -1511,7 +1511,7 @@ class Reporter:
         # check data to '?' rather than crashing mid-render. Under UTF-8 every
         # glyph we emit is encodable, so 'replace' never actually fires.
         try:
-            sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+            sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
         except (AttributeError, ValueError):
             pass
 

--- a/src/apotrope/scanner.py
+++ b/src/apotrope/scanner.py
@@ -22,6 +22,9 @@ from apotrope.scoring import calculate_score
 from apotrope.utils import get_wmi_object
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from types import ModuleType
+
     from apotrope import cis_map
     from apotrope.profile import Profile
 
@@ -52,8 +55,8 @@ def known_categories() -> set[str]:
     for name in names:
         try:
             module = importlib.import_module(f"apotrope.checks.{name}")
-        except Exception as exc:
-            log.error("Failed to import apotrope.checks.%s: %s", name, exc)
+        except Exception:
+            log.exception("Failed to import apotrope.checks.%s", name)
             continue
         categories.add(getattr(module, "CATEGORY", name).lower())
     return categories
@@ -102,8 +105,8 @@ class Scanner:
 
     def run(
         self,
-        modules: list | None = None,
-        on_module_start=None,
+        modules: list[ModuleType] | None = None,
+        on_module_start: Callable[[ModuleType], None] | None = None,
     ) -> AuditReport:
         """Discover check modules, run them, and return an AuditReport.
 
@@ -126,7 +129,9 @@ class Scanner:
                 try:
                     on_module_start(module)
                 except Exception:
-                    pass
+                    log.exception(
+                        "on_module_start callback failed for %s", module.__name__
+                    )
             module_results = self._run_module(module)
             results.extend(module_results)
 
@@ -193,8 +198,14 @@ class Scanner:
         discovered = []
 
         if getattr(sys, "frozen", False):
-            # PyInstaller bundle: use the explicit module registry
-            check_names: list[str] = list(checks_pkg.MODULES)
+            # PyInstaller bundle: use the explicit module registry.
+            # dict.fromkeys de-duplicates while preserving order. importlib
+            # returns the *cached* module for a repeated name, so a duplicated
+            # registry entry would append the same module twice and emit every
+            # one of its CheckResults twice — double-deducting each FAIL/WARN
+            # from the score. tests/test_checks_registry.py also asserts the
+            # registry is duplicate-free; this is the belt to that braces.
+            check_names: list[str] = list(dict.fromkeys(checks_pkg.MODULES))
         else:
             check_names = [
                 m.name for m in pkgutil.iter_modules(checks_pkg.__path__)
@@ -206,8 +217,8 @@ class Scanner:
             full_name = f"apotrope.checks.{name}"
             try:
                 module = importlib.import_module(full_name)
-            except Exception as exc:
-                log.error("Failed to import %s: %s", full_name, exc)
+            except Exception:
+                log.exception("Failed to import %s", full_name)
                 continue
 
             # Category filter (case-insensitive on both sides — a library caller
@@ -228,7 +239,7 @@ class Scanner:
 
         return discovered
 
-    def _run_module(self, module) -> list[CheckResult]:
+    def _run_module(self, module: ModuleType) -> list[CheckResult]:
         """Run a single check module and return its results.
 
         Handles three cases:
@@ -266,8 +277,8 @@ class Scanner:
             try:
                 module.configure(self.profile.thresholds)
                 configured = True
-            except Exception as exc:
-                log.warning("configure() on %s failed: %s", module.__name__, exc)
+            except Exception:
+                log.exception("configure() on %s failed", module.__name__)
 
         log.debug("Running %s", module.__name__)
         t_start = time.monotonic()
@@ -278,7 +289,7 @@ class Scanner:
                     f"run() must return list[CheckResult], got {type(results)}"
                 )
         except Exception as exc:
-            log.error("Error in %s.run(): %s", module.__name__, exc, exc_info=True)
+            log.exception("Error in %s.run()", module.__name__)
             results = [CheckResult(
                 category=cat,
                 check_name=f"{cat} — module error",
@@ -295,8 +306,8 @@ class Scanner:
                 if callable(reset_fn):
                     try:
                         reset_fn()
-                    except Exception as exc:
-                        log.warning("reset() on %s failed: %s", module.__name__, exc)
+                    except Exception:
+                        log.exception("reset() on %s failed", module.__name__)
                 else:
                     # configure() applied thresholds but there is no reset() to undo
                     # them — warn loudly, since they will leak into the next scan.

--- a/src/apotrope/utils.py
+++ b/src/apotrope/utils.py
@@ -239,6 +239,7 @@ def run_powershell(command: str, timeout: int = 30) -> str:
             errors="replace",
             timeout=timeout,
             env=_child_env(),
+            check=False,
         )
     except subprocess.TimeoutExpired as exc:
         raise ApotropeError(
@@ -290,7 +291,8 @@ def run_powershell_json(command: str, timeout: int = 30) -> dict | list:
         return []
 
     try:
-        return json.loads(output)
+        # json.loads is typed Any; the declared return type is the contract.
+        return cast("dict | list", json.loads(output))
     except json.JSONDecodeError as exc:
         raise ApotropeError(
             f"Failed to parse PowerShell JSON output: {exc}"
@@ -457,7 +459,7 @@ def is_admin() -> bool:
         return False
     try:
         return bool(ctypes.windll.shell32.IsUserAnAdmin())
-    except Exception:
+    except (AttributeError, OSError):
         return False
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from unittest.mock import patch
 
 import pytest
 
@@ -13,14 +14,48 @@ from apotrope.models import AuditReport, CheckResult, Severity, Status
 def _reset_powershell_cache():
     """Clear the cached PowerShell resolution between tests.
 
-    ``utils._ps_executable()`` caches both outcomes in a module global. Without
-    this, whichever test resolves first would decide the value every later test
-    sees — an order-dependent failure that looks like flakiness.
+    ``utils._ps_executable()`` memoises both outcomes. Without this, whichever
+    test resolves first would decide the value every later test sees — an
+    order-dependent failure that looks like flakiness.
     """
     from apotrope import utils
     utils._reset_ps_cache()
     yield
     utils._reset_ps_cache()
+
+
+@pytest.fixture(autouse=True)
+def _forbid_unmocked_subprocess(request):
+    """Fail loudly if any test reaches the real ``powershell.exe``.
+
+    Tests must mock the ``utils`` helpers (``run_powershell`` etc.) so the suite
+    is hermetic and OS-independent. A forgotten patch previously reached real
+    PowerShell on Windows (and degraded to ``[]`` on Linux, hiding the problem);
+    this guard turns that into an immediate error. A test that genuinely needs
+    the boundary can opt out with ``@pytest.mark.allow_subprocess``.
+    """
+    if request.node.get_closest_marker("allow_subprocess"):
+        yield
+        return
+
+    import apotrope.utils as u
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError(
+            "unmocked subprocess.run reached the real boundary — patch "
+            "run_powershell / run_powershell_json / get_wmi_object instead"
+        )
+
+    # Explicit sentinel so a test can prove WHICH callable is installed.
+    # unittest.mock's ``_mock_name`` is useless here — _boom is a plain
+    # function, not a Mock, so it has no such attribute either and asserting on
+    # it passes whether or not the guard is active. An identity check against
+    # ``subprocess.run`` proves nothing either: apotrope.utils imports the very
+    # same module object the test sees.
+    _boom._apotrope_guard = True
+
+    with patch.object(u.subprocess, "run", _boom):
+        yield
 
 
 @pytest.fixture()

--- a/tests/test_checks_registry.py
+++ b/tests/test_checks_registry.py
@@ -1,0 +1,25 @@
+"""Guard: the frozen-mode MODULES registry matches the check modules on disk.
+
+PyInstaller bundles cannot traverse the package with ``pkgutil``, so
+``apotrope.checks.MODULES`` lists the check modules explicitly. If a new check
+module is added but not registered, it silently vanishes from the shipped exe;
+this test catches that drift.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import apotrope.checks as checks_pkg
+
+
+def test_modules_registry_matches_disk():
+    on_disk = {
+        p.stem for p in Path(checks_pkg.__path__[0]).glob("*.py")
+        if not p.stem.startswith("_")
+    }
+    registered = set(checks_pkg.MODULES)
+    assert registered == on_disk, (
+        f"MODULES registry drift — symmetric difference: {registered ^ on_disk}. "
+        "Update apotrope/checks/__init__.py MODULES when adding/removing a check module."
+    )

--- a/tests/test_checks_registry.py
+++ b/tests/test_checks_registry.py
@@ -8,18 +8,53 @@ this test catches that drift.
 
 from __future__ import annotations
 
+from collections import Counter
 from pathlib import Path
+
+import pytest
 
 import apotrope.checks as checks_pkg
 
 
-def test_modules_registry_matches_disk():
-    on_disk = {
+def _on_disk() -> set[str]:
+    return {
         p.stem for p in Path(checks_pkg.__path__[0]).glob("*.py")
         if not p.stem.startswith("_")
     }
+
+
+def test_modules_registry_matches_disk():
+    # Count BEFORE comparing as sets. set() discards cardinality, so a
+    # duplicated entry compares equal to a clean registry — while the frozen
+    # scanner would import that name twice and emit its results twice.
+    duplicates = {name: n for name, n in Counter(checks_pkg.MODULES).items() if n > 1}
+    assert not duplicates, (
+        f"duplicate entries in apotrope.checks.MODULES: {duplicates}. "
+        "The frozen scanner walks the registry in order, so a duplicate runs "
+        "that check twice and double-deducts its FAIL/WARN score."
+    )
+
+    on_disk = _on_disk()
     registered = set(checks_pkg.MODULES)
     assert registered == on_disk, (
         f"MODULES registry drift — symmetric difference: {registered ^ on_disk}. "
         "Update apotrope/checks/__init__.py MODULES when adding/removing a check module."
     )
+
+
+def test_modules_registry_is_sorted():
+    """Canonical order keeps the diff — and the exe's run order — stable."""
+    assert checks_pkg.MODULES == sorted(checks_pkg.MODULES), (
+        f"apotrope.checks.MODULES must stay alphabetically sorted: {checks_pkg.MODULES}"
+    )
+
+
+def test_duplicate_detection_actually_fires(monkeypatch: pytest.MonkeyPatch):
+    """Meta-test: the guard above must fail on a duplicate.
+
+    The previous set()-only version passed in this scenario, which is exactly
+    why the Counter check exists.
+    """
+    monkeypatch.setattr(checks_pkg, "MODULES", [*checks_pkg.MODULES, "rdp"])
+    with pytest.raises(AssertionError, match="duplicate entries"):
+        test_modules_registry_matches_disk()

--- a/tests/test_cis_version.py
+++ b/tests/test_cis_version.py
@@ -111,8 +111,8 @@ class TestLookupOsAware:
 def _fake_module() -> ModuleType:
     # setattr (not mod.attr =) so mypy accepts dynamic attributes on ModuleType.
     mod = ModuleType("fake")
-    setattr(mod, "CATEGORY", "Test")
-    setattr(mod, "run", lambda: [CheckResult("Test", "x", Status.PASS, Severity.LOW, "d", "ok")])
+    mod.CATEGORY = "Test"
+    mod.run = lambda: [CheckResult("Test", "x", Status.PASS, Severity.LOW, "d", "ok")]
     return mod
 
 

--- a/tests/test_hermeticity.py
+++ b/tests/test_hermeticity.py
@@ -1,0 +1,22 @@
+"""The autouse hermeticity guard (conftest) must block unmocked subprocess calls."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_guard_blocks_unmocked_subprocess():
+    # Unmarked test → the conftest guard patches subprocess.run to raise.
+    import apotrope.utils as u
+
+    with pytest.raises(RuntimeError, match="unmocked subprocess"):
+        u.subprocess.run(["powershell.exe", "-Command", "echo hi"])
+
+
+@pytest.mark.allow_subprocess
+def test_marker_opts_out_of_guard():
+    # With the opt-out marker the guard does not patch, so subprocess.run is the
+    # real callable (we don't invoke it — just assert it wasn't replaced).
+    import apotrope.utils as u
+
+    assert not getattr(u.subprocess.run, "_mock_name", None)

--- a/tests/test_hermeticity.py
+++ b/tests/test_hermeticity.py
@@ -2,21 +2,52 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
+
 import pytest
+
+import apotrope.utils as u
 
 
 def test_guard_blocks_unmocked_subprocess():
     # Unmarked test → the conftest guard patches subprocess.run to raise.
-    import apotrope.utils as u
-
+    assert getattr(u.subprocess.run, "_apotrope_guard", False), (
+        "the autouse hermeticity guard is not installed for an unmarked test"
+    )
     with pytest.raises(RuntimeError, match="unmocked subprocess"):
         u.subprocess.run(["powershell.exe", "-Command", "echo hi"])
 
 
 @pytest.mark.allow_subprocess
 def test_marker_opts_out_of_guard():
-    # With the opt-out marker the guard does not patch, so subprocess.run is the
-    # real callable (we don't invoke it — just assert it wasn't replaced).
-    import apotrope.utils as u
+    """With the marker the guard must NOT be installed.
 
-    assert not getattr(u.subprocess.run, "_mock_name", None)
+    Asserted from both directions. The previous check —
+    ``not getattr(u.subprocess.run, "_mock_name", None)`` — was vacuous: the
+    guard is a plain function, not a Mock, so it has no ``_mock_name`` either
+    and the assertion passed whether or not the marker plumbing worked. An
+    identity check against ``subprocess.run`` proves nothing on its own either,
+    since ``apotrope.utils`` imports the very same module object this test sees.
+    """
+    assert u.subprocess is subprocess
+    assert not getattr(u.subprocess.run, "_apotrope_guard", False)
+    assert u.subprocess.run.__module__ == "subprocess"
+    assert u.subprocess.run.__qualname__ == "run"
+
+
+@pytest.mark.allow_subprocess
+def test_marker_reaches_the_real_boundary():
+    """End-to-end proof the opt-out works, not just that the guard is absent.
+
+    Spawns this interpreter rather than powershell.exe so the test is identical
+    on the Linux and Windows matrix legs.
+    """
+    proc = u.subprocess.run(
+        [sys.executable, "-c", "print('hermeticity-optout-ok')"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=True,
+    )
+    assert "hermeticity-optout-ok" in proc.stdout

--- a/tests/test_remediation_commands.py
+++ b/tests/test_remediation_commands.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
 
-from command_audit import Command, collect_commands, lint_commands  # noqa: E402
+from command_audit import Command, collect_commands, lint_commands
 
 
 def test_command_inventory_is_populated() -> None:

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -27,7 +27,8 @@ def _make_report(
     base = [
         CheckResult("Firewall", "Domain Profile",  Status.PASS, Severity.HIGH,   "desc", "ok"),
         CheckResult("Firewall", "Public Profile",  Status.FAIL, Severity.CRITICAL,"desc", "off", "Enable it"),
-        CheckResult("Services", "Risky Services",  Status.WARN, Severity.MEDIUM,  "desc", "SNMP running", "Disable SNMP"),
+        CheckResult("Services", "Risky Services",  Status.WARN, Severity.MEDIUM,
+                    "desc", "SNMP running", "Disable SNMP"),
         CheckResult("OS",       "OS Version",       Status.INFO, Severity.INFO,    "desc", "Win11 22621"),
     ]
     results = base + (extra_results or [])

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from types import ModuleType
 from unittest.mock import patch
 
@@ -33,14 +34,14 @@ def _make_module(
     """Return a minimal fake check module."""
     # setattr (not mod.attr =) so mypy accepts dynamic attributes on ModuleType.
     mod = ModuleType(name)
-    setattr(mod, "CATEGORY", category)
+    mod.CATEGORY = category
     if requires_admin:
-        setattr(mod, "REQUIRES_ADMIN", True)
+        mod.REQUIRES_ADMIN = True
 
     if run_raises is not None:
         def _run():
             raise run_raises
-        setattr(mod, "run", _run)
+        mod.run = _run
     else:
         _results = results or [CheckResult(
             category=category,
@@ -50,7 +51,7 @@ def _make_module(
             description="desc",
             details="ok",
         )]
-        setattr(mod, "run", lambda: _results)
+        mod.run = lambda: _results
 
     return mod
 
@@ -70,7 +71,7 @@ class TestThresholdConfigureReset:
     def _configurable_module(self, calls: list) -> ModuleType:
         """A fake module that records its configure/run/reset call order."""
         mod = ModuleType("configurable_mod")
-        setattr(mod, "CATEGORY", "Configurable")
+        mod.CATEGORY = "Configurable"
 
         def _configure(thresholds):
             calls.append(("configure", dict(thresholds)))
@@ -82,9 +83,9 @@ class TestThresholdConfigureReset:
             calls.append(("run", None))
             return []
 
-        setattr(mod, "configure", _configure)
-        setattr(mod, "reset", _reset)
-        setattr(mod, "run", _run)
+        mod.configure = _configure
+        mod.reset = _reset
+        mod.run = _run
         return mod
 
     def test_configure_then_run_then_reset_in_order(self):
@@ -154,7 +155,7 @@ class TestThresholdConfigureReset:
         def _bad_reset():
             raise RuntimeError("boom")
 
-        setattr(module, "reset", _bad_reset)
+        module.reset = _bad_reset
         scanner = Scanner(profile=Profile(thresholds={"max_update_age_fail": 90}))
         results = scanner._run_module(module)  # must not raise
         assert isinstance(results, list)
@@ -274,7 +275,7 @@ class TestModuleErrorHandling:
         scanner = Scanner()
         mod = ModuleType("empty_mod")
         mod.CATEGORY = "Test"
-        mod.run = lambda: []
+        mod.run = list
         results = scanner._run_module(mod)
         assert len(results) == 1
         assert results[0].status == Status.ERROR
@@ -671,3 +672,17 @@ class TestPowerShellUnavailable:
             side_effect=PowerShellUnavailableError("no powershell"),
         ):
             assert Scanner._detect_product_type() is None
+
+
+class TestFrozenRegistryDuplicates:
+    """A duplicated MODULES entry must not run a check twice in the frozen exe."""
+
+    def test_duplicate_registry_entry_runs_module_once(self, monkeypatch):
+        import apotrope.checks as checks_pkg
+
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(checks_pkg, "MODULES", ["rdp", "rdp", "uac"])
+        scanner = Scanner()
+        modules = scanner._discover_modules()
+        names = [m.__name__ for m in modules]
+        assert len(names) == len(set(names)), names

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -5,9 +5,18 @@ from __future__ import annotations
 from types import ModuleType
 from unittest.mock import patch
 
+import pytest
 
 from apotrope.models import AuditReport, CheckResult, Severity, Status
 from apotrope.scanner import Scanner
+
+
+@pytest.fixture(autouse=True)
+def _stub_wmi():
+    """Scanner.run() calls _detect_product_type() -> get_wmi_object; stub it so
+    the scanner tests never reach the real WMI / PowerShell boundary."""
+    with patch("apotrope.scanner.get_wmi_object", return_value=[]):
+        yield
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -150,7 +150,8 @@ def _neglected_win10_home_results() -> list[CheckResult]:
         _r("Patching", "Pending Updates",     Status.FAIL, Severity.HIGH, "15 updates", "Install updates"),
         # Accounts — guest enabled, many admins
         _r("Accounts", "Guest Account",          Status.FAIL, Severity.HIGH, "Enabled", "Disable guest"),
-        _r("Accounts", "Built-in Administrator", Status.FAIL, Severity.MEDIUM, "Enabled, default name", "Rename/disable"),
+        _r("Accounts", "Built-in Administrator", Status.FAIL, Severity.MEDIUM,
+           "Enabled, default name", "Rename/disable"),
         _r("Accounts", "Local Administrators",   Status.WARN, Severity.MEDIUM, "5 admins", "Reduce admins"),
         _r("Accounts", "Password Length",        Status.FAIL, Severity.HIGH, "6 chars min", "Increase length"),
         _r("Accounts", "Account Lockout",        Status.WARN, Severity.MEDIUM, "Disabled", "Enable lockout"),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -395,7 +395,9 @@ class TestReadRegistry:
 
     def test_returns_integer_when_value_is_numeric(self):
         with patch("apotrope.utils.subprocess.run", return_value=_mock_ps("1")):
-            result = utils.read_registry("HKLM", "SYSTEM\\CurrentControlSet\\Services\\LanmanServer\\Parameters", "SMB1")
+            result = utils.read_registry(
+                "HKLM", "SYSTEM\\CurrentControlSet\\Services\\LanmanServer\\Parameters", "SMB1"
+            )
         assert result == 1
         assert isinstance(result, int)
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,29 @@
+"""Guard: the package version is single-sourced.
+
+``pyproject.toml`` ``[project].version`` and ``apotrope.__version__`` are
+maintained by hand; this test fails if they drift, so the wheel's metadata
+version can never disagree with the version the CLI reports.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import apotrope
+
+
+def test_pyproject_version_matches_dunder():
+    root = Path(__file__).resolve().parents[1]
+    data = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    assert data["project"]["version"] == apotrope.__version__
+
+
+def test_license_is_spdx_expression():
+    # PEP 639: license is an SPDX string, and the deprecated classifier is gone.
+    root = Path(__file__).resolve().parents[1]
+    data = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    assert data["project"]["license"] == "MIT"
+    assert not any(
+        c.startswith("License ::") for c in data["project"].get("classifiers", [])
+    )

--- a/tools/command_audit.py
+++ b/tools/command_audit.py
@@ -70,13 +70,15 @@ def _collect_constants(tree: ast.Module) -> dict[str, str]:
         and n.targets[0].id != "command"
     ]
     for node in sorted(assigns, key=lambda n: n.lineno):
+        target = node.targets[0]
+        assert isinstance(target, ast.Name)  # guaranteed by the comprehension filter
         value = node.value
         if isinstance(value, ast.Constant) and isinstance(value.value, (str, int, float, bool)):
-            consts[node.targets[0].id] = str(value.value)
+            consts[target.id] = str(value.value)
         else:
             resolved = _resolve(value, consts)
             if resolved is not None:
-                consts[node.targets[0].id] = resolved
+                consts[target.id] = resolved
     return consts
 
 
@@ -141,7 +143,7 @@ def collect_commands() -> list[Command]:
 
         # Every `command=` keyword on any call, plus every `command = ...` assignment
         # (checks that build the string in a local variable before passing it on).
-        exprs: list[ast.AST] = []
+        exprs: list[ast.expr] = []
         for node in ast.walk(tree):
             if isinstance(node, ast.Call):
                 for kw in node.keywords:

--- a/tools/verify_commands.py
+++ b/tools/verify_commands.py
@@ -27,7 +27,7 @@ import tempfile
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from command_audit import collect_commands  # noqa: E402
+from command_audit import collect_commands
 
 # Sample values for the runtime interpolations in command templates.
 _PLACEHOLDERS = {
@@ -108,6 +108,10 @@ def main() -> int:
         env={**__import__("os").environ, "APOTROPE_CMD_FILE": cmd_file},
         capture_output=True,
         text=True,
+        # Explicitly False, never True: the return code is this script's own
+        # exit code (see main()), so check=True would turn a reported command
+        # failure into a CalledProcessError traceback in the CI step.
+        check=False,
     )
     print(proc.stdout)
     if proc.stderr.strip():


### PR DESCRIPTION
> Depends on #92 and #94, both merged. Rebased onto `main`; merge last, since this PR introduces the `ruff`/`mypy` gates and its run is the first to apply them to the merged tree.

The CI and packaging layer had gaps: `ruff` and `mypy` ran locally but were never enforced (and `mypy` had three real errors); the "OS-independent" test suite actually shelled out to real `powershell.exe`; publishing wasn't gated on the tag matching the version or on the wheel installing; and the version was maintained by hand in two files.

## What changed

- **Lint and types are enforced, at exact pins.** `ruff` and `mypy` steps in `test.yml`, with `ruff==0.16.0` and `mypy==1.19.1` in the dev extra rather than floors. This is not fussiness: `ruff>=0.6` resolved to 0.16.0, whose default rule set grew from 59 rules to 413, and the gate went red across every matrix leg with no code change. A required gate must not have its rule set chosen by whatever pip resolves that morning. `[tool.ruff.lint] select` *replaces* the default set rather than extending it, so upstream churn can't reach us either. This clears the 34 `ruff` violations and 7 `mypy` errors present on `main`, three of the latter in `tools/command_audit.py`.

- **Tests are hermetic.** An autouse fixture fails any test that reaches the real `subprocess` boundary; opt out with `@pytest.mark.allow_subprocess`. The mocked suite dropped from ~22s to ~4s — it had been spending ~18s in real PowerShell, which also meant those tests were quietly OS-dependent.

- **Publishing is gated.** An exact tag-vs-`pyproject` version check, plus a required Windows job that `pip install`s the built wheel and smoke-tests it before the OIDC publish. The probe compares the *importable* check set against the registry and asserts the Jinja templates load through the real loader, because `apotrope --dry-run` prints "0 module(s) would run" and returns 0 — it would have passed for a wheel containing no check modules and no templates at all.

- **The module registry is verified.** `checks.MODULES` is asserted against the modules on disk and counted with `Counter`, not `set`. `set()` discards cardinality, so a duplicated entry passed the old check while the frozen scanner imported that name twice and emitted its results twice — **double-deducting each FAIL and WARN from the score**. `_discover_modules` now dedupes while preserving order, with a meta-test proving the guard fires.

- **Version single-sourced**, asserted against `apotrope.__version__`; PEP 639 SPDX license metadata; `pillow` added to `requirements.txt`; `claude.yml` gains its missing checkout and permissions.

## Deferred

Pinning workflow `uses:` to full commit SHAs. Pure supply-chain hardening, where each SHA has to be verified against its release — it belongs in its own deliberate change rather than mixed in here.

## Tests

958 pass, 99.07% coverage against the 95% floor. `ruff` and `mypy` clean on `src`, `tests` and `tools`; `tools/verify_commands.py` passes 45/45 on Windows.

