### PR TITLE
fix(docs): refresh stale remediation in the published sample reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,46 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `[System.Environment]::OSVersion.Version` remain allowed — Constrained
   Language blocks the call, not the type.
 
+- **The published sample reports no longer advertise remediation the source has
+  already fixed.** `tools/fixtures/sample_report.json` was recovered by parsing
+  the v0.1.12 `docs/report.html`, so it arrived carrying that release's
+  remediation — faithfully, and wrongly. Three commands had moved on in the
+  source and were republished under a v0.2.0 banner: the BitLocker block created
+  a recovery password without ever displaying or saving it (the same defect this
+  release fixed in the scanner, above) — retrievable while Windows still boots,
+  but not at the recovery screen, which is the one place it is needed — the
+  AutoPlay write was a bare
+  `Set-ItemProperty` that fails outright when the `Policies\Explorer` key does
+  not exist, and the NetBIOS call discarded the WMI `ReturnValue` that is its
+  only failure signal.
+  All three now come from the check modules verbatim, as does the Audit Policy
+  wording.
+
+  The regeneration gate that landed with the fixture could not catch this: it
+  asserts the committed HTML is what the fixture renders, and both sides were
+  equally stale. What the fixture owns splits by origin rather than neatly by
+  field: machine-owned (`status`, `score`, timestamps, and the observations
+  carried inside `details`) is frozen at the sample scan, while code-owned
+  (`description`, `remediation`, `command`, `cis_reference`, and the prose that
+  wraps those observations in `details`) should say what the source says.
+
+  `tests/test_sample_reports.py` enforces a deliberately narrower slice of that:
+  every fixture command passes the shipped remediation lint; every non-Audit
+  command must appear in the command inventory, compared with whitespace
+  normalized against a statically extracted inventory; the Audit Policy row is
+  pinned on its own, its command against the module's template and its details
+  as an exact pin on the subcategory this persona reports, because a membership
+  check accepts the hardcoded `Logon` command the sample carried; and
+  `cis_reference` is pinned to `cis_map`. Verified against the previous fixture:
+  all three commands are rejected.
+
+  `description`, `remediation` and the general `details` prose are **not**
+  checked against source, and some remain v0.1.12-era — Guest Account omits the
+  `('Guest', RID-501)` the module now names, and Pending Windows Updates says
+  "were found; the system is up to date" where the module says "No pending
+  Windows Updates found." Left as follow-up: the published commands, which is
+  what an operator copies, are correct.
+
 ---
 
 ## [0.2.0] - 2026-07-27

--- a/docs/exec-report.html
+++ b/docs/exec-report.html
@@ -362,7 +362,7 @@ hr.rule { border: none; border-top: 1px solid var(--rule); margin: 14pt 0; }
       
       <div class="rm-item">
         <div class="rm-title"><span class="cat">Hardening</span>Audit Policy</div>
-        <div class="rm-action">Enable audit logging for the key subcategories that currently have auditing disabled so security-relevant events are recorded. This can also be configured via Group Policy (secpol.msc → Advanced Audit Policy Configuration).</div>
+        <div class="rm-action">Enable audit logging for the subcategories confirmed disabled so security-relevant events are recorded. This can also be configured via Group Policy (secpol.msc → Advanced Audit Policy Configuration).</div>
         <div class="rm-meta"><span class="sev med">MEDIUM</span><span class="cis-ref">CIS 17.1.1</span></div>
       </div>
       
@@ -453,11 +453,11 @@ hr.rule { border: none; border-top: 1px solid var(--rule); margin: 14pt 0; }
         <span class="fname">Audit Policy</span>
       </div>
       <div class="finding-grid">
-        <div class="fblock"><div class="fk">Finding</div><p class="fdetails">The following subcategories have auditing disabled: Sensitive Privilege Use. Security-relevant events may not be recorded.</p></div>
+        <div class="fblock"><div class="fk">Finding</div><p class="fdetails">Not all expected audit subcategories are confirmed logging: Sensitive Privilege Use. Security-relevant events may not be recorded.</p></div>
         <div class="fblock"><div class="fk">Business impact</div><p>Convenience features left enabled give attackers well-known shortcuts to run code or gather information on this machine.</p></div>
       </div>
       
-      <div class="fblock full action"><div class="fk">Recommended action</div><p>Enable audit logging for the key subcategories that currently have auditing disabled so security-relevant events are recorded. This can also be configured via Group Policy (secpol.msc → Advanced Audit Policy Configuration).</p></div>
+      <div class="fblock full action"><div class="fk">Recommended action</div><p>Enable audit logging for the subcategories confirmed disabled so security-relevant events are recorded. This can also be configured via Group Policy (secpol.msc → Advanced Audit Policy Configuration).</p></div>
       
     </div>
     
@@ -645,22 +645,22 @@ hr.rule { border: none; border-top: 1px solid var(--rule); margin: 14pt 0; }
     
     <div class="cmd">
       <div class="cmd-h"><span class="num">03</span><span class="t">BitLocker — G:</span><span class="c">Encryption · P2</span></div>
