### PR TITLE
Evaluate password policy on non-elevated scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Password policy is evaluated on non-elevated scans again.** `secedit /export`
+  reads a database ACL'd to SYSTEM and Administrators, so the documented
+  run-without-admin invocation could not read password policy and reported all
+  three controls as ERROR. ERROR is score-neutral, so a machine with a minimum
+  password length of 0 lost a HIGH FAIL and scored *higher* for being
+  unmeasurable — biased so that weak machines were the ones told they were fine.
+  Minimum length and account lockout now come from `NetUserModalsGet`, which a
+  standard user can read and which returns integers rather than the localized
+  text `net accounts` prints, so it does not reintroduce the locale dependence
+  that moving to `secedit` removed. Measured on a Windows 11 host: a non-elevated
+  scan went from 87/B back to 77/C, matching the elevated result. Password
+  complexity is an LSA setting with no unprivileged equivalent and is still
+  reported as requiring elevation rather than guessed.
+
 - **Security principals are identified by SID, not by localized display name.**
   The built-in Administrator/Guest are matched on RID suffix (`-500`/`-501`) and
   the Administrators group by `S-1-5-32-544`, so a renamed account or a

--- a/README.md
+++ b/README.md
@@ -405,64 +405,64 @@ scan time.
 
 ## Checks Performed
 
