### PR TITLE
Stop account remediations costing the operator their own access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `BackupToAAD-BitLockerKeyProtector` steps for domain- and Entra-joined hosts.
   A new `bitlocker-no-key-escrow` lint rule keeps it from regressing.
 
+- **Account remediations no longer risk the operator's own access.** Disabling
+  the built-in Administrator shipped as an active line — and that finding fires
+  precisely when RID-500 is *enabled*, which on a standalone or freshly imaged
+  host is often because it is the account in use. It also renamed first, so the
+  account could not afterwards be found by name, and hardcoded `RenamedAdmin`,
+  which gives up the only thing renaming buys you. The rename now takes a name
+  the operator chooses, the block lists every administrator and whether each is
+  enabled, and the disable is commented behind that check. Likewise the
+  "too many administrators" remediation shipped an active
+  `Remove-LocalGroupMember` against a fabricated `CORP\svc_backup`; it is now
+  commented, preceded by `whoami`, and no longer presents an invented account as
+  though it were real.
+
+- **The Spectre/Meltdown remediation no longer hides a failed write.**
+  `-ErrorAction SilentlyContinue` on `Remove-ItemProperty` meant an ACL-protected
+  key — or a GPO Preference re-creating the values — produced output identical to
+  success. It now tests for each value, removes only what is present, reports
+  what it did, and lets a real failure surface.
+
 - **Remediations that could cut the operator's own connection are now commented
   manual steps.** Disabling RDP (`fDenyTSConnections=1`), tearing down the whole
   Remote Desktop firewall group, and stopping or disabling WinRM all shipped as

--- a/src/apotrope/checks/accounts.py
+++ b/src/apotrope/checks/accounts.py
@@ -166,9 +166,29 @@ def _check_builtin_admin() -> list[CheckResult]:
         remediation = (
             "Rename the built-in Administrator account and disable it if it is not in active use."
         )
+        # The disable ships commented. This finding fires precisely when RID-500
+        # is *enabled* — which on a standalone or freshly imaged host is often
+        # because it is the account in use. Disabling it unprompted removes the
+        # operator's own access at next logon and destroys the break-glass
+        # account that exists for the case where every other credential fails.
+        # Renaming first compounds it: they cannot even find it by name after.
         command = (
-            f"Rename-LocalUser -SID '{sid}' -NewName 'RenamedAdmin'\n"
-            f"Disable-LocalUser -SID '{sid}'"
+            "# Pick your own name. A predictable one (RenamedAdmin, Admin1) gives\n"
+            "# up the only thing renaming buys you.\n"
+            f"$sid = '{sid}'\n"
+            "$newName = 'CHANGE-ME'\n"
+            "Rename-LocalUser -SID $sid -NewName $newName\n"
+            "\n"
+            "# Before disabling it, confirm another administrator can still get in.\n"
+            "# This is the break-glass account; on a standalone host it may be the\n"
+            "# one you are logged in with right now.\n"
+            "Get-LocalGroupMember -SID 'S-1-5-32-544' | ForEach-Object {\n"
+            "    $u = Get-LocalUser -SID $_.SID -ErrorAction SilentlyContinue\n"
+            "    [pscustomobject]@{ Name = $_.Name; "
+            "Enabled = if ($u) { $u.Enabled } else { 'n/a (domain or group)' } }\n"
+            "}\n"
+            "# Then, only if the list above shows another enabled administrator:\n"
+            "# Disable-LocalUser -SID $sid"
         )
     elif enabled:
         status, sev = Status.WARN, Severity.LOW
@@ -233,11 +253,15 @@ def _check_admin_count() -> list[CheckResult]:
         ),
         command=(
             "" if not over_threshold else
-            "# List current local administrators\n"
+            "# List current local administrators, and who you are:\n"
             "Get-LocalGroupMember -SID 'S-1-5-32-544'\n"
+            "whoami\n"
             "\n"
-            "# Remove a standing admin (replace with the account to remove)\n"
-            "Remove-LocalGroupMember -SID 'S-1-5-32-544' -Member 'CORP\\svc_backup'"
+            "# Then remove a standing admin. Commented deliberately: the name below\n"
+            "# is a placeholder, not an account on this machine, and pasting this\n"
+            "# with your OWN account substituted removes your administrative access\n"
+            "# at next logon. Check it against the list above first.\n"
+            "# Remove-LocalGroupMember -SID 'S-1-5-32-544' -Member 'DOMAIN\\the-account'"
         ),
     )]
 

