### PR TITLE
ci: pin workflow actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+# Every workflow `uses:` is pinned to a commit SHA (enforced by
+# tests/test_workflow_security.py). Pinning stops a repointed upstream tag from
+# silently changing what CI runs — but it also stops upstream *fixes* arriving on
+# their own. This updater is the other half of that trade: it opens a PR per bump,
+# rewriting both the SHA and its trailing `# vX.Y.Z` comment, so updates become
+# visible and reviewed rather than silent and automatic.
+#
+# Deliberately no `pip` ecosystem entry. pyproject.toml pins ruff and mypy exactly,
+# with a written requirement that either bump land in its own PR that absorbs the
+# resulting rule-set delta — a weekly updater would fight that.
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     if: github.event.comment.author_association == 'OWNER'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,10 +18,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -53,7 +53,7 @@ jobs:
           python -m twine check dist/*
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist
           path: dist/
@@ -66,13 +66,13 @@ jobs:
       contents: read
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist
           path: dist/
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -128,13 +128,13 @@ jobs:
       id-token: write  # required for OIDC trusted publishing
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           # PEP 740 attestations are already the default for Trusted
           # Publishing, but pin it explicitly: PyPI provenance is part of our

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,10 @@ jobs:
       id-token: write      # OIDC identity used to Sigstore-sign the attestation
       attestations: write  # persist the attestation to the repo's store
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -100,7 +100,7 @@ jobs:
 
       - name: Attest build provenance
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           # Attest the checksums file too, so it has the same trust anchor as
           # the exe rather than only the release page it ships from.
@@ -109,7 +109,7 @@ jobs:
             dist/SHA256SUMS
 
       - name: Upload workflow artifact (dry-run inspection)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: apotrope-release
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,10 +30,10 @@ jobs:
         python-version: ["3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -58,10 +58,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -86,7 +86,7 @@ jobs:
         run: python tools/verify_commands.py
 
       - name: Upload exe artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: apotrope-exe
           path: dist/apotrope.exe

--- a/tests/test_workflow_security.py
+++ b/tests/test_workflow_security.py
@@ -1,0 +1,219 @@
+"""Guard: every external GitHub Action this repo runs must be pinned to a commit SHA.
+
+A Git tag is a mutable pointer, not a version. ``actions/checkout@v4`` resolves to
+whatever commit ``v4`` names *at the moment the job starts*, and the upstream owner can
+repoint it at any time — every consumer picks that up on the next run with no diff and
+no review. That is how the ``tj-actions/changed-files`` compromise propagated in March
+2025. A 40-character SHA is the only ref form that commits to *content* rather than to
+a name.
+
+The stakes are not uniform across these four files. ``publish.yml``'s final job holds
+``id-token: write`` for PyPI trusted publishing, so code running there can mint a fresh
+OIDC identity and publish as apotrope without stealing any stored secret.
+``release.yml`` holds ``attestations: write`` — a compromise there ships a bad artifact
+carrying *valid* provenance, which is worse than shipping none.
+
+Scanning is regex over lines, deliberately, and not a YAML parse: PyYAML is not a
+declared dependency, and ``pyproject.toml``'s dev extras carry an explicit argument for
+keeping that set tight and exactly pinned. A workflow lint is not what should spend
+that budget.
+
+Two bounds of the line-based approach, recorded rather than left implicit:
+
+* A line *inside* a ``run: |`` block that exactly matches the anchored ``uses:`` shape
+  below would be a false positive. No workflow contains one, and it would fail loudly
+  and legibly if one were ever added — cheaper than the indentation tracking a real
+  block-scalar parse needs.
+* Commented lines are skipped, the same view ``_uncommented_lines()`` in
+  ``tools/command_audit.py`` takes, because a commented ref executes nothing. Note the
+  direction of that convention: the defect recorded in issue #108 was an assertion that
+  read *dead* lines as though they were live — a false negative about real code.
+  Skipping comments here applies that principle rather than contradicting it.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW_DIR = ROOT / ".github" / "workflows"
+
+# A floor, not an exact count: adding a step must not require editing this number, but
+# a scanner that silently stops matching must not be able to pass by finding nothing.
+MIN_EXPECTED_REFS = 18
+
+# Anchored to the structural shape of a YAML key rather than searching for the substring
+# "uses:" anywhere on the line. That anchoring is what keeps a `uses:` mentioned inside
+# a run: block or a prose comment from registering as configuration.
+#
+# The mandatory whitespace before "#" is YAML's own rule for an inline comment, so
+# `foo@abcdef#v1` is correctly read as one scalar with no comment rather than as a ref
+# plus a version.
+_USES = re.compile(r"^\s*(?:-\s+)?uses:\s*(?P<ref>\S+)(?:\s+#\s*(?P<comment>.*?))?\s*$")
+
+_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+# Dependabot and Renovate both write and rewrite this comment when they bump a pin. It
+# is the machine contract that keeps future diffs readable — without it a version bump
+# is two indistinguishable hex strings.
+_VERSION_COMMENT = re.compile(r"^v\d")
+
+# Refs that name something other than a mutable upstream tag: a local action in this
+# repo, or a container image resolved by the registry rather than by Git.
+_UNPINNABLE_PREFIXES = ("./", "docker://")
+
+
+@dataclass(frozen=True)
+class ActionRef:
+    """One `uses:` reference, located well enough to fix without searching."""
+
+    path: str
+    line: int
+    ref: str
+    comment: str | None
+
+
+def _collect_refs(text: str, path: str) -> list[ActionRef]:
+    """Extract every executing `uses:` reference from *text*."""
+    refs: list[ActionRef] = []
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        if raw.lstrip().startswith("#"):
+            continue
+        match = _USES.match(raw)
+        if match is None:
+            continue
+        refs.append(ActionRef(
+            path=path,
+            line=lineno,
+            ref=match.group("ref").strip("\"'"),
+            comment=match.group("comment"),
+        ))
+    return refs
+
+
+def _violation(ref: ActionRef) -> str | None:
+    """Return why *ref* is unacceptable, or None if it is correctly pinned."""
+    if ref.ref.startswith(_UNPINNABLE_PREFIXES):
+        return None
+
+    _, sep, rev = ref.ref.partition("@")
+    if not sep:
+        return "no ref at all — expected owner/repo@<40-character commit SHA>"
+    if not _SHA.match(rev):
+        return f"moving ref {rev!r} — expected a 40-character lowercase commit SHA"
+    if ref.comment is None or not _VERSION_COMMENT.match(ref.comment):
+        return "pinned, but missing the trailing '# vX.Y.Z' comment that keeps the diff readable"
+    return None
+
+
+def _workflow_files() -> list[Path]:
+    return sorted(p for pattern in ("*.yml", "*.yaml") for p in WORKFLOW_DIR.glob(pattern))
+
+
+def _all_refs() -> list[ActionRef]:
+    return [
+        ref
+        for path in _workflow_files()
+        for ref in _collect_refs(
+            path.read_text(encoding="utf-8"),
+            path.relative_to(ROOT).as_posix(),
+        )
+    ]
+
+
+def test_all_external_actions_are_sha_pinned() -> None:
+    """No workflow may reference an external action by anything but a commit SHA."""
+    problems = [(ref, why) for ref in _all_refs() if (why := _violation(ref)) is not None]
+    if problems:
+        report = "\n".join(
+            f"  {ref.path}:{ref.line} — {why}\n      {ref.ref}"
+            for ref, why in problems
+        )
+        raise AssertionError(
+            f"{len(problems)} workflow action reference(s) not pinned to a commit SHA:\n{report}\n\n"
+            "Resolve the tag with `gh api repos/<owner>/<repo>/commits/<tag> --jq .sha` "
+            "and pin it as `owner/repo@<sha> # <tag>`."
+        )
+
+
+def test_scanner_finds_the_full_inventory() -> None:
+    """The scanner must extract every ref, or the guard above passes vacuously.
+
+    Zero refs found reads identically to zero violations. This repo has shipped that
+    exact failure twice: the ``_mock_name`` probe in ``test_hermeticity.py`` that passed
+    whether or not the guard was installed, and the substring assertions recorded in
+    issue #108, which matched a commented line as happily as an active one and let
+    session-severing commands through roughly a thousand tests for seven weeks.
+    """
+    files = _workflow_files()
+    assert files, f"no workflow files found under {WORKFLOW_DIR} — has the layout moved?"
+
+    refs = _all_refs()
+    assert len(refs) >= MIN_EXPECTED_REFS, (
+        f"expected at least {MIN_EXPECTED_REFS} action references across {len(files)} "
+        f"workflow file(s), extracted only {len(refs)} — did the _USES pattern stop matching?"
+    )
+
+
+# (workflow line, is it expected to be reported as a violation)
+_PLANTED_LINES: tuple[tuple[str, bool], ...] = (
+    # Correctly pinned, in both the "- uses:" and bare "uses:" positions.
+    ("      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0", False),
+    ("        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0", False),
+    # Quoted, but still pinned — the quotes are YAML syntax, not part of the ref.
+    ('      - uses: "actions/checkout@11d5960a326750d5838078e36cf38b85af677262" # v4.4.0', False),
+    # Not pinnable by SHA, and not expected to be.
+    ("      - uses: ./.github/actions/local-thing", False),
+    ("      - uses: docker://alpine:3.19", False),
+    # Moving refs — the whole point of the guard. A branch ref is the weakest of these.
+    ("      - uses: actions/checkout@v4", True),
+    ("      - uses: pypa/gh-action-pypi-publish@release/v1", True),
+    ("      - uses: actions/checkout@main", True),
+    # 39 hex: a truncated paste is the realistic way a SHA pin goes wrong.
+    ("      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af67726 # v4.4.0", True),
+    # Uppercase hex resolves fine in Git, but is not the form Dependabot reads or writes.
+    ("      - uses: actions/checkout@11D5960A326750D5838078E36CF38B85AF677262 # v4.4.0", True),
+    # Pinned but unreadable: no version comment at all, and a non-version comment.
+    ("      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262", True),
+    ("      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # latest", True),
+    # No ref whatsoever.
+    ("      - uses: actions/checkout", True),
+)
+
+# Lines that must not register as configuration at all.
+_IGNORED_LINES: tuple[str, ...] = (
+    "# - uses: actions/cache@v4",
+    "      # - uses: actions/cache@v4",
+    "      # Historically this step used actions/checkout@v2.",
+    "      - name: Run tests",
+    "        run: pytest tests/ -q",
+    "          echo 'the upstream docs say uses: foo/bar@v1'",
+)
+
+
+@pytest.mark.parametrize(("line", "expected_violation"), _PLANTED_LINES)
+def test_scanner_verdict_on_planted_lines(line: str, expected_violation: bool) -> None:
+    """The detector must fire on planted defects, independent of the tree being clean.
+
+    ``test_all_external_actions_are_sha_pinned`` passing proves the workflows are clean
+    *if* the detector works. These planted lines are what prove the second half.
+    """
+    refs = _collect_refs(line, "planted.yml")
+    assert len(refs) == 1, f"expected exactly one ref parsed from {line!r}, got {len(refs)}"
+
+    why = _violation(refs[0])
+    assert (why is not None) is expected_violation, (
+        f"{line!r} was {'not ' if why is None else ''}reported "
+        f"but should have been {'reported' if expected_violation else 'accepted'}"
+        + (f" — {why}" if why else "")
+    )
+
+
+@pytest.mark.parametrize("line", _IGNORED_LINES)
+def test_scanner_ignores_non_configuration_lines(line: str) -> None:
+    """Commented refs and prose must not register — only what actually executes does."""
+    assert _collect_refs(line, "planted.yml") == []


### PR DESCRIPTION
Closes the first deferred item of #108 ("Pin workflow `uses:` to full commit SHAs", deferred in #96). The issue stays open for its other items.

## Why

A Git tag is a mutable pointer, not a version. `actions/checkout@v4` resolves to whatever commit `v4` names *at the moment the job starts*, and the upstream owner can repoint it at any time — every consumer picks that up with no diff and no review. That is how the `tj-actions/changed-files` compromise propagated in March 2025.

The exposure here is not uniform:

- **`publish.yml`** — the final job holds `id-token: write` for PyPI trusted publishing. Code running there can mint a fresh OIDC identity and publish as apotrope without stealing any stored secret.
- **`release.yml`** — holds `attestations: write`. A compromise there ships a bad artifact carrying *valid* provenance, which is worse than shipping none.
- **`claude.yml`** — four write scopes.
- **`test.yml`** — `contents: read`, low stakes.

This repo already had two of the three controls on a workflow: **who may trigger it** (`claude.yml`'s OWNER guard) and **what it may do** (`release.yml`'s `permissions: {}` default plus per-job grants). Missing was the third — **provenance of the code that arrives**. A repointed tag runs with every granted permission no matter how tight the trigger is.

## This change is inert at merge time

Every SHA was resolved through the GitHub API and compared against what its floating ref resolves to **today**:

| Action | Was | Pinned to | Drift |
|---|---|---|---|
| `actions/checkout` | `v4` | `11d5960…` (v4.4.0) | none |
| `anthropics/claude-code-action` | `v1` | `be7b93b…` (v1.0.183) | none |
| `actions/setup-python` | `v5` | `a26af69…` (v5.6.0) | none |
| `actions/upload-artifact` | `v4` | `ea165f8…` (v4.6.2) | none |
| `actions/download-artifact` | `v4` | `d3f86a1…` (v4.3.0) | none |
| `pypa/gh-action-pypi-publish` | `release/v1` (a **branch**) | `dc37677…` (v1.14.2) | none |
| `actions/attest-build-provenance` | `v4` | `0f67c3f…` (v4.1.1) | none |

All seven already resolve to the exact commits being pinned. Nothing about what CI runs changes — only what is *guaranteed* to run. 18 lines changed, 18 lines removed, no other edits to those files.

## What changed

- **18 `uses:` refs** across the four workflows now carry the full SHA plus a trailing `# vX.Y.Z` comment. The comment is not decoration — Dependabot and Renovate parse and rewrite it, which is what keeps a future bump readable instead of two indistinguishable hex strings.
- **`.github/dependabot.yml`** (new, weekly, `github-actions` only) — the other half of the trade. Pinning alone would freeze these actions until someone hand-edits a SHA; the point is moving updates from silent-and-automatic to visible-and-reviewed. Deliberately **no `pip` entry**: `pyproject.toml` pins `ruff` and `mypy` exactly and requires either bump land in its own PR that absorbs the rule-set delta.
- **`tests/test_workflow_security.py`** (new) — holds the line. Scans by regex rather than parsing YAML, since PyYAML is not a declared dependency and the dev extras carry a written argument for keeping that set tight.

## The test

Three tests, following the shape of `test_remediation_commands.py`:

1. `test_all_external_actions_are_sha_pinned` — the guard, reporting every violation at once as `file:line — reason`.
2. `test_scanner_finds_the_full_inventory` — an inventory floor (≥18). Zero refs found reads identically to zero violations, and this repo has shipped that failure twice: the `_mock_name` probe in `test_hermeticity.py`, and the substring assertions recorded in #108.
3. `test_scanner_verdict_on_planted_lines` — 13 planted samples proving the detector fires independently of the tree being clean: floats, a branch ref, a 39-hex truncation, uppercase hex, a missing version comment. Plus 6 lines that must *not* register at all.

Per #108's convention, commented lines are skipped — the same view `_uncommented_lines()` takes in `tools/command_audit.py`, since a commented ref executes nothing.

## Verification

- `pytest tests/test_workflow_security.py` — 21 passed
- Full suite: **1081 passed, 1 skipped**, coverage 98.90% (gate 95%)
- `ruff check src tests tools` and `mypy src/apotrope tools` — clean
- **Mutation test**: temporarily reverted one ref to `@v4` and confirmed the guard fails with `.github/workflows/test.yml:33 — moving ref 'v4'`, then restored. A green guard and a broken guard otherwise look identical.
- **Independent re-scan** (awk, not the test's own regex): all 18 SHAs re-resolved against the live API and matched their commented tags.
- `yaml.safe_load` on all four workflows plus `dependabot.yml` — all parse.

## Known gap

`publish.yml` and `release.yml` only trigger on `v*` tag pushes, so **CI does not execute them on this PR**. Their correctness rests on the substitution being mechanical, the pinned SHA being byte-identical to what the float resolves to today (verified above), and the YAML parse.

## Out of scope

The repo-level "Allow specified actions" setting (Settings → Actions) — a good complementary control, but a GitHub UI setting rather than a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)