-| Category       | Check                                  | Description                                                                        |
-|----------------|----------------------------------------|------------------------------------------------------------------------------------|
-| Access Control | UAC Admin Consent Behavior             | Checks the UAC consent prompt behavior for administrator accounts                  |
-| Access Control | UAC Enabled                            | Checks whether User Account Control (UAC) is enabled                               |
-| Access Control | UAC Secure Desktop                     | Checks whether UAC prompts are shown on the isolated secure desktop                |
-| Access Control | UAC Standard User Behavior             | Checks the UAC consent prompt behavior for standard user accounts                  |
-| Accounts       | Built-in Administrator Account         | Checks whether the built-in Administrator account is enabled or renamed            |
-| Accounts       | Guest Account                          | Checks whether the built-in Guest account is disabled                              |
-| Accounts       | Local Administrators                   | Counts members of the local Administrators group (warns if > 2)                    |
-| Accounts       | Password Policy — Account Lockout      | Checks whether account lockout is configured to deter brute-force attacks          |
-| Accounts       | Password Policy — Complexity           | Checks whether password complexity requirements are enforced                       |
-| Accounts       | Password Policy — Minimum Length       | Checks minimum password length (fail < 8 chars, warn < 12 chars)                  |
-| Antivirus      | Defender Real-Time Protection          | Checks whether Windows Defender real-time protection is active                     |
-| Antivirus      | Defender Signature Age                 | Checks whether virus definitions are less than 7 days old                          |
-| Antivirus      | Defender Tamper Protection             | Checks whether Tamper Protection prevents unauthorised Defender changes             |
-| Antivirus      | Registered AV Products                 | Lists antivirus products registered with Windows Security Center                   |
-| Encryption     | BitLocker — {drive} *                  | BitLocker encryption and protection status per fixed drive (one result per drive)  |
-| File Sharing   | SMB Encryption *                       | Checks whether SMB encryption (EncryptData) is enforced                            |
-| File Sharing   | SMB Signing Required *                 | Checks that SMB message signing is required (mitigates NTLM relay attacks)         |
-| File Sharing   | SMBv1 Disabled *                       | Checks that SMBv1 is disabled (mitigates EternalBlue/WannaCry/NotPetya)           |
-| Firewall       | Firewall — Domain Default Inbound Action | Checks that the Domain profile does not explicitly allow all inbound connections  |
-| Firewall       | Firewall — Domain Profile Enabled      | Checks whether Windows Firewall is enabled for domain networks                     |
-| Firewall       | Firewall — Private Default Inbound Action | Checks that the Private profile does not explicitly allow all inbound connections |
-| Firewall       | Firewall — Private Profile Enabled     | Checks whether Windows Firewall is enabled for private networks                    |
-| Firewall       | Firewall — Profiles Present            | Verifies all three profiles were reported — a missing one is an ERROR, not a silent gap |
-| Firewall       | Firewall — Public Default Inbound Action | Checks that the Public profile does not explicitly allow all inbound connections  |
-| Firewall       | Firewall — Public Profile Enabled      | Checks whether Windows Firewall is enabled for public networks                     |
-| Hardening      | Audit Policy                           | Checks that key subcategories (Logon, Lockout, etc.) log success/failure events    |
-| Hardening      | AutoPlay Disabled                      | Checks whether AutoPlay is disabled for all drive types                            |
-| Hardening      | Screen Lock Timeout                    | Checks that the screen automatically locks within 15 minutes of inactivity         |
-| Hardening      | Speculative Execution Mitigations      | Checks whether Spectre/Meltdown mitigations have been explicitly disabled          |
-| Hardening      | WinRM Status                           | Checks whether the Windows Remote Management (WinRM) service is running            |
-| Network        | IPv6 Status                            | Reports whether IPv6 is active on any network adapter (informational)              |
-| Network        | LLMNR Disabled                         | Checks whether LLMNR is disabled (susceptible to poisoning/Responder attacks)      |
-| Network        | Listening Port — {port}/{service}      | Flags known-dangerous listening ports: FTP (21), Telnet (23), TFTP (69), RDP (3389) |
-| Network        | Listening Ports — Summary              | Enumerates all TCP ports currently in LISTEN state (informational)                 |
-| Network        | NetBIOS over TCP/IP                    | Checks whether NetBIOS over TCP/IP is disabled on all network adapters             |
-| Patching       | Last Windows Update                    | Checks when the most recent update was installed (warn > 30 days, fail > 60 days) |
-| Patching       | Pending Windows Updates                | Counts Windows Updates that are available but not yet installed                    |
-| Patching       | Windows Update Service                 | Checks whether the Windows Update (wuauserv) service is running                   |
-| Persistence    | Scheduled Tasks                        | Enumerates non-Microsoft scheduled tasks (potential persistence points)            |
-| Persistence    | Startup Programs                       | Enumerates programs configured to run at startup (registry Run keys + folders)    |
-| PowerShell     | PowerShell Constrained Language Mode   | Checks whether PowerShell Constrained Language Mode is active                      |
-| PowerShell     | PowerShell Execution Policy            | Checks the LocalMachine execution policy (warns on Unrestricted/Bypass)            |
-| PowerShell     | PowerShell Module Logging              | Checks whether PowerShell module pipeline logging is enabled                       |
-| PowerShell     | PowerShell Script Block Logging        | Checks whether Script Block Logging is enabled (critical for forensics/IR)         |
-| PowerShell     | PowerShell v2                          | Checks whether PowerShell v2 is installed (downgrade attack vector)                |
-| Remote Access  | RDP Enabled                            | Checks whether Remote Desktop Protocol is enabled                                  |
-| Remote Access  | RDP Network Level Authentication †     | Checks whether NLA is required for RDP connections                                 |
-| Remote Access  | RDP Port †                             | Reports the RDP listening port (informational)                                     |
-| Services       | Risky Services / Risky Service — {name} | Flags known-dangerous services if running: Remote Registry, Telnet, SNMP          |
-| Services       | Unquoted Service Paths                 | Detects services with unquoted executable paths containing spaces (privilege-escalation vector) |
-| System         | Domain Membership                      | Reports whether the machine is domain-joined or in a workgroup (informational)     |
-| System         | OS End-of-Support Status               | Checks whether the installed Windows build is still supported by Microsoft         |
-| System         | OS Version                             | Reports the installed Windows version and build number (informational)             |
-| System         | Secure Boot                            | Checks whether UEFI Secure Boot is enabled                                         |
-| System         | System Uptime                          | Checks system uptime (warns if > 30 days, suggesting pending patch reboots)        |
-| System         | TPM Status                             | Checks whether a TPM chip is present and functional                                |
+| Category       | Check                                     | Description                                                                                     |
+|----------------|-------------------------------------------|-------------------------------------------------------------------------------------------------|
+| Access Control | UAC Admin Consent Behavior                | Checks the UAC consent prompt behavior for administrator accounts                               |
+| Access Control | UAC Enabled                               | Checks whether User Account Control (UAC) is enabled                                            |
+| Access Control | UAC Secure Desktop                        | Checks whether UAC prompts are shown on the isolated secure desktop                             |
+| Access Control | UAC Standard User Behavior                | Checks the UAC consent prompt behavior for standard user accounts                               |
+| Accounts       | Built-in Administrator Account            | Checks whether the built-in Administrator account is enabled or renamed                         |
+| Accounts       | Guest Account                             | Checks whether the built-in Guest account is disabled                                           |
+| Accounts       | Local Administrators                      | Counts members of the local Administrators group (warns if > 2)                                 |
+| Accounts       | Password Policy — Account Lockout         | Checks whether account lockout is configured to deter brute-force attacks                       |
+| Accounts       | Password Policy — Complexity \*           | Checks whether password complexity requirements are enforced                                    |
+| Accounts       | Password Policy — Minimum Length          | Checks minimum password length (fail < 8 chars, warn < 12 chars)                                |
+| Antivirus      | Defender Real-Time Protection             | Checks whether Windows Defender real-time protection is active                                  |
+| Antivirus      | Defender Signature Age                    | Checks whether virus definitions are less than 7 days old                                       |
+| Antivirus      | Defender Tamper Protection                | Checks whether Tamper Protection prevents unauthorised Defender changes                         |
+| Antivirus      | Registered AV Products                    | Lists antivirus products registered with Windows Security Center                                |
+| Encryption     | BitLocker — {drive} *                     | BitLocker encryption and protection status per fixed drive (one result per drive)               |
+| File Sharing   | SMB Encryption *                          | Checks whether SMB encryption (EncryptData) is enforced                                         |
+| File Sharing   | SMB Signing Required *                    | Checks that SMB message signing is required (mitigates NTLM relay attacks)                      |
+| File Sharing   | SMBv1 Disabled *                          | Checks that SMBv1 is disabled (mitigates EternalBlue/WannaCry/NotPetya)                         |
+| Firewall       | Firewall — Domain Default Inbound Action  | Checks that the Domain profile does not explicitly allow all inbound connections                |
+| Firewall       | Firewall — Domain Profile Enabled         | Checks whether Windows Firewall is enabled for domain networks                                  |
+| Firewall       | Firewall — Private Default Inbound Action | Checks that the Private profile does not explicitly allow all inbound connections               |
+| Firewall       | Firewall — Private Profile Enabled        | Checks whether Windows Firewall is enabled for private networks                                 |
+| Firewall       | Firewall — Profiles Present               | Verifies all three profiles were reported — a missing one is an ERROR                           |
+| Firewall       | Firewall — Public Default Inbound Action  | Checks that the Public profile does not explicitly allow all inbound connections                |
+| Firewall       | Firewall — Public Profile Enabled         | Checks whether Windows Firewall is enabled for public networks                                  |
+| Hardening      | Audit Policy                              | Checks that key subcategories (Logon, Lockout, etc.) log success/failure events                 |
+| Hardening      | AutoPlay Disabled                         | Checks whether AutoPlay is disabled for all drive types                                         |
+| Hardening      | Screen Lock Timeout                       | Checks that the screen automatically locks within 15 minutes of inactivity                      |
+| Hardening      | Speculative Execution Mitigations         | Checks whether Spectre/Meltdown mitigations have been explicitly disabled                       |
+| Hardening      | WinRM Status                              | Checks whether the Windows Remote Management (WinRM) service is running                         |
+| Network        | IPv6 Status                               | Reports whether IPv6 is active on any network adapter (informational)                           |
+| Network        | LLMNR Disabled                            | Checks whether LLMNR is disabled (susceptible to poisoning/Responder attacks)                   |
+| Network        | Listening Port — {port}/{service}         | Flags known-dangerous listening ports: FTP (21), Telnet (23), TFTP (69), RDP (3389)             |
+| Network        | Listening Ports — Summary                 | Enumerates all TCP ports currently in LISTEN state (informational)                              |
+| Network        | NetBIOS over TCP/IP                       | Checks whether NetBIOS over TCP/IP is disabled on all network adapters                          |
+| Patching       | Last Windows Update                       | Checks when the most recent update was installed (warn > 30 days, fail > 60 days)               |
+| Patching       | Pending Windows Updates                   | Counts Windows Updates that are available but not yet installed                                 |
+| Patching       | Windows Update Service                    | Checks whether the Windows Update (wuauserv) service is running                                 |
+| Persistence    | Scheduled Tasks                           | Enumerates non-Microsoft scheduled tasks (potential persistence points)                         |
+| Persistence    | Startup Programs                          | Enumerates programs configured to run at startup (registry Run keys + folders)                  |
+| PowerShell     | PowerShell Constrained Language Mode      | Checks whether PowerShell Constrained Language Mode is active                                   |
+| PowerShell     | PowerShell Execution Policy               | Checks the LocalMachine execution policy (warns on Unrestricted/Bypass)                         |
+| PowerShell     | PowerShell Module Logging                 | Checks whether PowerShell module pipeline logging is enabled                                    |
+| PowerShell     | PowerShell Script Block Logging           | Checks whether Script Block Logging is enabled (critical for forensics/IR)                      |
+| PowerShell     | PowerShell v2                             | Checks whether PowerShell v2 is installed (downgrade attack vector)                             |
+| Remote Access  | RDP Enabled                               | Checks whether Remote Desktop Protocol is enabled                                               |
+| Remote Access  | RDP Network Level Authentication †        | Checks whether NLA is required for RDP connections                                              |
+| Remote Access  | RDP Port †                                | Reports the RDP listening port (informational)                                                  |
+| Services       | Risky Services / Risky Service — {name}   | Flags known-dangerous services if running: Remote Registry, Telnet, SNMP                        |
+| Services       | Unquoted Service Paths                    | Detects services with unquoted executable paths containing spaces (privilege-escalation vector) |
+| System         | Domain Membership                         | Reports whether the machine is domain-joined or in a workgroup (informational)                  |
+| System         | OS End-of-Support Status                  | Checks whether the installed Windows build is still supported by Microsoft                      |
+| System         | OS Version                                | Reports the installed Windows version and build number (informational)                          |
+| System         | Secure Boot                               | Checks whether UEFI Secure Boot is enabled                                                      |
+| System         | System Uptime                             | Checks system uptime (warns if > 30 days, suggesting pending patch reboots)                     |
+| System         | TPM Status                                | Checks whether a TPM chip is present and functional                                             |
 
 \* Requires **Administrator** privileges for full results.
 † Only emitted when RDP is enabled.

