### PR TITLE
Broaden the destructive-command lint; guard registry key creation

### DIFF
--- a/src/apotrope/checks/network.py
+++ b/src/apotrope/checks/network.py
@@ -222,7 +222,7 @@ def _check_llmnr() -> list[CheckResult]:
             remediation="Disable LLMNR to block Responder-style name-resolution poisoning.",
             command=(
                 "$key = 'HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\DNSClient'\n"
-                "New-Item -Path $key -Force | Out-Null\n"
+                "if (-not (Test-Path $key)) { New-Item -Path $key -Force | Out-Null }\n"
                 "Set-ItemProperty -Path $key -Name 'EnableMulticast' -Value 0"
             ),
         )]

--- a/src/apotrope/checks/powershell.py
+++ b/src/apotrope/checks/powershell.py
@@ -117,7 +117,7 @@ def _check_script_block_logging() -> list[CheckResult]:
         command=(
             "" if enabled else
             f"$key = '{_SBL_KEY}'\n"
-            "New-Item -Path $key -Force | Out-Null\n"
+            "if (-not (Test-Path $key)) { New-Item -Path $key -Force | Out-Null }\n"
             "Set-ItemProperty -Path $key -Name 'EnableScriptBlockLogging' -Value 1 -Type DWord"
         ),
     )]
@@ -151,9 +151,10 @@ def _check_module_logging() -> list[CheckResult]:
         command=(
             "" if enabled else
             f"$key = '{_ML_KEY}'\n"
-            "New-Item -Path $key -Force | Out-Null\n"
+            "if (-not (Test-Path $key)) { New-Item -Path $key -Force | Out-Null }\n"
             "Set-ItemProperty -Path $key -Name 'EnableModuleLogging' -Value 1 -Type DWord\n"
-            "New-Item -Path \"$key\\ModuleNames\" -Force | Out-Null\n"
+            "if (-not (Test-Path \"$key\\ModuleNames\")) "
+            "{ New-Item -Path \"$key\\ModuleNames\" -Force | Out-Null }\n"
             "Set-ItemProperty -Path \"$key\\ModuleNames\" -Name '*' -Value '*'"
         ),
     )]

--- a/tests/test_remediation_commands.py
+++ b/tests/test_remediation_commands.py
@@ -107,3 +107,102 @@ class TestUnresolvedExpressionRule:
         bad = [v for v in lint_commands(collect_commands())
                if v.rule == "unresolved-expression"]
         assert not bad, bad
