### PR TITLE
Put CRLF on the clipboard so multi-line remediation pastes in order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Security
 
+- **The report's ⧉ Copy button now puts CRLF on the clipboard, and can report a
+  failed copy.** Multi-line remediation pasted into an elevated PowerShell window
+  executed **in reverse order** — last line first — which for the LLMNR command
+  meant the `$key` assignment ran last and the two lines depending on it failed.
+  The cause was the line endings: the HTML parser normalises CRLF to bare LF
+  inside attribute values, so `getAttribute('data-cmd')` handed the script
+  LF-only text no matter what the file contained, and Windows clipboard text is
+  conventionally CRLF. Confirmed by controlled A/B on Windows Terminal 1.24 with
+  pwsh 7.6 / PSReadLine 2.4: the same three lines pasted 3-2-1 as LF and 1-2-3 as
+  CRLF, while Notepad accepted either form correctly — so the clipboard content
+  was never wrong, only its line endings. The button also announced `✓ Copied`
+  unconditionally, with no fallback when `navigator.clipboard` is unavailable
+  (these reports are built to be emailed and opened over `file://`, where it is
+  not guaranteed) and no handler for a rejected write. It now falls back to
+  `execCommand` and shows a distinct failure state, so a failed copy can never
+  again be mistaken for a good one.
+
+
 - **The BitLocker remediation now hands the operator the recovery password.**
   Both commands created a recovery-password protector and never showed the
   48-digit key. `Enable-BitLocker` and `Add-BitLockerKeyProtector` return a

--- a/src/apotrope/templates/report.html.j2
+++ b/src/apotrope/templates/report.html.j2
@@ -400,6 +400,7 @@
                 border-radius:2px; background:rgba(68,224,230,0.06); cursor:pointer; transition:all .12s; }
   .code .copy:hover { color:var(--void); background:var(--cyan); border-color:var(--cyan); }
   .code .copy.done { color:var(--void); background:var(--green); border-color:var(--green); }
+  .code .copy.failed { color:var(--void); background:var(--red); border-color:var(--red); }
   .code-cmd { font-family:var(--mono); font-size:12.5px; line-height:1.7;
               white-space:pre-wrap; word-break:break-word; padding:12px 14px; margin:0; }
   .code-cmd .cl-c { color:var(--muted); }                 /* # comment lines       */
@@ -771,17 +772,62 @@
     rows.forEach(function(r){ r.querySelector('.fbody').setAttribute('hidden',''); r.querySelector('.fhead').classList.remove('is-open'); });
   });
 
+  // Windows clipboard text is CRLF by convention. The HTML parser normalises
+  // CRLF to bare LF inside attribute values, so data-cmd reaches this script as
+  // LF-only no matter what the file on disk contains — and pasting LF-only text
+  // into a Windows console reorders it. Reproduced on Windows Terminal 1.24 with
+  // pwsh 7.6 / PSReadLine 2.4: a three-line block pasted as line 3, 2, 1, while
+  // the identical text normalised to CRLF pasted in the correct order. Notepad
+  // took either form correctly, so the clipboard content was never the problem —
+  // only its line endings.
+  function toCrlf(s){ return s.replace(/\r\n/g, '\n').replace(/\n/g, '\r\n'); }
+
+  // Fallback for when navigator.clipboard is unavailable. These reports are
+  // built to be saved and emailed, so they are usually opened over file://,
+  // where the async clipboard API is not guaranteed to exist.
+  function legacyCopy(text){
+    var ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    ta.style.position = 'fixed';
+    ta.style.top = '-1000px';
+    document.body.appendChild(ta);
+    ta.select();
+    var ok = false;
+    try { ok = document.execCommand('copy'); } catch (e) { ok = false; }
+    document.body.removeChild(ta);
+    return ok;
+  }
+
   document.querySelectorAll('.code .copy').forEach(function(btn){
     btn.addEventListener('click', function(e){
       e.stopPropagation();
       // Copy the RAW command from data-cmd. The rendered lines carry a
       // non-selectable "PS>" prompt that must never reach the clipboard.
       var box = btn.closest('.code');
-      var code = box ? (box.getAttribute('data-cmd') || '') : '';
-      if (navigator.clipboard) navigator.clipboard.writeText(code);
-      btn.classList.add('done');
-      var t = btn.textContent; btn.textContent = '✓ Copied';
-      setTimeout(function(){ btn.textContent = t; btn.classList.remove('done'); }, 1400);
+      var code = toCrlf(box ? (box.getAttribute('data-cmd') || '') : '');
+      var label = btn.textContent;
+
+      // Report the real outcome. Announcing success unconditionally makes a
+      // failed copy indistinguishable from a good one, and the operator then
+      // pastes whatever the clipboard held before.
+      function settle(ok){
+        btn.classList.add(ok ? 'done' : 'failed');
+        btn.textContent = ok ? '✓ Copied' : '⚠ Copy failed — select the text';
+        setTimeout(function(){
+          btn.textContent = label;
+          btn.classList.remove('done', 'failed');
+        }, ok ? 1400 : 2600);
+      }
+
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(code).then(
+          function(){ settle(true); },
+          function(){ settle(legacyCopy(code)); }
+        );
+      } else {
+        settle(legacyCopy(code));
+      }
     });
   });
 

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -326,6 +326,39 @@ class TestGenerateHtmlReport:
             assert "PS&gt;" not in raw
             assert "<span" not in raw
 