--- a/src/apotrope/checks/accounts.py
+++ b/src/apotrope/checks/accounts.py
@@ -15,7 +15,7 @@ import logging
 
 from apotrope.exceptions import ApotropeError
 from apotrope.models import CheckResult, Severity, Status
-from apotrope.utils import run_powershell, run_powershell_json
+from apotrope.utils import read_password_policy, run_powershell, run_powershell_json
 
 log = logging.getLogger(__name__)
 
@@ -243,11 +243,18 @@ def _check_admin_count() -> list[CheckResult]:
 
 
 def _check_password_policy() -> list[CheckResult]:
-    """Check local password policy via secedit (locale-neutral INF keys)."""
+    """Check local password policy, preferring secedit and falling back to Win32.
+
+    ``secedit /export`` is the primary source because it is the only one that
+    carries all three controls. It requires elevation, so the non-elevated run —
+    the documented default — falls back to :func:`read_password_policy`, which
+    reads the same values from the local SAM through ``NetUserModalsGet`` and is
+    readable by a standard user.
+    """
     try:
         inf_text = run_powershell(_PS_SECEDIT)
-    except ApotropeError as exc:
-        return _password_policy_unavailable(exc)
+    except ApotropeError as secedit_exc:
+        return _password_policy_without_secedit(secedit_exc)
 
     policy = _parse_secedit_inf(inf_text)
     return [
@@ -257,8 +264,53 @@ def _check_password_policy() -> list[CheckResult]:
     ]
 
 
