### PR TITLE
ci: group Dependabot action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,33 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+    # Ungrouped, the first run opened five separate PRs (#111-#115). Groups are
+    # evaluated in order and a dependency joins the FIRST group it matches, so the
+    # order below is load-bearing. Note these `update-types` use major/minor/patch,
+    # NOT the `version-update:semver-*` spelling the `ignore` option takes.
+    groups:
+      # The artifact actions are a designed pair: upload's `archive` mode and
+      # download's Content-Type-aware decompression shipped together. publish.yml
+      # uploads `dist` in one job and downloads it in two others, so a PR that moves
+      # only one half proposes a combination nobody has run. First, so it claims them
+      # whatever the bump size.
+      artifact-actions:
+        patterns:
+          - "actions/upload-artifact"
+          - "actions/download-artifact"
+
+      # Routine bumps arrive as one PR rather than one per action.
+      actions-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+      # Majors are grouped, deliberately NOT ignored. Ignoring them looks like the
+      # stable choice and is not: of the lines this repo pins, only actions/checkout
+      # still receives backported fixes on its old major (v4.4.0, 2026-07-20).
+      # setup-python v5 and both artifact actions' v4 lines have shipped nothing
+      # since early 2025, so ignoring majors would strand them permanently — the
+      # outcome SHA-pinning exists to prevent.
+      actions-major:
+        patterns: ["*"]
+        update-types: ["major"]


### PR DESCRIPTION
The updater added in #110 opened **five separate PRs** on its first run (#111–#115), one per action. This groups them.

## Why the order matters

Groups are evaluated in order and a dependency joins the **first** group it matches, so the listing order is load-bearing:

1. **`artifact-actions`** — `upload-artifact` + `download-artifact`, no `update-types` filter, so it claims them whatever the bump size. They are a designed pair: upload's `archive` mode and download's Content-Type-aware decompression shipped together, and `publish.yml` uploads `dist` in one job and downloads it in two others. A PR moving only one half proposes a combination nobody has run — which is precisely what five independent PRs produce today.
2. **`actions-minor-patch`** — routine bumps as one PR instead of one per action.
3. **`actions-major`** — majors stay visible, grouped rather than hidden.

## Why majors are grouped and not ignored

`ignore` with `version-update:semver-major` reads like the stable choice. It isn't, and the reason is only visible from upstream release cadence:

| Action | Pinned | Old major still getting fixes? |
|---|---|---|
| `actions/checkout` | v4.4.0 | **Yes** — v4.4.0 (2026-07-20) backports the `pull_request_target` fix |
| `actions/setup-python` | v5.6.0 | No — nothing since 2025-04-24 |
| `actions/upload-artifact` | v4.6.2 | No — nothing since 2025-03-19 |
| `actions/download-artifact` | v4.3.0 | No — nothing since 2025-04-24 |

Three of the four pinned lines are receiving nothing. Ignoring majors would strand them there permanently — the exact outcome SHA-pinning was added to prevent. Grouping keeps them visible and reviewable while capping the noise.

## Verification

- `yaml.safe_load` confirms the parsed structure: three groups in the intended order, `artifact-actions` with no `update-types` filter, the other two scoped to `["minor","patch"]` and `["major"]`.
- Syntax checked against GitHub's Dependabot options reference — in particular that `groups` takes `major`/`minor`/`patch` while `ignore` takes `version-update:semver-*`. A malformed `dependabot.yml` doesn't fail loudly; it just stops updating, so this was worth confirming rather than assuming.
- `tests/test_workflow_security.py` unaffected (21 passed) — no `uses:` refs change here.

The real proof is the next Dependabot run producing grouped PRs; that is observable on the Dependabot tab after merge.

## Not in this PR

The five open PRs themselves. Taking those bumps — including the `verify-artifact` round-trip job that gives `download-artifact` its first PR-time coverage — is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)