--- a/src/apotrope/checks/misc.py
+++ b/src/apotrope/checks/misc.py
@@ -295,8 +295,24 @@ def _check_spectre() -> list[CheckResult]:
                 "registry keys that disable them."
             ),
             command=(
-                f"Remove-ItemProperty -Path '{_SPECTRE_KEY}' "
-                "-Name FeatureSettingsOverride,FeatureSettingsOverrideMask -ErrorAction SilentlyContinue"
+                # -ErrorAction SilentlyContinue on the *removal* was hiding the
+                # only signal there is: an ACL-protected key, or a GPO Preference
+                # re-creating the values, produced output identical to success.
+                # Only one of the two values is commonly present, which is
+                # presumably why it was silenced — so test for each instead, and
+                # let a genuine failure surface.
+                f"$k = '{_SPECTRE_KEY}'\n"
+                "foreach ($n in 'FeatureSettingsOverride','FeatureSettingsOverrideMask') {\n"
+                "    $present = (Get-ItemProperty -LiteralPath $k -Name $n "
+                "-ErrorAction SilentlyContinue).$n\n"
+                "    if ($null -ne $present) {\n"
+                "        Remove-ItemProperty -LiteralPath $k -Name $n\n"
+                "        Write-Host \"removed $n\"\n"
+                "    } else {\n"
+                "        Write-Host \"$n was not set\"\n"
+                "    }\n"
+                "}\n"
+                "# A reboot is required for the mitigations to take effect again."
             ),
         )]
 

--- a/tests/test_checks/test_accounts.py
+++ b/tests/test_checks/test_accounts.py
@@ -366,3 +366,66 @@ class TestRun:
             results = accounts.run()
         assert all(isinstance(r, CheckResult) for r in results)
         assert len(results) >= 6
+
+
+class TestAdminRemediationGuards:
+    """The account remediations must not cost the operator their own access.
+
+    No lint rule covers the rename+disable pairing: accounts.py's Guest branch
+    and the built-in-Administrator branch both reduce to a byte-identical
+    `Disable-LocalUser -SID '{sid}'` once the runtime SID becomes a placeholder,
+    so a rule keyed on Disable-LocalUser would fire on the (safe) Guest control.
+    These assertions cover it at the check level instead.
+    """
+
+    @staticmethod
+    def _active(command: str) -> str:
+        return "\n".join(
+            ln for ln in command.splitlines() if not ln.lstrip().startswith("#")
+        )
+
+    def _builtin_admin_fail(self):
+        # enabled + default name -> the FAIL branch that emits the rename/disable
+        with patch("apotrope.checks.accounts.run_powershell_json",
+                   return_value={"Name": "Administrator", "Enabled": True,
+                                 "SID": "S-1-5-21-1-2-3-500"}):
+            return accounts._check_builtin_admin()[0]
+
+    def test_disable_is_commented_not_active(self):
+        # This finding fires exactly when RID-500 is ENABLED — which on a
+        # standalone host is often because it is the account in use. Disabling it
+        # unprompted removes the operator's access and destroys break-glass.
+        r = self._builtin_admin_fail()
+        assert "Disable-LocalUser" in r.command
+        assert "Disable-LocalUser" not in self._active(r.command)
+
+    def test_rename_does_not_hardcode_a_predictable_name(self):
+        # A name every Apotrope user ends up with gives up the only thing
+        # renaming buys you. Checked against the ACTIVE lines: the comment
+        # naming RenamedAdmin as a *bad* example is exactly what we want kept.
+        r = self._builtin_admin_fail()
+        assert "RenamedAdmin" not in self._active(r.command)
+        assert "-NewName $newName" in self._active(r.command)
+
+    def test_operator_is_told_to_verify_another_admin_first(self):
+        r = self._builtin_admin_fail()
+        assert "Get-LocalGroupMember" in self._active(r.command)
+
+    def _admin_count_warn(self):
+        members = [{"Name": rf"MACHINE\Admin{n}"} for n in range(1, 4)]
+        with patch("apotrope.checks.accounts.run_powershell_json", return_value=members):
+            return accounts._check_admin_count()[0]
+
+    def test_admin_removal_is_commented(self):
+        r = self._admin_count_warn()
+        assert "Remove-LocalGroupMember" in r.command
+        assert "Remove-LocalGroupMember" not in self._active(r.command)
+
+    def test_no_fabricated_principal_is_presented_as_real(self):
+        # Shipping a made-up account name invites pasting it verbatim.
+        r = self._admin_count_warn()
+        assert "svc_backup" not in r.command
+
+    def test_operator_is_shown_who_they_are(self):
+        r = self._admin_count_warn()
+        assert "whoami" in self._active(r.command)

--- a/tests/test_remediation_commands.py
+++ b/tests/test_remediation_commands.py
@@ -374,3 +374,80 @@ class TestDiscardedCimReturnValueRule:
             if v.rule == "discarded-cim-returnvalue"
         ]
         assert not violations, [f"{v.module}:{v.line}" for v in violations]