-def _password_policy_unavailable(exc: ApotropeError) -> list[CheckResult]:
-    """Degrade a failed secedit export into one ERROR *per* password-policy control.
+def _password_policy_without_secedit(secedit_exc: ApotropeError) -> list[CheckResult]:
+    """Evaluate what can still be measured without the security-policy export.
+
+    ``NetUserModalsGet`` returns minimum length and account lockout as integers
+    from the local SAM, unprivileged and locale-neutral — so those two controls
+    are evaluated normally rather than degraded, and a weak policy is still
+    reported as a FAIL on a non-elevated scan.
+
+    Complexity has no equivalent at any ``USER_MODALS_INFO`` level: it is an LSA
+    policy setting, and the only readable carriers of it are the security-policy
+    export (Administrators-only) and the local GPO template, which reflects only
+    locally-configured policy and would silently miss a domain GPO. Guessing it
+    from either would be the confidently-wrong verdict this module exists to
+    avoid, so it is reported as unmeasurable instead.
+    """
+    try:
+        policy = read_password_policy()
+    except ApotropeError as modals_exc:
+        return _password_policy_unavailable(secedit_exc, modals_exc)
+
+    log.info(
+        "secedit unavailable (%s) — password length and lockout read via "
+        "NetUserModalsGet instead", secedit_exc,
+    )
+    return [
+        _eval_min_length(policy),
+        _eval_lockout(policy),
+        _complexity_requires_elevation(),
+    ]
+
+
+def _complexity_requires_elevation() -> CheckResult:
+    """Report password complexity as unmeasurable, with the reason."""
+    return _error(
+        _PW_COMPLEXITY,
+        "Password complexity could not be read. It is an LSA policy setting with "
+        "no unprivileged equivalent, and the security-policy export that carries "
+        "it requires administrator privileges. Minimum length and account lockout "
+        "were evaluated normally.",
+        remediation="Re-run Apotrope as Administrator to evaluate password complexity.",
+    )
+
+
+def _password_policy_unavailable(
+    secedit_exc: ApotropeError, modals_exc: ApotropeError
+) -> list[CheckResult]:
+    """Degrade into one ERROR *per* control when *both* policy sources fail.
 
     These three ``check_name`` strings key ``cis_map.py``, ``--compare``, and
     ``profile.disabled_checks``, so collapsing the failure into a single
@@ -267,19 +319,18 @@ def _password_policy_unavailable(exc: ApotropeError) -> list[CheckResult]:
     Account Lockout or Complexity row at all, and a baseline diff read the
     disappearance as lost coverage on both sides.
 
