### PR TITLE
ci: run tests once per PR push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,20 +1,41 @@
 name: Tests
 
 on:
+  # push is deliberately limited to main. It previously also listed feat/** and
+  # fix/**, which meant every push to a branch with an open PR matched BOTH
+  # triggers and ran the full 4-leg matrix (two legs Windows) plus build-exe
+  # twice — PR #110 ran as 31227373294 (push) and 31227375103 (pull_request) on
+  # the same commit. The concurrency block below cannot collapse those: a push
+  # event leaves github.event.pull_request.number null and falls through to
+  # github.ref, so the two events land in different groups by construction.
+  #
+  # The cost, stated plainly: pushing a feat/** or fix/** branch with NO pull
+  # request open now runs nothing. Open the PR as a draft (pull_request fires on
+  # drafts) or dispatch this workflow by hand.
   push:
-    branches: ["main", "feat/**", "fix/**"]
+    branches: ["main"]
   pull_request:
     # No branch filter: a stacked PR (base = another fix/** branch, as when
     # these PRs are chained) produced no pull_request-triggered run at all, so
     # it was never checked against its merge preview and offered no check
     # context a branch-protection rule could require.
+  workflow_dispatch:
 
-# One run per ref. Without this the push and pull_request triggers both fire on
-# every push to an open PR branch, duplicating a 4-leg matrix (two of them
-# Windows) and leaving superseded runs to finish.
+# Deduplication happens at the TRIGGER above, not here. Unifying the group key so
+# both events collapse into one — github.event.pull_request.head.ref ||
+# github.ref_name does yield an identical string — was rejected: combined with
+# cancel-in-progress that is a race, and whichever run starts second kills the
+# first. The two runs are not interchangeable (push tests the branch tip,
+# pull_request tests the merge preview), and a cancelled run reports `cancelled`
+# rather than `success`, which would poison any required-status-check rule added
+# later.
+#
+# What this block still does is collapse superseded runs when a PR branch is
+# pushed repeatedly. It must NOT do that on main: cancelling there would leave a
+# merged commit that never completed a run. Hence the event-conditional.
 concurrency:
   group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:


### PR DESCRIPTION
## The bug

Every push to a branch with an open PR ran `Tests` **twice** — the full 4-leg pytest matrix (two legs Windows) plus `build-exe`, duplicated. #110 is the evidence:

```
run push          branch=fix/pin-workflow-shas  success  — ci: pin workflow actions to commit SHAs
run pull_request  branch=fix/pin-workflow-shas  success  — ci: pin workflow actions to commit SHAs
```

`push` listed `main`, `feat/**`, `fix/**`; `pull_request` has no branch filter. A `fix/…` branch with an open PR matched both.

The `concurrency` block was written to prevent exactly this — its comment said so — but its key cannot collapse the two events, because they populate different fields:

| Event | `pull_request.number` | Resulting group |
|---|---|---|
| `push` | null → falls through to `github.ref` | `Tests-refs/heads/fix/pin-workflow-shas` |
| `pull_request` | `110` | `Tests-110` |

Two groups by construction, so neither run could ever cancel the other. (The `dependabot/**` PRs each produced a single run only because those branch names don't match the `push` filter — right outcome, wrong reason.)

## The fix

Narrow `push` to `main`. PRs keep the merge-preview run — the one the `pull_request` comment says is needed so a rule can require it — and merges to `main` still get a post-merge run. Deterministic: nothing races, nothing is cancelled to get there.

**Rejected alternative**, recorded in the file so it isn't re-proposed: unifying the group key (`github.event.pull_request.head.ref || github.ref_name` *does* yield one identical string for both events) looks tighter but is worse. Combined with `cancel-in-progress` it is a race — whichever run starts second kills the first. The two runs are not interchangeable (`push` tests the branch tip, `pull_request` tests the merge preview), and a cancelled run reports `cancelled`, not `success`, so it would poison any required-status-check rule added later.

**Cost, stated in the comment rather than discovered later:** pushing a `feat/**`/`fix/**` branch with no PR open now runs nothing. `workflow_dispatch` is added for that case; a draft PR also works, since `pull_request` fires on drafts.

## Also: `cancel-in-progress` is now PR-only

It applied to every event. Two merges to `main` in quick succession could cancel the first commit's run, leaving a merged commit that never completed one. PR iteration still collapses superseded runs, which is where that behaviour earns its keep.

## Verification

This PR verifies itself — both triggers evaluate the workflow file as it exists here, so the new filter is already in force.

- **Pushing the branch produced zero runs** (previously one). That is the fix, not a failure.
- **This PR should show exactly one `Tests` run, `event: pull_request`** — two rows would mean the fix did not take.
- Job set is unchanged from #110's: 4 pytest legs plus `build-exe`. Duplication was removed; coverage was not.
- Parsed with `yaml.safe_load` to confirm structure: `push.branches == ['main']`, `pull_request` unfiltered, `workflow_dispatch` present, matrix untouched.
- `tests/test_workflow_security.py` still passes (21) — the pinned `uses:` refs are unchanged.

## Note

No `required_status_checks` rule exists on the default-branch ruleset today, so no check name can be broken by this change. Whether the matrix *should* be required is a separate question the `pull_request` comment implies was intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)