+
+
+class TestSilencedRegistryMutationRule:
+    """Silencing a write hides the only failure signal there is.
+
+    An ACL-protected key, or a GPO Preference re-creating the values, produces
+    output byte-identical to full success. Silencing a *read* is fine — a guard
+    is supposed to be quiet — so only mutating cmdlets are listed.
+    """
+
+    _K = r"$k = 'HKLM:\SYSTEM\CurrentControlSet\Control\X'" + "\n"
+
+    def _fired(self, text):
+        return [
+            v for v in lint_commands([Command("fake.py", 1, text)])
+            if v.rule == "silenced-registry-mutation"
+        ]
+
+    def test_silenced_removal_is_flagged(self) -> None:
+        assert self._fired(self._K + "Remove-ItemProperty -Path $k -Name Foo -ErrorAction SilentlyContinue")
+
+    def test_ignore_is_flagged_too(self) -> None:
+        # -Ignore is worse: it does not even populate $Error.
+        assert self._fired(self._K + "Set-ItemProperty -Path $k -Name Foo -Value 1 -EA Ignore")
+
+    def test_silenced_read_is_not_flagged(self) -> None:
+        assert not self._fired(
+            self._K + "$v = (Get-ItemProperty -Path $k -Name Foo -ErrorAction SilentlyContinue).Foo"
+        )
+
+    def test_unsilenced_mutation_is_not_flagged(self) -> None:
+        assert not self._fired(self._K + "Remove-ItemProperty -Path $k -Name Foo")
+
+    def test_commented_line_is_not_flagged(self) -> None:
+        assert not self._fired(
+            self._K + "# Remove-ItemProperty -Path $k -Name Foo -ErrorAction SilentlyContinue"
+        )
+
+    def test_no_shipped_command_silences_a_registry_write(self) -> None:
+        violations = [
+            v for v in lint_commands(collect_commands())
+            if v.rule == "silenced-registry-mutation"
+        ]
+        assert not violations, [f"{v.module}:{v.line}" for v in violations]
+
+
+class TestUnguardedAdminRemovalRule:
+    """Removing yourself from Administrators is not undoable from that shell."""
+
+    def _fired(self, text):
+        return [
+            v for v in lint_commands([Command("fake.py", 1, text)])
+            if v.rule == "unguarded-admin-removal"
+        ]
+
+    def test_active_removal_by_sid_is_flagged(self) -> None:
+        assert self._fired("Remove-LocalGroupMember -SID 'S-1-5-32-544' -Member 'X'")
+
+    def test_active_removal_by_group_name_is_flagged(self) -> None:
+        assert self._fired("Remove-LocalGroupMember -Group 'Administrators' -Member 'X'")
+
+    def test_commented_removal_is_not_flagged(self) -> None:
+        assert not self._fired("# Remove-LocalGroupMember -SID 'S-1-5-32-544' -Member 'X'")
+
+    def test_adding_and_other_groups_are_not_flagged(self) -> None:
+        for safe in (
+            "Add-LocalGroupMember -SID 'S-1-5-32-544' -Member 'X'",   # granting, not removing
+            "Remove-LocalGroupMember -Group 'Remote Desktop Users' -Member 'X'",
+        ):
+            assert not self._fired(safe), safe
+
+    def test_no_shipped_command_actively_removes_an_admin(self) -> None:
+        violations = [
+            v for v in lint_commands(collect_commands())
+            if v.rule == "unguarded-admin-removal"
+        ]
+        assert not violations, [f"{v.module}:{v.line}" for v in violations]

--- a/tools/command_audit.py
+++ b/tools/command_audit.py
@@ -257,6 +257,26 @@ _DISCARDED_CIM_RETURN = re.compile(
     re.IGNORECASE,
 )
 
+# Silencing errors on a registry cmdlet that MUTATES destroys the only signal the
+# operator gets: an ACL-protected key, or a GPO Preference re-creating the values,
+# produces output byte-identical to full success. Silencing a *read* is fine and
+# often correct — a guard is supposed to be quiet — so only mutations are listed.
+# -Ignore is strictly worse than SilentlyContinue: it does not even populate
+# $Error, so nothing survives for a later check to find.
+_SILENCED_REGISTRY_MUTATION = re.compile(
+    r"\b(?:Remove|Set|New|Rename|Clear)-Item(?:Property)?\b[^\n]*"
+    r"-(?:ErrorAction|EA)\s+(?:SilentlyContinue|Ignore|0)\b",
+    re.IGNORECASE,
+)
+
+# Removing someone from Administrators is not reversible from a shell you no
+# longer have. The operator substituting their own account into the example is
+# the expected mistake, not an exotic one, so this belongs behind a comment and
+# a "check who you are first" step.
+_ADMIN_GROUP_REMOVAL = re.compile(
+    r"\bRemove-LocalGroupMember\b[^\n]*(?:S-1-5-32-544|Administrators)", re.IGNORECASE
+)
+
 _CREATES_RECOVERY_PASSWORD = re.compile(r"-RecoveryPasswordProtector\b", re.IGNORECASE)
 _SURFACES_RECOVERY_PASSWORD = re.compile(
     r"\bRecoveryPassword\b(?!Protector)"          # reads the property back
@@ -360,7 +380,27 @@ def lint_commands(commands: list[Command]) -> list[Violation]:
                 "or escrow it (Backup-BitLockerKeyProtector / BackupToAAD-...)",
                 text,
             ))
