### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [Unreleased]
+## [0.2.0] - 2026-07-27
 
 ### Security
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apotrope"
-version = "0.1.12"
+version = "0.2.0"
 description = "A portable Windows security posture auditor"
 readme = "README.md"
 license = "MIT"

--- a/src/apotrope/__init__.py
+++ b/src/apotrope/__init__.py
@@ -1,4 +1,4 @@
 """Apotrope — Windows Security Posture Auditor."""
 
-__version__ = "0.1.12"
+__version__ = "0.2.0"
 __all__ = ["__version__"]


### PR DESCRIPTION
Cuts **v0.2.0**. Three files: both version sources and the CHANGELOG heading.

## Why minor, not patch

Two documented contracts change in ways that can alter what a calling script does:

- **Exit 2 now also means** zero controls evaluated, a check errored, or a requested output file could not be written. Previously it meant only "fatal scan error" — so a wrapper treating 2 as a crash will now see it on healthy runs that merely could not be trusted.
- **`--profile` fails closed.** An explicitly requested profile that is missing or unparseable now exits 2. A script pointing at a typo'd path used to scan anyway, with a different check set than the operator asked for.

A patch bump would understate both.

## What's in it

22 entries, but the headline is security, and it's worth stating plainly rather than burying. **v0.1.12 and earlier shipped copy-paste remediation that could:**

- wipe a TPM (`Initialize-Tpm -AllowClear`), invalidating BitLocker protectors
- reboot the machine unattended, from a pasted block
- sever the operator's own RDP or WinRM session, on a headless host with no way back
- **enable BitLocker while never showing the recovery password** — leaving a volume nobody could open after the next firmware change

All fixed. 15 lint rules over the full 44-command inventory keep them fixed, and they apply to check modules that don't exist yet.

Alongside that: password policy now evaluates on non-elevated scans, security principals are identified by SID rather than localized display name, checks fail closed on uncertainty instead of guessing PASS, `ruff` and `mypy` are enforced gates at pinned versions, publishing is gated on tag-vs-version plus a wheel smoke test, and dependency floors sit at advisory-patched versions.

## Verified before tagging

- `tests/test_version.py` — version consistent across `pyproject.toml` and `__init__.py`
- **1058 tests**, 98.90% coverage
- `ruff` 0.16.0 and `mypy` 1.19.1 clean
- **The built wheel installs into a clean environment**, reports `0.2.0`, exposes all 14 check modules, and `apotrope --version` prints `apotrope 0.2.0` — the same probe #96 made a required gate ahead of the OIDC publish

## After merging

Tag `v0.2.0` on `main` to trigger `release.yml`. The publish workflow will re-check tag-vs-version and re-run the wheel smoke test before anything reaches PyPI, so a mismatch fails closed rather than shipping.