+
+
+class TestDestructiveRuleIsCaseInsensitive:
+    """PowerShell resolves cmdlet names case-insensitively; the rule must too.
+
+    `restart-computer -Force` reboots exactly as `Restart-Computer -Force` does.
+    A case-sensitive denylist reads as protection while catching only the
+    spelling its author happened to use.
+    """
+
+    def test_lowercase_reboot_is_flagged(self) -> None:
+        planted = [Command("fake.py", 1, "restart-computer -Force")]
+        assert [v for v in lint_commands(planted) if v.rule == "destructive-command"]
+
+    def test_mixed_case_tpm_clear_is_flagged(self) -> None:
+        planted = [Command("fake.py", 1, "clear-TPM")]
+        assert [v for v in lint_commands(planted) if v.rule == "destructive-command"]
+
+
+class TestDestructiveRuleCoversMoreThanReboots:
+    """The denylist covers the whole class, not just the two forms that shipped."""
+
+    def test_shutdown_exe_is_flagged(self) -> None:
+        for spelling in ("shutdown /r /t 0", "shutdown.exe -s -t 0", "shutdown /g"):
+            planted = [Command("fake.py", 1, spelling)]
+            assert [v for v in lint_commands(planted) if v.rule == "destructive-command"], spelling
+
+    def test_volume_and_bitlocker_teardown_is_flagged(self) -> None:
+        for spelling in (
+            "Disable-BitLocker -MountPoint 'C:'",
+            "Format-Volume -DriveLetter D",
+            "Clear-Disk -Number 1",
+            "Remove-Partition -DiskNumber 1 -PartitionNumber 2",
+        ):
+            planted = [Command("fake.py", 1, spelling)]
+            assert [v for v in lint_commands(planted) if v.rule == "destructive-command"], spelling
+
+    def test_autoreboot_update_is_flagged(self) -> None:
+        planted = [Command(
+            "fake.py", 1,
+            "Install-Module PSWindowsUpdate -Force\nInstall-WindowsUpdate -AutoReboot",
+        )]
+        assert [v for v in lint_commands(planted) if v.rule == "destructive-command"]
+
+    def test_ordinary_commands_are_not_flagged(self) -> None:
+        # A rule that fires on safe commands gets silenced and then protects nothing.
+        for safe in (
+            "Set-NetFirewallProfile -Profile Domain -Enabled True",
+            "Restart-Service -Name W32Time",           # a service, not the computer
+            "Get-Tpm",
+            "net accounts /minpwlen:14",
+            "Update-MpSignature",
+        ):
+            planted = [Command("fake.py", 1, safe)]
+            assert not [
+                v for v in lint_commands(planted) if v.rule == "destructive-command"
+            ], safe
+
+
+class TestUnguardedNewItemForceRule:
+    """`New-Item -Force` on the registry provider REPLACES the key.
+
+    It deletes every value and subkey underneath. On a shared policy container
+    that means destroying unrelated policy the operator never asked to touch.
+    """
+
+    _REG = r"$key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Foo'" + "\n"
+
+    def test_unguarded_registry_new_item_is_flagged(self) -> None:
+        planted = [Command("fake.py", 1, self._REG + "New-Item -Path $key -Force | Out-Null")]
+        assert [v for v in lint_commands(planted) if v.rule == "unguarded-new-item-force"]
+
+    def test_test_path_guard_clears_it(self) -> None:
+        planted = [Command(
+            "fake.py", 1,
+            self._REG + "if (-not (Test-Path $key)) { New-Item -Path $key -Force | Out-Null }",
+        )]
+        assert not [v for v in lint_commands(planted) if v.rule == "unguarded-new-item-force"]
+
+    def test_commented_new_item_is_not_flagged(self) -> None:
+        planted = [Command("fake.py", 1, self._REG + "# New-Item -Path $key -Force")]
+        assert not [v for v in lint_commands(planted) if v.rule == "unguarded-new-item-force"]
+
+    def test_filesystem_new_item_is_not_flagged(self) -> None:
+        # On the filesystem provider -Force creates parents; that is the
+        # documented behaviour and not destructive of unrelated state.
+        planted = [Command(
+            "fake.py", 1, r'New-Item -Path "$env:TEMP\apotrope" -ItemType Directory -Force',
+        )]
+        assert not [v for v in lint_commands(planted) if v.rule == "unguarded-new-item-force"]
+
+    def test_every_shipped_registry_create_is_guarded(self) -> None:
+        # The real inventory, not a planted case: this is what would have caught
+        # the AutoPlay block before it shipped.
+        violations = [
+            v for v in lint_commands(collect_commands())
+            if v.rule == "unguarded-new-item-force"
+        ]
+        assert not violations, [f"{v.module}:{v.line}" for v in violations]

--- a/tools/command_audit.py
+++ b/tools/command_audit.py
@@ -176,9 +176,41 @@ _ANGLE_PLACEHOLDER = re.compile(r"(?<!\?)<[A-Za-z_][\w -]*>")
 # Destructive / unattended-impact commands that must never ship as copy-paste:
 # a TPM clear can invalidate BitLocker protectors; a bare Restart-Computer can
 # reboot the machine the moment the block is pasted. Reboots belong in comments.
+#
+# IGNORECASE is load-bearing, not tidiness: PowerShell resolves cmdlet names
+# case-insensitively, so `restart-computer -Force` runs exactly as
+# `Restart-Computer -Force` does while slipping past a case-sensitive rule.
 _DESTRUCTIVE = re.compile(
-    r"\b(Clear-Tpm|Restart-Computer|Stop-Computer)\b|-AllowClear\b|-AllowPhysicalPresence\b"
+    r"""
+    \b(?:
+        Clear-Tpm                    # wipes the TPM; invalidates BitLocker protectors
+      | Restart-Computer             # immediate unattended reboot
+      | Stop-Computer                # immediate unattended shutdown
+      | Disable-BitLocker            # decrypts the volume
+      | Clear-Disk | Format-Volume   # destroys a volume
+      | Remove-Partition
+      | Reset-ComputerMachinePassword
+    )\b
+  | -AllowClear\b | -AllowPhysicalPresence\b
+  | \bshutdown(?:\.exe)?\b[^\n]*\s[/-][rsg]\b   # shutdown /r, /s, /g
+  | \bInstall-WindowsUpdate\b[^\n]*-AutoReboot\b
+    """,
+    re.IGNORECASE | re.VERBOSE,
 )