+        if _ADMIN_GROUP_REMOVAL.search(active):
+            violations.append(Violation(
+                cmd.module, cmd.line, "unguarded-admin-removal",
+                "actively removes a member of Administrators. The operator "
+                "substituting their own account is the expected mistake, and it is "
+                "not reversible from a shell they no longer have — ship it commented, "
+                "after a step that shows the current membership and `whoami`",
+                text,
+            ))
         if _REGISTRY_HIVE.search(active):
+            for line in _uncommented_lines(text):
+                if _SILENCED_REGISTRY_MUTATION.search(line):
+                    violations.append(Violation(
+                        cmd.module, cmd.line, "silenced-registry-mutation",
+                        "silences errors on a registry cmdlet that mutates state, so a "
+                        "denied or re-created value produces output identical to "
+                        "success. Silencing a read is fine; test the value and report "
+                        "instead of hiding the write's only failure signal",
+                        text,
+                    ))
+                    break
             for line in _uncommented_lines(text):
                 if _NEW_ITEM_FORCE.search(line) and not _TEST_PATH_GUARD.match(line):
                     violations.append(Violation(


### PR DESCRIPTION
The four remaining audit findings — the last of the 44-command sweep. Each verified before being acted on.

## 1. The built-in Administrator disable was an active line

This finding fires **precisely when RID-500 is enabled** — which on a standalone or freshly imaged host is often because it *is* the account in use. Disabling it unprompted removes the operator's access at next logon and destroys the break-glass account that exists for the case where every other credential has failed.

Renaming first compounds it: they cannot even find it by name afterwards.

**Now:** the rename takes a name the operator chooses, the block lists every member of Administrators with whether each is enabled, and the disable is commented behind that check.

## 2. The admin-removal line was active, against a placeholder account

```powershell
Remove-LocalGroupMember -SID 'S-1-5-32-544' -Member 'CORP\svc_backup'
```

Live, under a comment reading *"replace with the account to remove"*. The expected mistake is substituting your own account — and that is not reversible from a shell you no longer have. `CORP\svc_backup` was intended as a placeholder, but presented as though it were real.

**Now:** commented, preceded by `whoami`, and the invented principal is gone.

## 3. The Spectre remediation silenced its own write

`-ErrorAction SilentlyContinue` on `Remove-ItemProperty` meant an ACL-protected key — or a GPO Preference re-creating the values — produced output identical to full success.

Only one of the two values is commonly present, which is presumably *why* it was silenced. So the fix tests for each, removes what is there, reports what it did, and lets a genuine failure surface.

## Two new lint rules

- **`silenced-registry-mutation`** — mutating cmdlets only. A silenced *read* is a guard and correctly stays quiet; flagging it would fire on every `Get-ItemProperty ... -ErrorAction SilentlyContinue` in the tree.
- **`unguarded-admin-removal`** — scoped to the Administrators group. Adding a member, and removing from any other group, are not flagged.

## One rule I deliberately did not write

The rename+disable pairing has no lint rule. `accounts.py`'s Guest branch and the built-in-Administrator branch both reduce to a byte-identical `Disable-LocalUser -SID '{sid}'` once the runtime SID becomes a placeholder — so a rule keyed on that cmdlet would fire on the safe Guest control, get silenced, and protect nothing. Covered by check-level assertions on the *active* lines instead.

## Portability

Both rewritten commands parse under **Windows PowerShell 5.1** (`5.1.26100.8894`) as well as 7.6.3 — checked directly, since an `if` expression inside a hashtable literal is not obviously portable.

## Tests

1058 pass, 98.90% coverage. `ruff` and `mypy` clean at the pinned versions. `tools/verify_commands.py` 44/44 on real Windows. Also fixed a `W605` invalid escape my own new test introduced — caught by the gate before merge.

With this, all 14 confirmed findings from the audit of all 44 shipped remediation commands are closed.