-      <pre><div class="cmt"># BitLocker requires Windows Pro/Enterprise/Education (absent on Home).</div><div>if (Get-Command Enable-BitLocker -ErrorAction SilentlyContinue) {</div><div>    Enable-BitLocker -MountPoint &#39;G:&#39; -EncryptionMethod XtsAes256 -UsedSpaceOnly -RecoveryPasswordProtector -SkipHardwareTest</div><div>    if (&#39;G:&#39; -eq $env:SystemDrive) { Add-BitLockerKeyProtector -MountPoint &#39;G:&#39; -TpmProtector } else { Enable-BitLockerAutoUnlock -MountPoint &#39;G:&#39; }</div><div>} else {</div><div>    Write-Warning &#39;BitLocker is unavailable on this Windows edition.&#39;</div><div>}</div></pre>
+      <pre><div class="cmt"># BitLocker requires Windows Pro/Enterprise/Education (absent on Home).</div><div>if (Get-Command Enable-BitLocker -ErrorAction SilentlyContinue) {</div><div>    Enable-BitLocker -MountPoint &#39;G:&#39; -EncryptionMethod XtsAes256 -UsedSpaceOnly -RecoveryPasswordProtector -SkipHardwareTest</div><div>    if (&#39;G:&#39; -eq $env:SystemDrive) { Add-BitLockerKeyProtector -MountPoint &#39;G:&#39; -TpmProtector } else { Enable-BitLockerAutoUnlock -MountPoint &#39;G:&#39; }</div><div> </div><div class="cmt">    # SAVE THIS BEFORE YOU REBOOT. The recovery password is the only</div><div class="cmt">    # way back in once the key stops being released automatically. The</div><div class="cmt">    # cmdlets above return a volume object whose default table shows the</div><div class="cmt">    # protector TYPES but not the password, and it cannot be read back</div><div class="cmt">    # from the recovery prompt itself.</div><div>    $rp = (Get-BitLockerVolume -MountPoint &#39;G:&#39;).KeyProtector | Where-Object KeyProtectorType -eq &#39;RecoveryPassword&#39;</div><div>    $rp | Format-List KeyProtectorId, RecoveryPassword</div><div class="cmt">    # Domain- or Entra-joined? Escrow it centrally as well:</div><div class="cmt">    # Backup-BitLockerKeyProtector -MountPoint &#39;G:&#39; -KeyProtectorId $rp.KeyProtectorId</div><div class="cmt">    # BackupToAAD-BitLockerKeyProtector -MountPoint &#39;G:&#39; -KeyProtectorId $rp.KeyProtectorId</div><div>} else {</div><div>    Write-Warning &#39;BitLocker is unavailable on this Windows edition.&#39;</div><div>}</div></pre>
     </div>
     
     <div class="cmd">
       <div class="cmd-h"><span class="num">04</span><span class="t">Audit Policy</span><span class="c">Hardening · P2</span></div>
-      <pre><div>auditpol /set /subcategory:&#39;Logon&#39; /success:enable /failure:enable</div></pre>
+      <pre><div>auditpol /set /subcategory:&#39;Sensitive Privilege Use&#39; /success:enable /failure:enable</div></pre>
     </div>
     
     <div class="cmd">
       <div class="cmd-h"><span class="num">05</span><span class="t">AutoPlay Disabled</span><span class="c">Hardening · P2</span></div>
-      <pre><div>Set-ItemProperty -Path &#39;HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer&#39; -Name NoDriveTypeAutoRun -Value 255 -Type DWord -Force</div></pre>
+      <pre><div>reg.exe add &#34;HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer&#34; /v NoDriveTypeAutoRun /t REG_DWORD /d 255 /f</div><div>if ($LASTEXITCODE -ne 0) { throw &#34;reg.exe add failed ($LASTEXITCODE)&#34; }</div></pre>
     </div>
     
     <div class="cmd">
       <div class="cmd-h"><span class="num">06</span><span class="t">NetBIOS over TCP/IP</span><span class="c">Network · P3</span></div>
-      <pre><div>Get-CimInstance Win32_NetworkAdapterConfiguration -Filter &#39;IPEnabled=True&#39; | ForEach-Object { Invoke-CimMethod -InputObject $_ -MethodName SetTcpipNetbios -Arguments @{ TcpipNetbiosOptions = 2 } | Out-Null }</div></pre>
+      <pre><div>Get-CimInstance Win32_NetworkAdapterConfiguration -Filter &#39;IPEnabled=True&#39; | ForEach-Object {</div><div>    $r = Invoke-CimMethod -InputObject $_ -MethodName SetTcpipNetbios -Arguments @{ TcpipNetbiosOptions = 2 }</div><div>    switch ($r.ReturnValue) {</div><div>        0 { &#34;$($_.Description): NetBIOS disabled&#34; }</div><div>        1 { Write-Warning &#34;$($_.Description): disabled, REBOOT REQUIRED&#34; }</div><div>        default { Write-Warning &#34;$($_.Description): failed, ReturnValue=$($r.ReturnValue)&#34; }</div><div>    }</div><div>}</div></pre>
     </div>
     
     