+    def test_copy_handler_normalises_line_endings_to_crlf(self):
+        """The clipboard payload must carry CRLF, not bare LF.
+
+        The HTML parser normalises CRLF to LF inside attribute values, so
+        ``getAttribute('data-cmd')`` hands the script LF-only text regardless of
+        the file's own line endings. Pasting LF-only text into a Windows console
+        reorders it: reproduced on Windows Terminal 1.24 with pwsh 7.6 /
+        PSReadLine 2.4, where a three-line block pasted as line 3, 2, 1 while the
+        same text normalised to CRLF pasted correctly. Notepad accepted either
+        form in the right order, so the content was never wrong -- only the line
+        endings.
+        """
+        html = self._generate(_make_report())
+        assert "function toCrlf" in html, "the CRLF normaliser is gone"
+        # and it must actually be applied to the value that reaches the clipboard
+        assert "toCrlf(box ? (box.getAttribute('data-cmd')" in html, (
+            "data-cmd is being copied without CRLF normalisation"
+        )
+
+    def test_copy_handler_can_report_failure(self):
+        """A failed copy must not look identical to a successful one.
+
+        Announcing success unconditionally leaves the operator pasting whatever
+        the clipboard held before, with no signal that anything went wrong -- and
+        makes the next copy bug undiagnosable. These reports are built to be
+        saved and emailed, so they are usually opened over ``file://`` where the
+        async clipboard API is not guaranteed to exist.
+        """
+        html = self._generate(_make_report())
+        assert "Copy failed" in html, "no failure state on the copy button"
+        assert "document.execCommand('copy')" in html, "no fallback copy path"
+        assert ".code .copy.failed" in html, "no styling for the failure state"
+
     def test_share_warning_rendered_in_footer(self):
         """The footer warns that the report embeds machine-identifying detail."""
         html = self._generate(_make_report())


### PR DESCRIPTION
Multi-line remediation copied from the technical report with the ⧉ button and right-click-pasted into an elevated PowerShell 7 window executed **in reverse order**. For the LLMNR command that meant the `$key` assignment ran last, and the two lines depending on it failed against an empty path.

## The cause is the line endings, and it is ours

The HTML parser normalises CRLF to bare LF inside attribute values, so `getAttribute('data-cmd')` hands the script **LF-only** text regardless of what the file on disk contains. Windows clipboard text is conventionally **CRLF**.

Established by controlled A/B on Windows Terminal 1.24 / pwsh 7.6.3 / PSReadLine 2.4.5, one variable changed:

| clipboard payload | paste result |
|---|---|
| LF-only (current behaviour) | **3, 2, 1** |
| CRLF (same text, normalised) | **1, 2, 3** |
| either form → Notepad | correct order |

So the clipboard *content* was never wrong. Only its line endings were.

This also explains why only multi-line commands were ever affected — single-line commands contain no newline to mishandle.

## A second, independent defect in the same handler

```js
if (navigator.clipboard) navigator.clipboard.writeText(code);
btn.textContent = '✓ Copied';        // outside the if, runs unconditionally
```

No `else`, no `.catch()` on the returned Promise, success UI outside the guard. A failed copy was indistinguishable from a good one.

That is **not** what caused the reversal — but it would have made the next copy problem undiagnosable, and these reports are built to be saved and emailed, so they are usually opened over `file://` where the async clipboard API is not guaranteed to exist. It now falls back to `execCommand` and shows a distinct failure state.

## What this deliberately does not do

The three flat `$key … New-Item … Set-ItemProperty` commands are unchanged. Rewriting working commands to defend against a mechanism just eliminated at its source is churn, and the evidence points at line endings rather than command shape. If a reorder is ever observed again with CRLF in place, that is the evidence that would justify collapsing them into a `;`-chained one-liner — and not before.

## Guards

Two tests. The normaliser must exist **and** be applied to the value that reaches the clipboard — verified by dropping `toCrlf(...)` from the copy path and watching the test fail. The handler must retain both a fallback and a failure state.

The normaliser is idempotent across LF, CRLF, mixed and newline-free input.

## Tests

1060 pass, 98.90% coverage. `ruff` and `mypy` clean at the pinned versions.