+
+# `New-Item -Force` on the REGISTRY provider replaces an existing key: it deletes
+# every value and subkey beneath it. That is harmless for a key we know is
+# absent and destructive for a shared policy container — ...\Policies\Explorer
+# carries NoRecentDocsHistory, NoActiveDesktop and friends alongside the value
+# being set. `Set-ItemProperty -Force` cannot create a missing key, so the
+# New-Item is legitimate; it just has to be guarded by a Test-Path.
+#
+# Filesystem New-Item is NOT flagged — there `-Force` creates parents and
+# overwrites a file, which is the documented, expected behaviour. The registry
+# gate below keys off the hive reference in the surrounding command.
+_NEW_ITEM_FORCE = re.compile(r"\bNew-Item\b[^\n]*?-Force\b", re.IGNORECASE)
+_TEST_PATH_GUARD = re.compile(r"^\s*if\s*\(\s*-not\s*\(\s*Test-Path\b", re.IGNORECASE)
+_REGISTRY_HIVE = re.compile(r"\b(?:HKLM|HKCU|HKCR|HKU|HKCC)\s*:|Registry::|\bHKEY_", re.IGNORECASE)
 # -DisplayGroup selects an EXISTING firewall rule by its resolved MUI string
 # ('Remote Desktop' is @FirewallAPI.dll,-28752 rendered in the display
 # language), so it matches nothing on non-English Windows and the cmdlet
@@ -238,10 +270,21 @@ def lint_commands(commands: list[Command]) -> list[Violation]:
         if _DESTRUCTIVE.search(active):
             violations.append(Violation(
                 cmd.module, cmd.line, "destructive-command",
-                "destructive/unattended command (TPM clear or bare reboot) must be a "
-                "commented manual step, not copy-paste",
+                "destructive/unattended command (TPM clear, reboot, shutdown, volume "
+                "or BitLocker teardown) must be a commented manual step, not copy-paste",
                 text,
             ))
+        if _REGISTRY_HIVE.search(active):
+            for line in _uncommented_lines(text):
+                if _NEW_ITEM_FORCE.search(line) and not _TEST_PATH_GUARD.match(line):
+                    violations.append(Violation(
+                        cmd.module, cmd.line, "unguarded-new-item-force",
+                        "New-Item -Force on a registry key REPLACES it, deleting every "
+                        "value and subkey under it. Guard the create with "
+                        "`if (-not (Test-Path <key>)) { New-Item ... }`",
+                        text,
+                    ))
+                    break
         if _LOCALIZED_FW_SELECTOR.search(active):
             violations.append(Violation(
                 cmd.module, cmd.line, "localized-firewall-selector",


### PR DESCRIPTION
Two gaps in the remediation-command lint, plus the four shipped commands the new rule catches.

## The destructive rule was case-sensitive

PowerShell resolves cmdlet names case-insensitively, so `restart-computer -Force` reboots exactly as `Restart-Computer -Force` does — while slipping past a case-sensitive denylist. `re.IGNORECASE` here is load-bearing, not tidiness.

It also only listed the two spellings that happened to ship. It now covers the class:

| added | why |
|---|---|
| `shutdown.exe` with `/r`, `/s`, `/g` | the non-cmdlet spelling of the same reboot |
| `Disable-BitLocker` | decrypts the volume |
| `Format-Volume`, `Clear-Disk`, `Remove-Partition` | destroys a volume |
| `Reset-ComputerMachinePassword` | breaks the domain trust |
| `Install-WindowsUpdate -AutoReboot` | unattended reboot by flag |

## New rule: `unguarded-new-item-force`

On the **registry** provider, `New-Item -Force` *replaces* an existing key — deleting every value and subkey beneath it. Harmless for a key known to be absent; destructive for a shared policy container. `Set-ItemProperty -Force` cannot create a missing key, so the `New-Item` is legitimate — it just has to be guarded.

Scoped to registry paths only. On the filesystem provider `-Force` creates parents and overwrites a file, which is documented behaviour and not destructive of unrelated state, so flagging it would be a false positive.

**The rule fires on four commands that shipped before it, all fixed here:**

| module | key it was replacing |
|---|---|
| `network.py` | the DNSClient policy key (LLMNR) |
| `powershell.py` ×3 | script-block logging, module logging, and its `ModuleNames` subkey |

Each now creates the key only when absent. `misc.py`'s AutoPlay block was already guarded.

## Precision is tested as hard as recall

A rule that fires on a safe command gets silenced, and then protects nothing. Both rules are asserted *not* to fire on `Set-NetFirewallProfile`, `Restart-Service` (a service, not the computer), `Get-Tpm`, `net accounts`, `Update-MpSignature`, a commented reboot, a commented `New-Item`, and a filesystem `New-Item -Force`.

Regression-verified rather than asserted: unguarding `network.py` makes both the planted case and the whole-inventory test fail.

## Tests

1019 pass, 98.90% coverage. `ruff` and `mypy` clean at the pinned versions. `tools/verify_commands.py` 44/44 on real Windows, so every rewritten command still parses and every cmdlet still resolves.