-    The overwhelmingly common cause is elevation, not a broken machine — secedit
-    exports from ``%windir%\\security\\database\\secedit.sdb``, which is ACL'd to
-    SYSTEM and Administrators only, so the documented non-elevated invocation
-    always lands here. Say that in ``details`` instead of surfacing a bare
-    stderr, and point the remediation at re-running elevated.
+    Reaching here now means the machine genuinely is not answering. Lack of
+    elevation on its own no longer lands here — that is what the
+    ``NetUserModalsGet`` fallback handles — so both underlying errors are
+    reported rather than blaming a cause we have not established.
     """
     detail = (
-        f"Could not export the local security policy ({exc}) — password policy "
-        "was not evaluated. secedit reads a database readable only by SYSTEM and "
-        "Administrators, so a scan run without elevation always reports this."
+        "Could not read the local password policy. The security-policy export "
+        f"failed ({secedit_exc}) and the Win32 fallback also failed "
+        f"({modals_exc}), so none of the three controls could be evaluated."
     )
     return [
-        _error(name, detail, remediation="Re-run Apotrope as Administrator to evaluate password policy.")
+        _error(name, detail, remediation="Run with --log-level DEBUG for more detail.")
         for name in _PW_POLICY_CHECKS
     ]
 

--- a/src/apotrope/utils.py
+++ b/src/apotrope/utils.py
@@ -446,6 +446,127 @@ def get_wmi_object(
 
 
 # ---------------------------------------------------------------------------
+# Local password policy (netapi32)
+# ---------------------------------------------------------------------------
+
+# NetUserModalsGet reads the local SAM's password policy. It is the API that
+# `net accounts` itself wraps, and it matters here for two reasons:
+#
+#   * it is readable by a **standard user**, where `secedit /export` is not —
+#     secedit reads %windir%\security\database\secedit.sdb, which is ACL'd to
+#     SYSTEM and Administrators only, so the documented non-elevated invocation
+#     can never use it; and
+#   * it returns **integers**, not the localized text `net accounts` prints, so
+#     it survives non-English Windows — which is the whole reason the check
+#     stopped parsing `net accounts` in the first place.
+#
+# It does NOT expose PasswordComplexity; that is an LSA policy setting with no
+# field in any USER_MODALS_INFO level. Callers must not synthesise one.
+
+
+class _UserModals0(ctypes.Structure):
+    """``USER_MODALS_INFO_0`` — password length, ages, and history depth."""
+
+    _fields_ = (
+        ("min_passwd_len", ctypes.c_uint32),
+        ("max_passwd_age", ctypes.c_uint32),
+        ("min_passwd_age", ctypes.c_uint32),
+        ("force_logoff", ctypes.c_uint32),
+        ("password_hist_len", ctypes.c_uint32),
+    )
+
+
+class _UserModals3(ctypes.Structure):
+    """``USER_MODALS_INFO_3`` — account lockout.
+
+    All three fields are ``DWORD``. Declaring the two durations wider does not
+    fail: the call still returns success and the struct is simply misread, so
+    the error surfaces as plausible-looking garbage rather than an exception.
+    Both durations are in **seconds**; the secedit INF expresses them in
+    minutes, which is why :func:`read_password_policy` converts.
+    """
+
+    _fields_ = (
+        ("lockout_duration", ctypes.c_uint32),
+        ("lockout_observation_window", ctypes.c_uint32),
+        ("lockout_threshold", ctypes.c_uint32),
+    )
+
+
+# TIMEQ_FOREVER: "never expires" / "until an administrator unlocks". The secedit
+# INF spells the same thing -1, and the evaluators read INF conventions.
+_TIMEQ_FOREVER = 0xFFFFFFFF
+
+
+def _query_user_modals(level: int, struct_type: type[ctypes.Structure]) -> ctypes.Structure:
+    """Call ``NetUserModalsGet`` for *level* and return a copy of the struct.
+
+    The buffer is always released with ``NetApiBufferFree``; the copy is taken
+    first so the returned object does not point into freed memory.
+
+    Raises:
+        ApotropeError: Off Windows, or when the call returns a non-zero status.
+    """
+    if sys.platform != "win32":
+        raise ApotropeError("NetUserModalsGet is Windows-only")
+    netapi32 = ctypes.WinDLL("netapi32", use_last_error=True)
+    get_modals = netapi32.NetUserModalsGet
+    # servername NULL = this machine. bufptr is an out-param the API allocates.
+    get_modals.argtypes = (ctypes.c_wchar_p, ctypes.c_uint32, ctypes.POINTER(ctypes.c_void_p))
+    get_modals.restype = ctypes.c_uint32
+    free_buffer = netapi32.NetApiBufferFree
+    free_buffer.argtypes = (ctypes.c_void_p,)
+    free_buffer.restype = ctypes.c_uint32
+
+    buf = ctypes.c_void_p()
+    status = get_modals(None, level, ctypes.byref(buf))
+    if status != 0:
+        raise ApotropeError(
+            f"NetUserModalsGet(level={level}) failed with status {status}"
+        )
+    try:
+        # copy(): the struct lives in the API-allocated buffer freed below.
+        return struct_type.from_buffer_copy(
+            ctypes.cast(buf, ctypes.POINTER(struct_type)).contents
+        )
+    finally:
+        free_buffer(buf)
+
+
+def read_password_policy() -> dict[str, str]:
+    """Read the local password policy, keyed like a parsed secedit INF.
+
+    Returns the same lowercase ``key -> str`` shape that a ``secedit /export``
+    INF parses to, so a caller can feed either source to the same evaluators.
+    Durations are converted from the API's seconds to the INF's minutes.
+
+    ``PasswordComplexity`` is deliberately absent — see the module comment
+    above. A caller must report that control as unmeasurable rather than
+    inferring a value.
+
+    Raises:
+        ApotropeError: Off Windows, or when either query fails.
+    """
+    modals0 = cast("_UserModals0", _query_user_modals(0, _UserModals0))
+    modals3 = cast("_UserModals3", _query_user_modals(3, _UserModals3))
+
+    def _minutes(seconds: int) -> str:
+        # The INF writes -1 for "forever"; preserve that rather than emitting a
+        # 71-million-minute duration that would read as a real threshold.
+        if seconds == _TIMEQ_FOREVER:
+            return "-1"
+        return str(seconds // 60)
+
+    return {
+        "minimumpasswordlength": str(modals0.min_passwd_len),
+        "passwordhistorysize": str(modals0.password_hist_len),
+        "lockoutbadcount": str(modals3.lockout_threshold),
+        "lockoutduration": _minutes(modals3.lockout_duration),
+        "resetlockoutcount": _minutes(modals3.lockout_observation_window),
+    }
+
+
+# ---------------------------------------------------------------------------
 # Platform / privilege helpers
 # ---------------------------------------------------------------------------
 

--- a/tests/test_checks/test_accounts.py
+++ b/tests/test_checks/test_accounts.py
@@ -245,50 +245,101 @@ class TestCheckPasswordPolicy:
         r = self._by_name(self._run(self._inf(lockout="lots")), "Lockout")
         assert r.status == Status.ERROR
 
-    def test_secedit_error_returns_error(self):
-        with patch("apotrope.checks.accounts.run_powershell",
-                   side_effect=ApotropeError("secedit denied")):
-            results = accounts._check_password_policy()
-        assert any(r.status == Status.ERROR for r in results)
-
-    def test_secedit_failure_degrades_every_control_separately(self):
-        # A single collapsed "Password Policy" result DELETED three CIS-mapped
-        # rows from the report rather than degrading them — the operator saw no
-        # Minimum Length / Account Lockout / Complexity row at all. Each control
-        # must survive the failure under its own name.
-        with patch("apotrope.checks.accounts.run_powershell",
-                   side_effect=ApotropeError("secedit denied")):
-            results = accounts._check_password_policy()
-        assert [r.check_name for r in results] == list(accounts._PW_POLICY_CHECKS)
-        assert all(r.status == Status.ERROR for r in results)
-
-    def test_secedit_failure_names_stay_cis_mapped(self):
-        # These check_name strings key cis_map.py, --compare and
-        # profile.disabled_checks; a renamed result silently loses all three.
-        with patch("apotrope.checks.accounts.run_powershell",
-                   side_effect=ApotropeError("secedit denied")):
-            results = accounts._check_password_policy()
-        for r in results:
-            assert cis_map.lookup(r.check_name), f"{r.check_name!r} has no CIS reference"
-
-    def test_secedit_failure_points_at_elevation(self):
-        # secedit exports from a database readable only by SYSTEM and
-        # Administrators, so the documented non-elevated invocation always lands
-        # here. Say so — a bare stderr string is not actionable.
-        with patch("apotrope.checks.accounts.run_powershell",
-                   side_effect=ApotropeError("secedit denied")):
-            results = accounts._check_password_policy()
-        for r in results:
-            assert "Administrator" in r.remediation
-            assert "Administrators" in r.details
-
     def test_success_and_failure_paths_agree_on_names(self):
-        # If the two paths ever disagree, a --compare diff reads the mismatch as
-        # one control vanishing and another appearing.
+        # If any path ever disagrees, a --compare diff reads the mismatch as one
+        # control vanishing and another appearing.
         with patch("apotrope.checks.accounts.run_powershell",
                    return_value=self._inf()):
             ok = accounts._check_password_policy()
         assert [r.check_name for r in ok] == list(accounts._PW_POLICY_CHECKS)
+
+
+# ---------------------------------------------------------------------------
+# Non-elevated fallback: secedit needs admin, NetUserModalsGet does not
+# ---------------------------------------------------------------------------
+
+class TestPasswordPolicyWithoutSecedit:
+    """A non-elevated scan must still produce real verdicts, not three ERRORs.
+
+    ``secedit /export`` reads a database ACL'd to SYSTEM and Administrators, so
+    the documented default invocation cannot use it. Minimum length and lockout
+    come from ``NetUserModalsGet`` instead — unprivileged and locale-neutral.
+    """
+
+    _MODALS = {
+        "minimumpasswordlength": "0",
+        "passwordhistorysize": "0",
+        "lockoutbadcount": "10",
+        "lockoutduration": "30",
+        "resetlockoutcount": "30",
+    }
+
+    def _run(self, modals=None, modals_raises=None):
+        kw = {"side_effect": modals_raises} if modals_raises else {"return_value": modals}
+        with (
+            patch("apotrope.checks.accounts.run_powershell",
+                  side_effect=ApotropeError("secedit exited 1")),
+            patch("apotrope.checks.accounts.read_password_policy", **kw),
+        ):
+            return accounts._check_password_policy()
+
+    def _by(self, results, needle):
+        return next(r for r in results if needle in r.check_name)
+
+    def test_weak_length_is_still_a_fail_without_elevation(self):
+        # THE POINT OF THIS CHANGE. MinimumPasswordLength=0 is a HIGH FAIL worth
+        # -10. Reporting it as an unscored ERROR inflates the score on exactly
+        # the machines that deserve the deduction.
+        r = self._by(self._run(self._MODALS), "Minimum Length")
+        assert r.status == Status.FAIL
+        assert r.severity == Severity.HIGH
+
+    def test_lockout_is_evaluated_without_elevation(self):
+        r = self._by(self._run(self._MODALS), "Account Lockout")
+        assert r.status == Status.PASS
+        assert "10 attempt(s)" in r.details
+
+    def test_complexity_is_reported_unmeasurable_not_guessed(self):
+        # Complexity is an LSA setting with no USER_MODALS_INFO field. Inventing
+        # a value would be the confidently-wrong verdict this module avoids.
+        r = self._by(self._run(self._MODALS), "Complexity")
+        assert r.status == Status.ERROR
+        assert "Administrator" in r.remediation
+
+    def test_all_three_controls_still_reported_and_cis_mapped(self):
+        results = self._run(self._MODALS)
+        assert [r.check_name for r in results] == list(accounts._PW_POLICY_CHECKS)
+        for r in results:
+            assert cis_map.lookup(r.check_name), f"{r.check_name!r} lost its CIS reference"
+
+    def test_strong_policy_passes_without_elevation(self):
+        strong = {**self._MODALS, "minimumpasswordlength": "14"}
+        r = self._by(self._run(strong), "Minimum Length")
+        assert r.status == Status.PASS
+
+    def test_both_sources_failing_degrades_every_control(self):
+        # Lack of elevation no longer lands here; reaching it means the machine
+        # genuinely is not answering, so both causes are reported.
+        results = self._run(modals_raises=ApotropeError("netapi32 status 5"))
+        assert [r.check_name for r in results] == list(accounts._PW_POLICY_CHECKS)
+        assert all(r.status == Status.ERROR for r in results)
+        for r in results:
+            assert "secedit exited 1" in r.details
+            assert "netapi32 status 5" in r.details
+
+    def test_fallback_is_not_used_when_secedit_works(self):
+        # The fallback must never override the richer source.
+        inf = (
+            "[System Access]\nMinimumPasswordLength = 14\nLockoutBadCount = 5\n"
+            "LockoutDuration = 30\nPasswordComplexity = 1\n"
+        )
+        with (
+            patch("apotrope.checks.accounts.run_powershell", return_value=inf),
+            patch("apotrope.checks.accounts.read_password_policy") as modals,
+        ):
+            results = accounts._check_password_policy()
+        modals.assert_not_called()
+        assert next(r for r in results if "Complexity" in r.check_name).status == Status.PASS
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -643,3 +643,119 @@ class TestGetWmiObjectScalarJson:
     def test_scalar_json_returns_empty_list(self):
         with patch("apotrope.utils.run_powershell", return_value="42"):
             assert utils.get_wmi_object("Win32_Weird") == []
+
+
+# ---------------------------------------------------------------------------
+# read_password_policy / NetUserModalsGet
+# ---------------------------------------------------------------------------
+
+class TestUserModalsStructs:
+    """Field widths are load-bearing and fail silently if wrong.
+
+    ``NetUserModalsGet`` returns success regardless of how the caller declares
+    the struct, so a too-wide field is not an error — it is plausible-looking
+    garbage. (Declaring the two durations as 64-bit produced a lockout duration
+    of 7,730,941,134,600 during development, which would have rendered as a
+    perfectly straight-faced finding.) These sizes pin the layout.
+    """
+
+    def test_modals0_layout(self):
+        import ctypes
+        assert ctypes.sizeof(utils._UserModals0) == 5 * 4
+        assert [n for n, _ in utils._UserModals0._fields_][0] == "min_passwd_len"
+
+    def test_modals3_layout(self):
+        import ctypes
+        assert ctypes.sizeof(utils._UserModals3) == 3 * 4
+        assert [n for n, _ in utils._UserModals3._fields_] == [
+            "lockout_duration", "lockout_observation_window", "lockout_threshold",
+        ]
+
+
+class TestReadPasswordPolicy:
+    def _query(self, *, min_len=8, hist=5, threshold=10, duration_s=1800, window_s=1800):
+        m0 = utils._UserModals0(
+            min_passwd_len=min_len, max_passwd_age=0, min_passwd_age=0,
+            force_logoff=0, password_hist_len=hist,
+        )
+        m3 = utils._UserModals3(
+            lockout_duration=duration_s,
+            lockout_observation_window=window_s,
+            lockout_threshold=threshold,
+        )
+        return lambda level, struct_type: m0 if level == 0 else m3
+
+    def _run(self, **kw):
+        with patch.object(utils, "_query_user_modals", self._query(**kw)):
+            return utils.read_password_policy()
+
+    def test_keys_match_the_secedit_inf_shape(self):
+        # The evaluators are shared with the secedit path, so the fallback must
+        # speak the same lowercase INF key names.
+        policy = self._run()
+        assert policy["minimumpasswordlength"] == "8"
+        assert policy["lockoutbadcount"] == "10"
+
+    def test_durations_convert_seconds_to_minutes(self):
+        # The API reports seconds; the INF (and therefore the evaluators and the
+        # rendered "Duration: N minute(s)") use minutes.
+        policy = self._run(duration_s=1800, window_s=900)
+        assert policy["lockoutduration"] == "30"
+        assert policy["resetlockoutcount"] == "15"
+
+    def test_forever_duration_renders_as_the_inf_sentinel(self):
+        # TIMEQ_FOREVER means "until an administrator unlocks". Dividing it by 60
+        # would report a 71-million-minute lockout as a real threshold.
+        policy = self._run(duration_s=0xFFFFFFFF)
+        assert policy["lockoutduration"] == "-1"
+
+    def test_complexity_is_never_synthesised(self):
+        # No USER_MODALS_INFO level carries PasswordComplexity. Emitting a key
+        # here would let the evaluator render a guess as a real verdict.
+        assert "passwordcomplexity" not in self._run()
+
+    def test_values_are_strings(self):
+        assert all(isinstance(v, str) for v in self._run().values())
+
+
+class TestQueryUserModals:
+    def test_raises_off_windows(self):
+        with patch.object(sys, "platform", "linux"):
+            with pytest.raises(ApotropeError, match="Windows-only"):
+                utils._query_user_modals(0, utils._UserModals0)
+
+    def test_non_zero_status_raises(self):
+        netapi32 = MagicMock()
+        netapi32.NetUserModalsGet.return_value = 5  # ERROR_ACCESS_DENIED
+        with (
+            patch.object(sys, "platform", "win32"),
+            patch("ctypes.WinDLL", return_value=netapi32),
+        ):
+            with pytest.raises(ApotropeError, match="status 5"):
+                utils._query_user_modals(0, utils._UserModals0)
+        netapi32.NetApiBufferFree.assert_not_called()
+
+    def test_success_path_copies_then_frees_the_api_buffer(self):
+        import ctypes
+        source = utils._UserModals3(
+            lockout_duration=1800, lockout_observation_window=1800, lockout_threshold=7,
+        )
+
+        def _get(_server, _level, bufptr):
+            # bufptr is byref(buf); ._obj reaches the c_void_p the caller passed.
+            bufptr._obj.value = ctypes.addressof(source)
+            return 0
+
+        netapi32 = MagicMock()
+        netapi32.NetUserModalsGet.side_effect = _get
+        with (
+            patch.object(sys, "platform", "win32"),
+            patch("ctypes.WinDLL", return_value=netapi32),
+        ):
+            out = utils._query_user_modals(3, utils._UserModals3)
+
+        assert out.lockout_threshold == 7
+        # The buffer is API-allocated; not freeing it leaks once per scan.
+        netapi32.NetApiBufferFree.assert_called_once()
+        # A copy, not a view into the freed buffer.
+        assert ctypes.addressof(out) != ctypes.addressof(source)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -545,7 +545,7 @@ class TestGetWmiObject:
 
 class TestIsAdmin:
     def test_returns_false_on_non_windows(self):
-        with patch.object(sys, "platform", "linux"):
+        with patch.object(utils.sys, "platform", "linux"):
             assert utils.is_admin() is False
 
     def test_returns_false_on_darwin(self):
@@ -581,7 +581,7 @@ class TestIsAdmin:
 
 class TestRequireWindows:
     def test_raises_on_linux(self):
-        with patch.object(sys, "platform", "linux"):
+        with patch.object(utils.sys, "platform", "linux"):
             with pytest.raises(ApotropeError, match="requires Windows"):
                 utils.require_windows()
 
@@ -720,7 +720,7 @@ class TestReadPasswordPolicy:
 
 class TestQueryUserModals:
     def test_raises_off_windows(self):
-        with patch.object(sys, "platform", "linux"):
+        with patch.object(utils.sys, "platform", "linux"):
             with pytest.raises(ApotropeError, match="Windows-only"):
                 utils._query_user_modals(0, utils._UserModals0)
 
@@ -728,8 +728,8 @@ class TestQueryUserModals:
         netapi32 = MagicMock()
         netapi32.NetUserModalsGet.return_value = 5  # ERROR_ACCESS_DENIED
         with (
-            patch.object(sys, "platform", "win32"),
-            patch("ctypes.WinDLL", return_value=netapi32),
+            patch.object(utils.sys, "platform", "win32"),
+            patch("apotrope.utils.ctypes.WinDLL", return_value=netapi32, create=True),
         ):
             with pytest.raises(ApotropeError, match="status 5"):
                 utils._query_user_modals(0, utils._UserModals0)
@@ -749,8 +749,8 @@ class TestQueryUserModals:
         netapi32 = MagicMock()
         netapi32.NetUserModalsGet.side_effect = _get
         with (
-            patch.object(sys, "platform", "win32"),
-            patch("ctypes.WinDLL", return_value=netapi32),
+            patch.object(utils.sys, "platform", "win32"),
+            patch("apotrope.utils.ctypes.WinDLL", return_value=netapi32, create=True),
         ):
             out = utils._query_user_modals(3, utils._UserModals3)
 


### PR DESCRIPTION
Follow-up to #93, which moved password policy off localized `net accounts` text and onto a `secedit /export` INF. That fixed a real bug — on non-English Windows the old parser matched nothing and fabricated defaults, producing a false FAIL — but `secedit` needs elevation, and running without admin is the invocation the README advertises.

## Why

`secedit /export` reads `%windir%\security\database\secedit.sdb`, which is ACL'd to SYSTEM and Administrators with no Users ACE. Confirmed both by the ACL and by running it under a de-elevated token, where it produces no output at all. So a non-elevated scan reported all three password-policy controls as ERROR.

ERROR is score-neutral by design, which makes the failure mode worse than it looks: a host with `MinimumPasswordLength = 0` lost a HIGH FAIL worth 10 points and scored **higher** for being unmeasurable. The bias points the wrong way — it is specifically the weak machines that get told they are fine.

Measured on a Windows 11 host, de-elevated (Basic User token):

| | before | after |
|---|---|---|
| Score | **87** (B) | **77** (C) |
| Minimum Length | ERROR | **FAIL** — "0 characters" |
| Account Lockout | ERROR | **PASS** — "10 attempt(s) \| 30 minute(s)" |
| Complexity | ERROR | ERROR, with the reason |
| Controls evaluated | 30 | **32** |

77/C is the same verdict an elevated scan gives.

## What changed

- **`utils.read_password_policy()`** reads minimum length and lockout from `NetUserModalsGet` (netapi32) — the API `net accounts` itself wraps. A standard user can read it, and it returns **integers**, so it does not reintroduce the locale dependence #93 removed. It returns the same lowercase INF key shape a parsed `secedit` export produces, so both sources feed the same evaluators.
- **`accounts._check_password_policy()`** keeps `secedit` primary and falls back only when it fails. If both fail, all three controls still degrade to correctly-named ERRORs reporting both causes.
- Durations are converted: the API reports **seconds**, the INF and the rendered "Duration: N minute(s)" use **minutes**. `TIMEQ_FOREVER` maps to the INF's `-1` rather than dividing into a 71-million-minute lockout.

## Complexity is not guessed

`PasswordComplexity` has no field at any `USER_MODALS_INFO` level — it is an LSA policy setting. The only readable carriers are the Administrators-only security-policy export and the local GPO template, and the latter reflects only *locally configured* policy, so it would silently miss a domain GPO. Inferring from either would be exactly the confidently-wrong verdict this module exists to avoid, so that control reports as unmeasurable with the reason, and is now marked `*` (admin required) in the README.

## Struct widths are pinned by tests

`NetUserModalsGet` returns success regardless of how the caller declares the struct, so a too-wide field is not an error — it is plausible-looking garbage. Declaring the two durations as 64-bit during development produced a lockout duration of 7,730,941,134,600, which would have rendered as a perfectly straight-faced finding. `ctypes.sizeof` assertions catch it; I verified they fail against the wrong declaration.

Uses the plain `ctypes` spellings rather than `ctypes.wintypes`, which is Windows-only and would break the Linux CI legs at import.

## Tests

1008 pass, 1 skipped, 98.90% coverage. `accounts.py` stays at **100%** line and branch; the new `utils.py` code is fully covered (the only uncovered line in that file is a pre-existing Windows guard). `ruff` and `mypy` clean at the pinned versions.

New coverage: the fallback producing a real FAIL for a weak policy and a PASS for a strong one; complexity reported unmeasurable rather than synthesised; all three controls still CIS-mapped; both-sources-failing degrading correctly; the fallback *not* being consulted when `secedit` works; seconds-to-minutes conversion; the `TIMEQ_FOREVER` sentinel; struct layout; non-zero API status; and the success path copying before `NetApiBufferFree`.

**Wants real-Windows validation:** behaviour on a domain-joined host and on a Server SKU. Only tested on a Windows 11 workstation in a workgroup.