--- a/docs/report.html
+++ b/docs/report.html
@@ -1142,6 +1142,17 @@ secedit /configure /db &#34;$env:TEMP\pwcomplexity.sdb&#34; /cfg $inf /areas SEC
 if (get-command enable-bitlocker -erroraction silentlycontinue) {
     enable-bitlocker -mountpoint &#39;g:&#39; -encryptionmethod xtsaes256 -usedspaceonly -recoverypasswordprotector -skiphardwaretest
     if (&#39;g:&#39; -eq $env:systemdrive) { add-bitlockerkeyprotector -mountpoint &#39;g:&#39; -tpmprotector } else { enable-bitlockerautounlock -mountpoint &#39;g:&#39; }
+
+    # save this before you reboot. the recovery password is the only
+    # way back in once the key stops being released automatically. the
+    # cmdlets above return a volume object whose default table shows the
+    # protector types but not the password, and it cannot be read back
+    # from the recovery prompt itself.
+    $rp = (get-bitlockervolume -mountpoint &#39;g:&#39;).keyprotector | where-object keyprotectortype -eq &#39;recoverypassword&#39;
+    $rp | format-list keyprotectorid, recoverypassword
+    # domain- or entra-joined? escrow it centrally as well:
+    # backup-bitlockerkeyprotector -mountpoint &#39;g:&#39; -keyprotectorid $rp.keyprotectorid
+    # backuptoaad-bitlockerkeyprotector -mountpoint &#39;g:&#39; -keyprotectorid $rp.keyprotectorid
 } else {
     write-warning &#39;bitlocker is unavailable on this windows edition.&#39;
 }">
@@ -1169,6 +1180,17 @@ if (get-command enable-bitlocker -erroraction silentlycontinue) {
 if (Get-Command Enable-BitLocker -ErrorAction SilentlyContinue) {
     Enable-BitLocker -MountPoint &#39;G:&#39; -EncryptionMethod XtsAes256 -UsedSpaceOnly -RecoveryPasswordProtector -SkipHardwareTest
     if (&#39;G:&#39; -eq $env:SystemDrive) { Add-BitLockerKeyProtector -MountPoint &#39;G:&#39; -TpmProtector } else { Enable-BitLockerAutoUnlock -MountPoint &#39;G:&#39; }
+
+    # SAVE THIS BEFORE YOU REBOOT. The recovery password is the only
+    # way back in once the key stops being released automatically. The
+    # cmdlets above return a volume object whose default table shows the
+    # protector TYPES but not the password, and it cannot be read back
+    # from the recovery prompt itself.
+    $rp = (Get-BitLockerVolume -MountPoint &#39;G:&#39;).KeyProtector | Where-Object KeyProtectorType -eq &#39;RecoveryPassword&#39;
+    $rp | Format-List KeyProtectorId, RecoveryPassword
+    # Domain- or Entra-joined? Escrow it centrally as well:
+    # Backup-BitLockerKeyProtector -MountPoint &#39;G:&#39; -KeyProtectorId $rp.KeyProtectorId
+    # BackupToAAD-BitLockerKeyProtector -MountPoint &#39;G:&#39; -KeyProtectorId $rp.KeyProtectorId
 } else {
     Write-Warning &#39;BitLocker is unavailable on this Windows edition.&#39;
 }">
@@ -1176,7 +1198,7 @@ if (Get-Command Enable-BitLocker -ErrorAction SilentlyContinue) {
                     <span class="code-tag"><span class="shield">⛨</span> Elevated PowerShell · run as Administrator</span>
                     <button class="copy" type="button">⧉ Copy</button>
                   </div>
-                  <pre class="code-cmd"><div class="cl-c"># BitLocker requires Windows Pro/Enterprise/Education (absent on Home).</div><div class="cl-x"><span class="ps">PS&gt;</span>if (Get-Command Enable-BitLocker -ErrorAction SilentlyContinue) {</div><div class="cl-x"><span class="ps">PS&gt;</span>    Enable-BitLocker -MountPoint &#39;G:&#39; -EncryptionMethod XtsAes256 -UsedSpaceOnly -RecoveryPasswordProtector -SkipHardwareTest</div><div class="cl-x"><span class="ps">PS&gt;</span>    if (&#39;G:&#39; -eq $env:SystemDrive) { Add-BitLockerKeyProtector -MountPoint &#39;G:&#39; -TpmProtector } else { Enable-BitLockerAutoUnlock -MountPoint &#39;G:&#39; }</div><div class="cl-x"><span class="ps">PS&gt;</span>} else {</div><div class="cl-x"><span class="ps">PS&gt;</span>    Write-Warning &#39;BitLocker is unavailable on this Windows edition.&#39;</div><div class="cl-x"><span class="ps">PS&gt;</span>}</div></pre>
+                  <pre class="code-cmd"><div class="cl-c"># BitLocker requires Windows Pro/Enterprise/Education (absent on Home).</div><div class="cl-x"><span class="ps">PS&gt;</span>if (Get-Command Enable-BitLocker -ErrorAction SilentlyContinue) {</div><div class="cl-x"><span class="ps">PS&gt;</span>    Enable-BitLocker -MountPoint &#39;G:&#39; -EncryptionMethod XtsAes256 -UsedSpaceOnly -RecoveryPasswordProtector -SkipHardwareTest</div><div class="cl-x"><span class="ps">PS&gt;</span>    if (&#39;G:&#39; -eq $env:SystemDrive) { Add-BitLockerKeyProtector -MountPoint &#39;G:&#39; -TpmProtector } else { Enable-BitLockerAutoUnlock -MountPoint &#39;G:&#39; }</div><div class="cl-b"> </div><div class="cl-c">    # SAVE THIS BEFORE YOU REBOOT. The recovery password is the only</div><div class="cl-c">    # way back in once the key stops being released automatically. The</div><div class="cl-c">    # cmdlets above return a volume object whose default table shows the</div><div class="cl-c">    # protector TYPES but not the password, and it cannot be read back</div><div class="cl-c">    # from the recovery prompt itself.</div><div class="cl-x"><span class="ps">PS&gt;</span>    $rp = (Get-BitLockerVolume -MountPoint &#39;G:&#39;).KeyProtector | Where-Object KeyProtectorType -eq &#39;RecoveryPassword&#39;</div><div class="cl-x"><span class="ps">PS&gt;</span>    $rp | Format-List KeyProtectorId, RecoveryPassword</div><div class="cl-c">    # Domain- or Entra-joined? Escrow it centrally as well:</div><div class="cl-c">    # Backup-BitLockerKeyProtector -MountPoint &#39;G:&#39; -KeyProtectorId $rp.KeyProtectorId</div><div class="cl-c">    # BackupToAAD-BitLockerKeyProtector -MountPoint &#39;G:&#39; -KeyProtectorId $rp.KeyProtectorId</div><div class="cl-x"><span class="ps">PS&gt;</span>} else {</div><div class="cl-x"><span class="ps">PS&gt;</span>    Write-Warning &#39;BitLocker is unavailable on this Windows edition.&#39;</div><div class="cl-x"><span class="ps">PS&gt;</span>}</div></pre>
                   <div class="code-warn">⚠ Review before running — these commands run elevated and can change system settings, or require a reboot or maintenance window.</div>
                 </div>
                 
@@ -1470,7 +1492,8 @@ if (Get-Command Enable-BitLocker -ErrorAction SilentlyContinue) {
         
         
         
-        <div class="frow is-warn" data-status="WARN" data-text="autoplay disabled hardening autoplay is partially disabled (nodrivetypeautorun = 158). some drive types may still trigger autoplay. cis 18.10.8.3 set-itemproperty -path &#39;hklm:\software\microsoft\windows\currentversion\policies\explorer&#39; -name nodrivetypeautorun -value 255 -type dword -force">
+        <div class="frow is-warn" data-status="WARN" data-text="autoplay disabled hardening autoplay is partially disabled (nodrivetypeautorun = 158). some drive types may still trigger autoplay. cis 18.10.8.3 reg.exe add &#34;hklm\software\microsoft\windows\currentversion\policies\explorer&#34; /v nodrivetypeautorun /t reg_dword /d 255 /f
+if ($lastexitcode -ne 0) { throw &#34;reg.exe add failed ($lastexitcode)&#34; }">
           <button class="fhead is-open">
             <span class="spill spill-warn">WARN</span>
             <span class="fsevcell"><span class="fsev" style="color:#ffb23d;border:1px solid #ffb23d;background:transparent">MEDIUM</span></span>
@@ -1491,12 +1514,13 @@ if (Get-Command Enable-BitLocker -ErrorAction SilentlyContinue) {
               <div class="rem">
                 <div class="rem-note">Disable AutoPlay for all drive types so the remaining drive types can no longer auto-execute content.</div>
                 
-                <div class="code" data-cmd="Set-ItemProperty -Path &#39;HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer&#39; -Name NoDriveTypeAutoRun -Value 255 -Type DWord -Force">
+                <div class="code" data-cmd="reg.exe add &#34;HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer&#34; /v NoDriveTypeAutoRun /t REG_DWORD /d 255 /f
+if ($LASTEXITCODE -ne 0) { throw &#34;reg.exe add failed ($LASTEXITCODE)&#34; }">
                   <div class="code-bar">
                     <span class="code-tag"><span class="shield">⛨</span> Elevated PowerShell · run as Administrator</span>
                     <button class="copy" type="button">⧉ Copy</button>
                   </div>
-                  <pre class="code-cmd"><div class="cl-x"><span class="ps">PS&gt;</span>Set-ItemProperty -Path &#39;HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer&#39; -Name NoDriveTypeAutoRun -Value 255 -Type DWord -Force</div></pre>
+                  <pre class="code-cmd"><div class="cl-x"><span class="ps">PS&gt;</span>reg.exe add &#34;HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer&#34; /v NoDriveTypeAutoRun /t REG_DWORD /d 255 /f</div><div class="cl-x"><span class="ps">PS&gt;</span>if ($LASTEXITCODE -ne 0) { throw &#34;reg.exe add failed ($LASTEXITCODE)&#34; }</div></pre>
                   <div class="code-warn">⚠ Review before running — these commands run elevated and can change system settings, or require a reboot or maintenance window.</div>
                 </div>
                 
@@ -1507,13 +1531,13 @@ if (Get-Command Enable-BitLocker -ErrorAction SilentlyContinue) {
         </div>
         
         
-        <div class="frow is-warn" data-status="WARN" data-text="audit policy hardening the following subcategories have auditing disabled: sensitive privilege use. security-relevant events may not be recorded. cis 17.1.1 auditpol /set /subcategory:&#39;logon&#39; /success:enable /failure:enable">
+        <div class="frow is-warn" data-status="WARN" data-text="audit policy hardening not all expected audit subcategories are confirmed logging: sensitive privilege use. security-relevant events may not be recorded. cis 17.1.1 auditpol /set /subcategory:&#39;sensitive privilege use&#39; /success:enable /failure:enable">
           <button class="fhead is-open">
             <span class="spill spill-warn">WARN</span>
             <span class="fsevcell"><span class="fsev" style="color:#ffb23d;border:1px solid #ffb23d;background:transparent">MEDIUM</span></span>
             <span class="fname">
               <b>Audit Policy</b>
-              <div class="fsnip">The following subcategories have auditing disabled: Sensitive Privilege Use</div>
+              <div class="fsnip">Not all expected audit subcategories are confirmed logging: Sensitive Privilege Use</div>
             </span>
             <span class="fright">
               <span class="cis">CIS 17.1.1</span>
@@ -1522,18 +1546,18 @@ if (Get-Command Enable-BitLocker -ErrorAction SilentlyContinue) {
           </button>
           <div class="fbody">
             <div class="fld"><span class="k">Checks</span><span class="vv">Checks that key audit policy subcategories log Success/Failure events.</span></div>
-            <div class="fld"><span class="k">Found</span><span class="vv">The following subcategories have auditing disabled: Sensitive Privilege Use. Security-relevant events may not be recorded.</span></div>
+            <div class="fld"><span class="k">Found</span><span class="vv">Not all expected audit subcategories are confirmed logging: Sensitive Privilege Use. Security-relevant events may not be recorded.</span></div>
             
             <div class="fld"><span class="k">Remediation</span>
               <div class="rem">
-                <div class="rem-note">Enable audit logging for the key subcategories that currently have auditing disabled so security-relevant events are recorded. This can also be configured via Group Policy (secpol.msc → Advanced Audit Policy Configuration).</div>
+                <div class="rem-note">Enable audit logging for the subcategories confirmed disabled so security-relevant events are recorded. This can also be configured via Group Policy (secpol.msc → Advanced Audit Policy Configuration).</div>
                 
-                <div class="code" data-cmd="auditpol /set /subcategory:&#39;Logon&#39; /success:enable /failure:enable">
+                <div class="code" data-cmd="auditpol /set /subcategory:&#39;Sensitive Privilege Use&#39; /success:enable /failure:enable">
                   <div class="code-bar">
                     <span class="code-tag"><span class="shield">⛨</span> Elevated PowerShell · run as Administrator</span>
                     <button class="copy" type="button">⧉ Copy</button>
                   </div>
-                  <pre class="code-cmd"><div class="cl-x"><span class="ps">PS&gt;</span>auditpol /set /subcategory:&#39;Logon&#39; /success:enable /failure:enable</div></pre>
+                  <pre class="code-cmd"><div class="cl-x"><span class="ps">PS&gt;</span>auditpol /set /subcategory:&#39;Sensitive Privilege Use&#39; /success:enable /failure:enable</div></pre>
                   <div class="code-warn">⚠ Review before running — these commands run elevated and can change system settings, or require a reboot or maintenance window.</div>
                 </div>
                 
@@ -1629,7 +1653,14 @@ if (Get-Command Enable-BitLocker -ErrorAction SilentlyContinue) {
         
         
         
-        <div class="frow is-warn" data-status="WARN" data-text="netbios over tcp/ip network 2 adapter(s) inherit netbios setting from dhcp. if the dhcp server does not explicitly disable netbios, it may be active.  get-ciminstance win32_networkadapterconfiguration -filter &#39;ipenabled=true&#39; | foreach-object { invoke-cimmethod -inputobject $_ -methodname settcpipnetbios -arguments @{ tcpipnetbiosoptions = 2 } | out-null }">
+        <div class="frow is-warn" data-status="WARN" data-text="netbios over tcp/ip network 2 adapter(s) inherit netbios setting from dhcp. if the dhcp server does not explicitly disable netbios, it may be active.  get-ciminstance win32_networkadapterconfiguration -filter &#39;ipenabled=true&#39; | foreach-object {
+    $r = invoke-cimmethod -inputobject $_ -methodname settcpipnetbios -arguments @{ tcpipnetbiosoptions = 2 }
+    switch ($r.returnvalue) {
+        0 { &#34;$($_.description): netbios disabled&#34; }
+        1 { write-warning &#34;$($_.description): disabled, reboot required&#34; }
+        default { write-warning &#34;$($_.description): failed, returnvalue=$($r.returnvalue)&#34; }
+    }
+}">
           <button class="fhead is-open">
             <span class="spill spill-warn">WARN</span>
             <span class="fsevcell"><span class="fsev" style="color:#44e0e6;border:1px solid #44e0e6;background:transparent">LOW</span></span>
@@ -1650,12 +1681,19 @@ if (Get-Command Enable-BitLocker -ErrorAction SilentlyContinue) {
               <div class="rem">
                 <div class="rem-note">Explicitly disable NetBIOS on all adapters rather than relying on DHCP.</div>
                 
-                <div class="code" data-cmd="Get-CimInstance Win32_NetworkAdapterConfiguration -Filter &#39;IPEnabled=True&#39; | ForEach-Object { Invoke-CimMethod -InputObject $_ -MethodName SetTcpipNetbios -Arguments @{ TcpipNetbiosOptions = 2 } | Out-Null }">
+                <div class="code" data-cmd="Get-CimInstance Win32_NetworkAdapterConfiguration -Filter &#39;IPEnabled=True&#39; | ForEach-Object {
+    $r = Invoke-CimMethod -InputObject $_ -MethodName SetTcpipNetbios -Arguments @{ TcpipNetbiosOptions = 2 }
+    switch ($r.ReturnValue) {
+        0 { &#34;$($_.Description): NetBIOS disabled&#34; }
+        1 { Write-Warning &#34;$($_.Description): disabled, REBOOT REQUIRED&#34; }
+        default { Write-Warning &#34;$($_.Description): failed, ReturnValue=$($r.ReturnValue)&#34; }
+    }
+}">
                   <div class="code-bar">
                     <span class="code-tag"><span class="shield">⛨</span> Elevated PowerShell · run as Administrator</span>
                     <button class="copy" type="button">⧉ Copy</button>
                   </div>
-                  <pre class="code-cmd"><div class="cl-x"><span class="ps">PS&gt;</span>Get-CimInstance Win32_NetworkAdapterConfiguration -Filter &#39;IPEnabled=True&#39; | ForEach-Object { Invoke-CimMethod -InputObject $_ -MethodName SetTcpipNetbios -Arguments @{ TcpipNetbiosOptions = 2 } | Out-Null }</div></pre>
+                  <pre class="code-cmd"><div class="cl-x"><span class="ps">PS&gt;</span>Get-CimInstance Win32_NetworkAdapterConfiguration -Filter &#39;IPEnabled=True&#39; | ForEach-Object {</div><div class="cl-x"><span class="ps">PS&gt;</span>    $r = Invoke-CimMethod -InputObject $_ -MethodName SetTcpipNetbios -Arguments @{ TcpipNetbiosOptions = 2 }</div><div class="cl-x"><span class="ps">PS&gt;</span>    switch ($r.ReturnValue) {</div><div class="cl-x"><span class="ps">PS&gt;</span>        0 { &#34;$($_.Description): NetBIOS disabled&#34; }</div><div class="cl-x"><span class="ps">PS&gt;</span>        1 { Write-Warning &#34;$($_.Description): disabled, REBOOT REQUIRED&#34; }</div><div class="cl-x"><span class="ps">PS&gt;</span>        default { Write-Warning &#34;$($_.Description): failed, ReturnValue=$($r.ReturnValue)&#34; }</div><div class="cl-x"><span class="ps">PS&gt;</span>    }</div><div class="cl-x"><span class="ps">PS&gt;</span>}</div></pre>
                   <div class="code-warn">⚠ Review before running — these commands run elevated and can change system settings, or require a reboot or maintenance window.</div>
                 </div>
                 

--- a/tests/test_sample_reports.py
+++ b/tests/test_sample_reports.py
@@ -6,13 +6,55 @@ when the package version moved they could not be regenerated and sat advertising
 v0.1.12 two releases later. ``tools/fixtures/sample_report.json`` is now their
 source and ``tools/generate_sample_reports.py`` renders them.
 
-Two failure modes are guarded here:
+Three failure modes are guarded here:
 
 * **Branding drift** — a committed asset naming a version the package no longer
   is. Covers ``docs/index.html`` too, whose demo terminal and JSON-LD carry the
   same version by hand.
 * **Source drift** — the committed assets no longer being what the fixture
   renders, which would put the reproducible path back where it started.
+* **Content drift** — the fixture publishing remediation the check modules no
+  longer emit. The fixture was recovered from the v0.1.12 report, so it arrived
+  carrying that release's commands: a BitLocker block that creates a recovery
+  password without ever displaying or saving it — retrievable while Windows
+  still boots, but not at the recovery screen, which is where it is needed — a
+  bare ``Set-ItemProperty`` AutoPlay write that fails outright when its policy
+  key does not exist, and a WMI call that discards its ``ReturnValue``. All
+  three had been fixed in the source by then and all three were published under
+  a v0.2.0 banner.
+
+What the fixture owns splits by *origin*, not neatly by field, and that split
+is what makes it a sanitized scan rather than a snapshot of an old release:
+
+* **machine-owned** — ``status``, ``hostname``, ``score``, timestamps, and the
+  observations carried inside ``details`` (which subcategories were disabled,
+  which drive is unencrypted). Frozen at the sample machine.
+* **code-owned** — ``description``, ``remediation``, ``command``,
+  ``cis_reference``, and the prose that wraps those observations in
+  ``details``. These *should* say what the modules say today.
+
+``details`` therefore straddles both: the finding is the machine's, the
+sentence around it is the source's.
+
+What this module actually enforces is narrower than that second bullet, and
+the gap is deliberate — closing it is what turned an earlier attempt at this
+guard into a rewrite of the whole check layer:
+
+* every fixture command passes the shipped remediation lint;
+* every non-Audit command must appear in the command inventory — a
+  **whitespace-normalized** comparison against a **statically extracted**
+  inventory, so it proves the command is one the modules still carry, not that
+  the two are byte-identical;
+* the Audit Policy row is pinned on its own — the command from the module's
+  template, the details as an exact pin on this persona's finding;
+* ``cis_reference`` is checked against ``cis_map``.
+
+Nothing here verifies ``description``, ``remediation`` or the general
+``details`` prose against source. Some of it is still v0.1.12-era: Guest
+Account omits the ``('Guest', RID-501)`` the module now names, and Pending
+Windows Updates says "were found; the system is up to date" where the module
+says "No pending Windows Updates found." Those are known and left alone — the
+published *commands* are correct, which is what this change is for.
 """
 
 from __future__ import annotations
@@ -24,6 +66,8 @@ from pathlib import Path
 import pytest
 
 import apotrope
+from apotrope import cis_map
+from apotrope.checks import misc
 from apotrope.compare import load_baseline
 from apotrope.models import Status
 from apotrope.scoring import calculate_score
@@ -32,6 +76,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
 
 # Imported in-process, not spawned: conftest's autouse guard patches
 # subprocess.run process-wide, so shelling out to the generator would raise.
+import command_audit
+
 from generate_sample_reports import (
     EXECUTIVE_NAME,
     EXPECTED_COUNTS,
@@ -45,6 +91,11 @@ from generate_sample_reports import (
 ROOT = Path(__file__).resolve().parent.parent
 DOCS = ROOT / "docs"
 REGENERATE = "python tools/generate_sample_reports.py"
+
+
+def _squash(text: str) -> str:
+    """Collapse whitespace runs so reflowed source literals still compare equal."""
+    return re.sub(r"\s+", " ", text).strip()
 
 # Anchors are deliberately narrow. All three files also contain CIS benchmark
 # strings ("v5.0.0", "v4.0.0"), so a loose r"v\d+\.\d+\.\d+" sweep captures those
@@ -143,3 +194,124 @@ def test_fixture_severity_placeholders_are_confined_to_unrendered_rows() -> None
         r.severity for r in report.results if r.status in (Status.FAIL, Status.WARN)
     }
     assert len(rendered) > 1, "FAIL/WARN severities look overwritten, not recovered"
+
+
+def _fixture_commands() -> list[command_audit.Command]:
+    """Fixture rows carrying a command, shaped for the shipped lint."""
+    report = load_baseline(str(FIXTURE))
+    return [
+        command_audit.Command(module=r.check_name, line=0, text=r.command)
+        for r in report.results
+        if r.command
+    ]
+
+
+def test_fixture_commands_pass_the_shipped_lint() -> None:
+    """The sample's commands must clear the same lint the check modules do.
+
+    ``tests/test_remediation_commands.py`` runs this over the source inventory.
+    Running it over the fixture as well is what stops the published sample
+    advertising a command the source has already fixed — which is exactly how a
+    BitLocker block with no recovery-password readback reached apotrope.sh under
+    a v0.2.0 banner.
+    """
+    violations = command_audit.lint_commands(_fixture_commands())
+    assert violations == [], (
+        "the published sample carries remediation the lint rejects:\n"
+        + "\n".join(f"  {v.module}: {v.rule}" for v in violations)
+    )
+
+
+def test_fixture_commands_are_still_shipped_by_the_check_modules() -> None:
+    """Every sample command must be one the modules emit today, verbatim.
+
+    Catches drift no lint rule models — a reworded comment, a dropped guard —
+    by requiring membership in the real inventory rather than mere plausibility.
+    Runtime values are substituted back out: ``BitLocker — G:`` renders the
+    ``{mount}`` command with its own mount point.
+
+    Audit Policy is excluded here and checked by
+    ``test_the_audit_policy_command_enables_the_reported_subcategories``
+    instead. Its command is one enable line per subcategory this scan found
+    disabled, so membership would have to fold the subcategory name back into
+    the template — and that fold accepts *any* name, including the hardcoded
+    'Logon' this sample once carried. The dedicated check pins the exact
+    subcategory instead, which the fold cannot do.
+    """
+    shipped = {_squash(c.text) for c in command_audit.collect_commands()}
+
+    stale: list[str] = []
+    for cmd in _fixture_commands():
+        if cmd.module == "Audit Policy":
+            continue
+        candidates = {_squash(cmd.text)}
+        # Per-row mount, taken from the check name (e.g. "BitLocker — G:").
+        mount = cmd.module.rsplit("—", 1)[-1].strip()
+        if re.fullmatch(r"[A-Z]:", mount):
+            candidates.add(_squash(cmd.text.replace(mount, "{mount}")))
+        if not candidates & shipped:
+            stale.append(cmd.module)
+
+    assert not stale, (
+        f"these sample commands are no longer what the check modules emit: {stale}. "
+        "Refresh them from source, then regenerate: " + REGENERATE
+    )
+
+
+#: The subcategories the sample machine reports as confirmed disabled. Pinned,
+#: because the Audit Policy command is built from them: a fixture naming a
+#: different subcategory — or the hardcoded 'Logon' the sample carried before
+#: the check emitted one line per finding — must fail rather than be
+#: normalized into agreement.
+_SAMPLE_AUDIT_SUBCATEGORIES = ("Sensitive Privilege Use",)
+
+
+def test_the_audit_policy_command_enables_the_reported_subcategories() -> None:
+    """The sample's audit command must enable exactly what its details report.
+
+    The two halves are pinned by different means. The command is built from
+    ``misc._CMD_AUDITPOL_ENABLE``, so it stays tied to the source template.
+    The details prose is not source-linked: it is an exact pin on this
+    persona's finding, rejecting a subcategory that goes missing, one that is
+    added, and one that is swapped for another. Equality rather than
+    membership is what buys the last two — a membership test accepts a details
+    line naming extra subcategories, and accepted the hardcoded 'Logon'
+    command this sample used to carry.
+
+    It is not a source-drift alarm for the details wording. Catching a reword
+    that happens only in the source would mean executing the real check or
+    exposing its sentence as a constant, and neither is in scope here.
+    """
+    row = next(
+        r for r in load_baseline(str(FIXTURE)).results if r.check_name == "Audit Policy"
+    )
+    expected_command = "\n".join(
+        misc._CMD_AUDITPOL_ENABLE.format(subcategory=name)
+        for name in _SAMPLE_AUDIT_SUBCATEGORIES
+    )
+    assert row.command == expected_command, (
+        "the sample's Audit Policy command does not enable exactly the "
+        f"subcategories it reports as disabled. Refresh it, then regenerate: {REGENERATE}"
+    )
+    # Mirrors how _check_audit_policy builds the line. Equality, not
+    # membership, so a missing, extra or substituted subcategory all fail.
+    expected_details = (
+        "Not all expected audit subcategories are confirmed logging: "
+        f"{', '.join(_SAMPLE_AUDIT_SUBCATEGORIES)}. "
+        "Security-relevant events may not be recorded."
+    )
+    assert row.details == expected_details, (
+        "the sample's Audit Policy details no longer report exactly the "
+        f"subcategories its command enables. Refresh it, then regenerate: {REGENERATE}"
+    )
+
+
+def test_fixture_cis_references_match_the_benchmark_map() -> None:
+    """``cis_reference`` is code-owned too — it comes from cis_map, not the scan."""
+    report = load_baseline(str(FIXTURE))
+    wrong = [
+        (r.check_name, r.cis_reference, cis_map.lookup(r.check_name))
+        for r in report.results
+        if r.cis_reference != cis_map.lookup(r.check_name)
+    ]
+    assert not wrong, f"fixture CIS references disagree with cis_map: {wrong}"

--- a/tools/fixtures/sample_report.json
+++ b/tools/fixtures/sample_report.json
@@ -181,7 +181,7 @@
       "description": "Checks BitLocker encryption status for drive G:.",
       "details": "Drive: G: | Type: 1 | Status: Unknown | Encrypted: 0% | Protection: Off",
       "remediation": "Encrypt drive G: with BitLocker using the TPM protector.",
-      "command": "# BitLocker requires Windows Pro/Enterprise/Education (absent on Home).\nif (Get-Command Enable-BitLocker -ErrorAction SilentlyContinue) {\n    Enable-BitLocker -MountPoint 'G:' -EncryptionMethod XtsAes256 -UsedSpaceOnly -RecoveryPasswordProtector -SkipHardwareTest\n    if ('G:' -eq $env:SystemDrive) { Add-BitLockerKeyProtector -MountPoint 'G:' -TpmProtector } else { Enable-BitLockerAutoUnlock -MountPoint 'G:' }\n} else {\n    Write-Warning 'BitLocker is unavailable on this Windows edition.'\n}",
+      "command": "# BitLocker requires Windows Pro/Enterprise/Education (absent on Home).\nif (Get-Command Enable-BitLocker -ErrorAction SilentlyContinue) {\n    Enable-BitLocker -MountPoint 'G:' -EncryptionMethod XtsAes256 -UsedSpaceOnly -RecoveryPasswordProtector -SkipHardwareTest\n    if ('G:' -eq $env:SystemDrive) { Add-BitLockerKeyProtector -MountPoint 'G:' -TpmProtector } else { Enable-BitLockerAutoUnlock -MountPoint 'G:' }\n\n    # SAVE THIS BEFORE YOU REBOOT. The recovery password is the only\n    # way back in once the key stops being released automatically. The\n    # cmdlets above return a volume object whose default table shows the\n    # protector TYPES but not the password, and it cannot be read back\n    # from the recovery prompt itself.\n    $rp = (Get-BitLockerVolume -MountPoint 'G:').KeyProtector | Where-Object KeyProtectorType -eq 'RecoveryPassword'\n    $rp | Format-List KeyProtectorId, RecoveryPassword\n    # Domain- or Entra-joined? Escrow it centrally as well:\n    # Backup-BitLockerKeyProtector -MountPoint 'G:' -KeyProtectorId $rp.KeyProtectorId\n    # BackupToAAD-BitLockerKeyProtector -MountPoint 'G:' -KeyProtectorId $rp.KeyProtectorId\n} else {\n    Write-Warning 'BitLocker is unavailable on this Windows edition.'\n}",
       "check_duration": 0.0,
       "cis_reference": "CIS 18.10.10"
     },
@@ -313,7 +313,7 @@
       "description": "Checks whether AutoPlay is disabled for all drive types.",
       "details": "AutoPlay is partially disabled (NoDriveTypeAutoRun = 158). Some drive types may still trigger AutoPlay.",
       "remediation": "Disable AutoPlay for all drive types so the remaining drive types can no longer auto-execute content.",
-      "command": "Set-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer' -Name NoDriveTypeAutoRun -Value 255 -Type DWord -Force",
+      "command": "reg.exe add \"HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\" /v NoDriveTypeAutoRun /t REG_DWORD /d 255 /f\nif ($LASTEXITCODE -ne 0) { throw \"reg.exe add failed ($LASTEXITCODE)\" }",
       "check_duration": 0.0,
       "cis_reference": "CIS 18.10.8.3"
     },
@@ -323,9 +323,9 @@
       "status": "WARN",
       "severity": "MEDIUM",
       "description": "Checks that key audit policy subcategories log Success/Failure events.",
-      "details": "The following subcategories have auditing disabled: Sensitive Privilege Use. Security-relevant events may not be recorded.",
-      "remediation": "Enable audit logging for the key subcategories that currently have auditing disabled so security-relevant events are recorded. This can also be configured via Group Policy (secpol.msc → Advanced Audit Policy Configuration).",
-      "command": "auditpol /set /subcategory:'Logon' /success:enable /failure:enable",
+      "details": "Not all expected audit subcategories are confirmed logging: Sensitive Privilege Use. Security-relevant events may not be recorded.",
+      "remediation": "Enable audit logging for the subcategories confirmed disabled so security-relevant events are recorded. This can also be configured via Group Policy (secpol.msc → Advanced Audit Policy Configuration).",
+      "command": "auditpol /set /subcategory:'Sensitive Privilege Use' /success:enable /failure:enable",
       "check_duration": 0.0,
       "cis_reference": "CIS 17.1.1"
     },
@@ -373,7 +373,7 @@
       "description": "Checks whether NetBIOS over TCP/IP is disabled on all network adapters.",
       "details": "2 adapter(s) inherit NetBIOS setting from DHCP. If the DHCP server does not explicitly disable NetBIOS, it may be active.",
       "remediation": "Explicitly disable NetBIOS on all adapters rather than relying on DHCP.",
-      "command": "Get-CimInstance Win32_NetworkAdapterConfiguration -Filter 'IPEnabled=True' | ForEach-Object { Invoke-CimMethod -InputObject $_ -MethodName SetTcpipNetbios -Arguments @{ TcpipNetbiosOptions = 2 } | Out-Null }",
+      "command": "Get-CimInstance Win32_NetworkAdapterConfiguration -Filter 'IPEnabled=True' | ForEach-Object {\n    $r = Invoke-CimMethod -InputObject $_ -MethodName SetTcpipNetbios -Arguments @{ TcpipNetbiosOptions = 2 }\n    switch ($r.ReturnValue) {\n        0 { \"$($_.Description): NetBIOS disabled\" }\n        1 { Write-Warning \"$($_.Description): disabled, REBOOT REQUIRED\" }\n        default { Write-Warning \"$($_.Description): failed, ReturnValue=$($r.ReturnValue)\" }\n    }\n}",
       "check_duration": 0.0,
       "cis_reference": ""
     },


### PR DESCRIPTION
## Summary

Refreshes stale remediation content in the published sample reports:

- BitLocker recovery-password guidance — the published block created a recovery password without displaying or saving it, leaving nothing to provide at the recovery screen
- AutoPlay policy remediation — a bare `Set-ItemProperty` that fails outright when the `Policies\Explorer` key does not exist
- NetBIOS failure reporting — the WMI `ReturnValue`, that call's only failure signal, was discarded
- Audit Policy remediation — the command hardcoded `'Logon'` regardless of the finding, so a host missing only `Sensitive Privilege Use` got a command that ran cleanly and remediated nothing

The fixture, technical report, and executive report are updated together. The sample persona, findings, score, version, and scan date remain unchanged.

Audit Policy's `details` prose is refreshed alongside its command, since the sentence is authored in `misc.py` while only the observation inside it belongs to the machine. The observation is preserved: the sample still reports `Sensitive Privilege Use` as the disabled subcategory.

## Drift protection

The focused sample-report tests now verify that:

- fixture commands pass the shipped remediation lint;
- non-Audit fixture commands pass a whitespace-normalized membership check against the statically extracted source command inventory;
- fixture CIS references match `cis_map`; and
- the Audit Policy row is consistent, by equality on both halves.

The two halves of that last check are pinned by different means, which is worth stating precisely. The **command** is built from `misc._CMD_AUDITPOL_ENABLE`, so it stays tied to the source template. The **details prose is not source-linked** — it is an exact pin on this persona's finding, rejecting a subcategory that goes missing, one that is added, and one that is swapped for another. Equality rather than membership is what buys the last two; a membership test accepts a details line naming extra subcategories, and accepted the hardcoded `'Logon'` command this sample used to carry.

It is not a drift alarm for the details wording. Catching a reword that happens only in the source would mean executing the real check or exposing its sentence as a constant, and neither is in scope here.

## Scope

This PR intentionally contains only the sample-report refresh and its narrow drift checks. The later generation-framework, runtime-remediation, and command-audit experiments are preserved on `codex/pr-122-pre-rollback-729485f` for separate review.
