### PR TITLE
fix(checks): remediate what the finding reports, and stop replacing registry keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,68 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **The Audit Policy remediation now names the subcategories that are actually
+  disabled.** It emitted the literal `auditpol /set /subcategory:'Logon'`
+  regardless of the finding, while the finding itself listed whatever was
+  missing. On a host where only `Sensitive Privilege Use` had auditing off, the
+  operator pasted an elevated command that succeeded and changed nothing
+  relevant — then saw the same WARN on the next scan. It now emits one enable
+  line per confirmed-disabled subcategory, sorted so the command is stable
+  between scans.
+
+  Subcategories that `auditpol` never reported get no command at all. They were
+  not observed disabled — usually the name came back localized and this check
+  could not match it — and enabling auditing the operator never asked for is a
+  change they did not consent to. Those are called out for manual verification
+  instead, in wording kept distinct from the confirmed-disabled case.
+
+- **Registry policy values are written with `reg.exe`, not `New-Item -Force`.**
+  Four remediation commands — AutoPlay, LLMNR, script-block logging and module
+  logging — created their policy key first, across five create operations. On
+  the registry provider `-Force` *replaces* a key, deleting every value and
+  subkey under it, and `...\Policies\Explorer` is shared with
+  `NoRecentDocsHistory`, `NoActiveDesktop` and friends. Each create was wrapped
+  in `if (-not (Test-Path $key))`, which is not a fix: the test and the create
+  are two operations, so a key created in between by a Group Policy refresh, an
+  installer or another admin is replaced anyway. Measured on a live key — a
+  `-Force` create over a key holding a value drops that value.
+
+  Each command now makes a single `reg.exe add ... /v <Name> /t <type> /d <data> /f`
+  write. That creates any missing parents, touches only the named value, and
+  removes the create-then-set window entirely. `reg.exe` reports failure through
+  the exit code rather than a PowerShell error, so every write is followed by an
+  explicit `$LASTEXITCODE` check — without it a denied write is indistinguishable
+  from a successful one.
+
+  Two other forms were tried and rejected, both by measurement rather than
+  argument. Dropping `-Force` from `New-Item` cannot create a key whose parents
+  are missing, and a policy key is absent precisely when its parents are too.
+  `[Microsoft.Win32.Registry]::...CreateSubKey()` is refused by PowerShell
+  **Constrained Language Mode** — which Apotrope scores as a hardened PASS, so
+  it would have failed on exactly the machines the tool praises.
+
+  `tests/test_registry_create.py` runs each shipped command against a throwaway
+  `HKCU` key and asserts it creates missing parents, leaves an unrelated value,
+  the default value and a child subkey intact, runs under Constrained Language,
+  and surfaces a genuine failure. It also keeps the counter-example proving
+  `-Force` really does destroy neighbouring state.
+
+  Two lint rules changed. `unguarded-new-item-force` prescribed the racy
+  `Test-Path` form as its remedy; it is now `registry-new-item-force`, rejects
+  registry `New-Item -Force` outright, points at `reg.exe`, and no longer misses
+  a `-Force` carried onto the next line by a backtick continuation. A new
+  `constrained-language-method-call` rule rejects .NET method invocation in
+  remediation, so a command that cannot run on a hardened host fails the build
+  instead of shipping. Static property reads such as
+  `[System.Environment]::OSVersion.Version` remain allowed — Constrained
+  Language blocks the call, not the type.
+
+---
+
 ## [0.2.0] - 2026-07-27
 
 ### Security

--- a/src/apotrope/checks/misc.py
+++ b/src/apotrope/checks/misc.py
@@ -16,30 +16,51 @@ CATEGORY = "Hardening"
 # PowerShell snippets
 # ---------------------------------------------------------------------------
 
-_AUTOPLAY_KEY = "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer"
+_AUTOPLAY_SUBKEY = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer"
+_AUTOPLAY_KEY = "HKLM:\\" + _AUTOPLAY_SUBKEY
 _PS_AUTOPLAY = (
     f"$v = (Get-ItemProperty -LiteralPath '{_AUTOPLAY_KEY}' "
     "-ErrorAction SilentlyContinue).NoDriveTypeAutoRun; "
     "if ($null -eq $v) { 'NOTSET' } else { [string]$v }"
 )
-# Create the policy key first: Set-ItemProperty -Force does NOT create a missing
-# key, and the NOTSET finding fires precisely when that key is absent.
-# `Set-ItemProperty -Force` cannot create a missing key, so the NOTSET branch
-# genuinely needs a New-Item — but on the *registry* provider `New-Item -Force`
-# REPLACES an existing key, deleting every value and subkey under it. This key is
-# shared with unrelated Explorer policies (NoRecentDocsHistory, NoActiveDesktop,
-# ForceActiveDesktopOn, ...), and the two other branches that emit this command
-# are only reachable when a value was read back, i.e. when the key already
-# exists. Unguarded, the paste would destroy those neighbouring policies.
+# Create the policy key first: `Set-ItemProperty -Force` cannot create a missing
+# key, and the NOTSET finding fires precisely when that key is absent — so the
+# NOTSET branch genuinely needs a New-Item.
+#
+# `reg.exe add` writes the value and creates whatever parents are missing, in
+# one operation. Four things ruled out the alternatives, each measured rather
+# than reasoned about:
+#
+#   New-Item -Force            on the registry provider REPLACES the key,
+#                              deleting every value and subkey under it. This
+#                              key is shared with unrelated Explorer policies
+#                              (NoRecentDocsHistory, NoActiveDesktop, ...).
+#   ... behind a Test-Path     still replaces: the test and the create are two
+#                              operations, and a key created in between by a
+#                              GPO refresh or an installer is destroyed anyway.
+#   New-Item without -Force    cannot create a key whose parents are missing —
+#                              and a policy key is absent exactly when its
+#                              parents are too.
+#   [Registry]::...CreateSubKey  blocked by PowerShell Constrained Language
+#                              Mode, which Apotrope itself scores as a hardened
+#                              PASS. It would fail on the machines we praise.
+#
+# reg.exe is a native executable, so Constrained Language permits it; it creates
+# the full path; and writing the value directly leaves no create/set window.
+# Verified against a live key: an unrelated value, the default value and a child
+# subkey all survive a repeat `reg add`.
+#
+# reg.exe reports failure through the exit code, not a PowerShell error, so the
+# check below is the only thing standing between a denied write and a clean
+# prompt.
 #
 # Kept as one module-level string so tools/command_audit.py still resolves it
 # statically; a wrapper it cannot resolve collapses the command to "{expr}" and
 # drops it from the lint inventory.
 _CMD_AUTOPLAY_DISABLE = (
-    f"if (-not (Test-Path '{_AUTOPLAY_KEY}')) "
-    f"{{ New-Item -Path '{_AUTOPLAY_KEY}' -Force | Out-Null }}\n"
-    f"Set-ItemProperty -Path '{_AUTOPLAY_KEY}' -Name NoDriveTypeAutoRun -Value 255 "
-    "-Type DWord -Force"
+    f'reg.exe add "HKLM\\{_AUTOPLAY_SUBKEY}" /v NoDriveTypeAutoRun '
+    "/t REG_DWORD /d 255 /f\n"
+    'if ($LASTEXITCODE -ne 0) { throw "reg.exe add failed ($LASTEXITCODE)" }'
 )
 
 # The five security-relevant audit subcategories Apotrope requires (order fixed
@@ -47,6 +68,18 @@ _CMD_AUTOPLAY_DISABLE = (
 _EXPECTED_AUDIT = (
     "Logon", "Account Lockout", "Logoff",
     "Credential Validation", "Sensitive Privilege Use",
+)
+
+# One enable line, expanded per confirmed-disabled subcategory at scan time.
+# Subcategory names contain spaces, so each is single-quoted.
+#
+# This lives at module level under the `_CMD_` prefix on purpose:
+# tools/command_audit.py collects those constants directly, so the template is
+# linted and PowerShell-parsed even though the emitted command is assembled
+# with a join it cannot resolve statically. Inline the format string into
+# _check_audit_policy and the command leaves the inventory entirely.
+_CMD_AUDITPOL_ENABLE = (
+    "auditpol /set /subcategory:'{subcategory}' /success:enable /failure:enable"
 )
 
 # Machine-wide inactivity lock policy (applies even without a per-user screensaver).
@@ -371,6 +404,39 @@ def _check_audit_policy() -> list[CheckResult]:
 
     if no_audit or missing:
         problem = no_audit + [f"{name} (not reported)" for name in missing]
+
+        # One line per subcategory this scan actually confirmed disabled. The
+        # command previously hardcoded 'Logon' regardless of the finding, so a
+        # host missing only 'Sensitive Privilege Use' got a command that ran
+        # cleanly and remediated nothing.
+        #
+        # Only `no_audit` is enabled. A subcategory auditpol never reported was
+        # not observed disabled — it is usually a localized name this check
+        # could not match — and turning on auditing the operator never asked
+        # for is a change they did not consent to. Those are called out for
+        # manual verification instead.
+        enable = "\n".join(
+            _CMD_AUDITPOL_ENABLE.format(subcategory=name) for name in sorted(no_audit)
+        )
+
+        if no_audit and missing:
+            fix = (
+                "Enable audit logging for the subcategories confirmed disabled, and "
+                f"verify the ones this scan could not read back ({', '.join(missing)}) "
+                "by hand — they may be localized under different names."
+            )
+        elif no_audit:
+            fix = (
+                "Enable audit logging for the subcategories confirmed disabled so "
+                "security-relevant events are recorded."
+            )
+        else:
+            fix = (
+                "Verify these subcategories by hand — this scan could not read them "
+                "back, which usually means auditpol reported them under localized "
+                "names rather than that auditing is off."
+            )
+
         return [CheckResult(
             category=CATEGORY,
             check_name="Audit Policy",
@@ -382,11 +448,10 @@ def _check_audit_policy() -> list[CheckResult]:
                 f"{', '.join(problem)}. Security-relevant events may not be recorded."
             ),
             remediation=(
-                "Enable audit logging for the listed subcategories so security-relevant "
-                "events are recorded. This can also be configured via Group Policy "
+                f"{fix} This can also be configured via Group Policy "
                 "(secpol.msc → Advanced Audit Policy Configuration)."
             ),
-            command="auditpol /set /subcategory:'Logon' /success:enable /failure:enable",
+            command=enable,
         )]
 
     return [CheckResult(

--- a/src/apotrope/checks/network.py
+++ b/src/apotrope/checks/network.py
@@ -237,9 +237,14 @@ def _check_llmnr() -> list[CheckResult]:
             ),
             remediation="Disable LLMNR to block Responder-style name-resolution poisoning.",
             command=(
-                "$key = 'HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\DNSClient'\n"
-                "if (-not (Test-Path $key)) { New-Item -Path $key -Force | Out-Null }\n"
-                "Set-ItemProperty -Path $key -Name 'EnableMulticast' -Value 0"
+                # reg.exe writes the value and creates the missing parents in one
+                # step. New-Item -Force would replace the key and delete its
+                # values; without -Force it cannot create the parents; and a
+                # [Registry]::...CreateSubKey() call is blocked under Constrained
+                # Language Mode. See misc.py for the full comparison.
+                'reg.exe add "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\DNSClient" '
+                "/v EnableMulticast /t REG_DWORD /d 0 /f\n"
+                'if ($LASTEXITCODE -ne 0) { throw "reg.exe add failed ($LASTEXITCODE)" }'
             ),
         )]
 

--- a/src/apotrope/checks/powershell.py
+++ b/src/apotrope/checks/powershell.py
@@ -17,14 +17,16 @@ _RISKY_POLICIES = {"unrestricted", "bypass"}
 
 _PS_EXEC_POLICY = "Get-ExecutionPolicy -Scope LocalMachine"
 
-_SBL_KEY = "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\PowerShell\\ScriptBlockLogging"
+_SBL_SUBKEY = "SOFTWARE\\Policies\\Microsoft\\Windows\\PowerShell\\ScriptBlockLogging"
+_SBL_KEY = "HKLM:\\" + _SBL_SUBKEY
 _PS_SBL = (
     f"$v = (Get-ItemProperty -LiteralPath '{_SBL_KEY}' "
     "-ErrorAction SilentlyContinue).EnableScriptBlockLogging; "
     "if ($null -eq $v) { 'NOTSET' } else { [string]$v }"
 )
 
-_ML_KEY = "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\PowerShell\\ModuleLogging"
+_ML_SUBKEY = "SOFTWARE\\Policies\\Microsoft\\Windows\\PowerShell\\ModuleLogging"
+_ML_KEY = "HKLM:\\" + _ML_SUBKEY
 _PS_ML = (
     f"$v = (Get-ItemProperty -LiteralPath '{_ML_KEY}' "
     "-ErrorAction SilentlyContinue).EnableModuleLogging; "
@@ -116,9 +118,12 @@ def _check_script_block_logging() -> list[CheckResult]:
         ),
         command=(
             "" if enabled else
-            f"$key = '{_SBL_KEY}'\n"
-            "if (-not (Test-Path $key)) { New-Item -Path $key -Force | Out-Null }\n"
-            "Set-ItemProperty -Path $key -Name 'EnableScriptBlockLogging' -Value 1 -Type DWord"
+            # reg.exe writes the value and creates the missing parents in one
+            # step, and works under Constrained Language Mode where a
+            # [Registry]::...CreateSubKey() call does not. See misc.py.
+            f'reg.exe add "HKLM\\{_SBL_SUBKEY}" /v EnableScriptBlockLogging '
+            "/t REG_DWORD /d 1 /f\n"
+            'if ($LASTEXITCODE -ne 0) { throw "reg.exe add failed ($LASTEXITCODE)" }'
         ),
     )]
 
@@ -150,12 +155,15 @@ def _check_module_logging() -> list[CheckResult]:
         ),
         command=(
             "" if enabled else
-            f"$key = '{_ML_KEY}'\n"
-            "if (-not (Test-Path $key)) { New-Item -Path $key -Force | Out-Null }\n"
-            "Set-ItemProperty -Path $key -Name 'EnableModuleLogging' -Value 1 -Type DWord\n"
-            "if (-not (Test-Path \"$key\\ModuleNames\")) "
-            "{ New-Item -Path \"$key\\ModuleNames\" -Force | Out-Null }\n"
-            "Set-ItemProperty -Path \"$key\\ModuleNames\" -Name '*' -Value '*'"
+            # Two writes: the policy flag, then the wildcard under ModuleNames
+            # that selects every module. Each is checked on its own, so a failure
+            # on the first does not leave the second reporting success. See
+            # misc.py for why this is reg.exe and not New-Item.
+            f'reg.exe add "HKLM\\{_ML_SUBKEY}" /v EnableModuleLogging '
+            "/t REG_DWORD /d 1 /f\n"
+            'if ($LASTEXITCODE -ne 0) { throw "reg.exe add failed ($LASTEXITCODE)" }\n'
+            f'reg.exe add "HKLM\\{_ML_SUBKEY}\\ModuleNames" /v "*" /t REG_SZ /d "*" /f\n'
+            'if ($LASTEXITCODE -ne 0) { throw "reg.exe add failed ($LASTEXITCODE)" }'
         ),
     )]
 

--- a/tests/test_checks/test_misc.py
+++ b/tests/test_checks/test_misc.py
@@ -168,6 +168,83 @@ class TestCheckAuditPolicy:
             r = misc._check_audit_policy()[0]
         assert r.status == Status.ERROR
 
+    # -- the command must remediate the finding it reports -------------------
+    #
+    # It used to be the literal `auditpol /set /subcategory:'Logon' ...` no
+    # matter which subcategory was disabled, so a host missing only 'Sensitive
+    # Privilege Use' got a command that ran cleanly and fixed nothing.
+
+    def _all_auditing_except(self, disabled=(), omitted=()):
+        return [
+            self._entry(name, "No Auditing" if name in disabled else "Success and Failure")
+            for name in misc._EXPECTED_AUDIT
+            if name not in omitted
+        ]
+
+    def test_command_names_the_disabled_subcategory(self):
+        r = self._run(self._all_auditing_except(disabled=["Sensitive Privilege Use"]))[0]
+        assert "Sensitive Privilege Use" in r.command
+        assert "Logon" not in r.command, "the old hardcoded subcategory is back"
+        assert r.command.count("auditpol") == 1
+
+    def test_subcategory_names_are_quoted_as_one_argument(self):
+        # Every auditpol subcategory name contains spaces. Unquoted,
+        # `/subcategory:Sensitive Privilege Use` parses fine as PowerShell and
+        # reaches auditpol as three arguments, so verify_commands.py's parser
+        # cannot catch this — only an assertion on the exact text can.
+        r = self._run(self._all_auditing_except(disabled=["Sensitive Privilege Use"]))[0]
+        assert (
+            "/subcategory:'Sensitive Privilege Use'" in r.command
+        ), f"subcategory not quoted as a single argument: {r.command!r}"
+
+    def test_command_covers_every_disabled_subcategory_in_order(self):
+        disabled = ["Sensitive Privilege Use", "Logoff"]
+        r = self._run(self._all_auditing_except(disabled=disabled))[0]
+
+        lines = r.command.splitlines()
+        assert len(lines) == 2, f"expected one line per disabled subcategory, got {lines}"
+        # Sorted, so the emitted command is stable across scans.
+        assert lines == sorted(lines)
+        for name in disabled:
+            assert sum(f"'{name}'" in ln for ln in lines) == 1, f"{name} missing or duplicated"
+
+    def test_unreported_subcategories_get_no_command(self):
+        # auditpol never reported it — usually a localized name this check could
+        # not match. Enabling auditing the operator never asked for is a change
+        # they did not consent to, so this is verification guidance, not a fix.
+        r = self._run(self._all_auditing_except(omitted=["Logon"]))[0]
+        assert r.status == Status.WARN
+        assert r.command == ""
+        assert "verify" in r.remediation.lower()
+
+    def test_mixed_targets_only_the_confirmed_disabled(self):
+        r = self._run(self._all_auditing_except(
+            disabled=["Sensitive Privilege Use"], omitted=["Logon"],
+        ))[0]
+        assert "Sensitive Privilege Use" in r.command
+        assert "Logon" not in r.command
+        assert "Logon" in r.details and "not reported" in r.details
+        assert "Logon" in r.remediation
+
+    def test_pass_branch_still_emits_nothing(self):
+        r = self._run([self._entry(name) for name in misc._EXPECTED_AUDIT])[0]
+        assert r.command == "" and r.remediation == ""
+
+    def test_emitted_command_clears_the_shipped_lint(self):
+        import sys
+        from pathlib import Path
+
+        sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+        import command_audit
+
+        r = self._run(self._all_auditing_except(
+            disabled=["Sensitive Privilege Use", "Credential Validation"],
+        ))[0]
+        violations = command_audit.lint_commands(
+            [command_audit.Command(module="misc.py", line=0, text=r.command)]
+        )
+        assert violations == [], violations
+
 
 # ---------------------------------------------------------------------------
 # _check_screen_lock
@@ -288,33 +365,58 @@ class TestScreenLockPayloadShapes:
 
 
 class TestMiscFixes:
-    def test_autoplay_command_creates_key(self):
-        # Set-ItemProperty -Force does not create a missing key; the command must
-        # New-Item it first (the NOTSET finding fires when the key is absent).
+    def test_autoplay_command_writes_the_value(self):
+        # `Set-ItemProperty` cannot create a missing key, and the NOTSET finding
+        # fires exactly when the key is absent. reg.exe writes the value and
+        # creates the parents in one step.
         with patch("apotrope.checks.misc.run_powershell", return_value="NOTSET"):
             r = misc._check_autoplay()[0]
-        assert "New-Item" in r.command
 
-    def test_autoplay_new_item_is_guarded_by_test_path(self):
-        # `New-Item -Force` on the registry provider REPLACES an existing key,
-        # deleting the unrelated Explorer policies that share it. Assert the
-        # guard wraps the New-Item rather than merely appearing somewhere in the
-        # block — an unguarded create on a later line would still be destructive.
+        assert "reg.exe add" in r.command
+        assert "/v NoDriveTypeAutoRun" in r.command
+        assert "/t REG_DWORD" in r.command and "/d 255" in r.command
+
+    def test_autoplay_uses_no_form_that_destroys_or_cannot_run(self):
+        # Three forms are ruled out, each measured: New-Item -Force replaces the
+        # key and deletes the unrelated Explorer policies sharing it (a Test-Path
+        # guard does not fix that, since the test and the create are separate);
+        # New-Item without -Force cannot create the missing parents; and a .NET
+        # method call is refused under Constrained Language Mode, which Apotrope
+        # scores as a hardened PASS.
         with patch("apotrope.checks.misc.run_powershell", return_value="NOTSET"):
             r = misc._check_autoplay()[0]
-        guard = r.command.splitlines()[0]
-        assert guard.startswith("if (-not (Test-Path ")
-        assert "New-Item" in guard
-        assert "New-Item" not in "\n".join(r.command.splitlines()[1:])
 
-    def test_autoplay_remediation_guarded_on_every_branch(self):
+        assert "New-Item" not in r.command
+        assert "]::" not in r.command, "a .NET call cannot run under Constrained Language"
+
+    def test_autoplay_command_targets_the_reg_exe_hive_form(self):
+        # reg.exe takes "HKLM\..." — the "HKLM:\..." provider form would be read
+        # as a key literally named "HKLM:".
+        with patch("apotrope.checks.misc.run_powershell", return_value="NOTSET"):
+            r = misc._check_autoplay()[0]
+
+        add = next(ln for ln in r.command.splitlines() if "reg.exe add" in ln)
+        assert "HKLM:" not in add, f"provider-form path passed to reg.exe: {add}"
+        assert f'"HKLM\\{misc._AUTOPLAY_SUBKEY}"' in add
+
+    def test_autoplay_checks_the_exit_code(self):
+        # reg.exe reports failure through the exit code, not a PowerShell error,
+        # so without this a denied write looks exactly like a successful one.
+        with patch("apotrope.checks.misc.run_powershell", return_value="NOTSET"):
+            r = misc._check_autoplay()[0]
+
+        assert "$LASTEXITCODE" in r.command and "throw" in r.command
+
+    def test_autoplay_remediation_is_safe_on_every_branch(self):
         # 158 -> "partially disabled" WARN; 0 and an unparseable value -> the
         # AutoPlay-enabled branch. Both read a value back, so the key provably
-        # exists — precisely the case an unguarded New-Item -Force would wipe.
+        # exists — precisely the case a -Force create would wipe.
         for output in ("158", "0", "notanint"):
             with patch("apotrope.checks.misc.run_powershell", return_value=output):
                 r = misc._check_autoplay()[0]
-            assert "Test-Path" in r.command, f"unguarded New-Item for output {output!r}"
+            assert "reg.exe add" in r.command, f"no write for output {output!r}"
+            assert "New-Item" not in r.command, f"New-Item returned for output {output!r}"
+            assert "]::" not in r.command, f"a .NET call returned for output {output!r}"
 
     def test_machine_inactivity_policy_is_pass(self):
         # A machine-wide inactivity lock counts even without a per-user screensaver.

--- a/tests/test_registry_create.py
+++ b/tests/test_registry_create.py
@@ -1,0 +1,157 @@
+"""Guard: the shipped registry writes behave, and run where operators run them.
+
+``tools/verify_commands.py`` parses every remediation command and resolves the
+cmdlets it invokes — it proves nothing about what those cmdlets *do*, and
+nothing about the language mode they need. Both gaps have bitten this command:
+
+* ``New-Item -Force`` parses perfectly and silently deletes a shared policy key.
+* ``[Registry]::…CreateSubKey()`` parses perfectly and is refused outright by
+  Constrained Language Mode — which Apotrope itself scores as a hardened PASS.
+
+These tests run the **real command text** against a throwaway ``HKCU`` path,
+with only the hive and key retargeted. Windows-only, and they reach a real
+PowerShell — hence ``allow_subprocess``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import uuid
+
+import pytest
+
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parents[1] / "tools"))
+
+from command_audit import collect_commands
+
+pytestmark = [
+    pytest.mark.skipif(sys.platform != "win32", reason="registry semantics are Windows-only"),
+    pytest.mark.allow_subprocess,
+]
+
+#: Every shipped command that writes a registry value, by (module, first key path).
+REGISTRY_COMMANDS = [
+    pytest.param(c.text, id=f"{c.module}:{c.line}")
+    for c in collect_commands()
+    if "reg.exe add" in c.text
+]
+
+
+def _powershell(script: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script],
+        capture_output=True, text=True, check=False,
+    )
+
+
+def _retarget(command: str, root: str) -> str:
+    """The shipped command with its hive and path swapped for a throwaway one.
+
+    Only ``"HKLM\\`` is rewritten, so the value names, types, data and the
+    exit-code checks are exactly what ships.
+    """
+    return command.replace('"HKLM\\', f'"HKCU\\{root}\\')
+
+
+@pytest.fixture
+def temp_root():
+    root = f"Software\\ApotropeTest\\{uuid.uuid4().hex}"
+    try:
+        yield root
+    finally:
+        _powershell(
+            f"Remove-Item -Path 'HKCU:\\{root}' -Recurse -Force -ErrorAction SilentlyContinue"
+        )
+
+
+def test_every_registry_command_was_collected():
+    # Four commands, five writes. If this drops to zero the whole module is
+    # asserting nothing.
+    assert len(REGISTRY_COMMANDS) == 4, REGISTRY_COMMANDS
+
+
+@pytest.mark.parametrize("command", REGISTRY_COMMANDS)
+def test_writes_value_and_creates_missing_parents(command, temp_root):
+    # The parents genuinely do not exist: a policy key is absent exactly when
+    # its parents are. `New-Item` without -Force fails outright here, which is
+    # why simply dropping -Force was not a fix.
+    result = _powershell(_retarget(command, temp_root))
+    assert result.returncode == 0, result.stderr
+    assert _powershell(f"Test-Path 'HKCU:\\{temp_root}'").stdout.strip() == "True"
+
+
+@pytest.mark.parametrize("command", REGISTRY_COMMANDS)
+def test_runs_under_constrained_language_mode(command, temp_root):
+    # Apotrope scores a Constrained Language machine as a hardened PASS. A
+    # remediation that needs full language fails on the hosts it just praised —
+    # which is what [Registry]::…CreateSubKey() did.
+    script = (
+        "$ExecutionContext.SessionState.LanguageMode = 'ConstrainedLanguage'\n"
+        + _retarget(command, temp_root)
+    )
+    result = _powershell(script)
+    assert result.returncode == 0, (
+        f"blocked under ConstrainedLanguage:\n{result.stderr}"
+    )
+
+
+@pytest.mark.parametrize("command", REGISTRY_COMMANDS)
+def test_neighbouring_state_survives(command, temp_root):
+    # -Force would delete all three of these. They stand in for the unrelated
+    # Explorer policies (NoRecentDocsHistory, NoActiveDesktop, ...) that share
+    # the AutoPlay key.
+    key = f"HKCU:\\{temp_root}"
+    assert _powershell(_retarget(command, temp_root)).returncode == 0
+
+    seed = (
+        f"Set-ItemProperty -Path '{key}' -Name Neighbour -Value 'keepme'\n"
+        f"Set-ItemProperty -Path '{key}' -Name '(default)' -Value 'defaultkeep'\n"
+        f"New-Item -Path '{key}\\ChildKey' -Force | Out-Null\n"
+        f"Set-ItemProperty -Path '{key}\\ChildKey' -Name Inner -Value 'innerkeep'"
+    )
+    assert _powershell(seed).returncode == 0
+
+    # Run it a second time, over the now-populated key.
+    assert _powershell(_retarget(command, temp_root)).returncode == 0
+
+    probe = _powershell(
+        f"$p = Get-ItemProperty '{key}'\n"
+        f"$c = Get-ItemProperty '{key}\\ChildKey' -ErrorAction SilentlyContinue\n"
+        "$p.Neighbour; $p.'(default)'; $c.Inner"
+    )
+    assert probe.stdout.split() == ["keepme", "defaultkeep", "innerkeep"], (
+        f"the write destroyed neighbouring state: {probe.stdout!r}"
+    )
+
+
+def test_new_item_force_would_have_destroyed_them(temp_root):
+    # The counter-example, so the test above cannot pass vacuously: the form
+    # this command used to ship really does delete neighbouring state.
+    key = f"HKCU:\\{temp_root}\\Probe"
+    setup = (
+        f"New-Item -Path '{key}' -Force | Out-Null\n"
+        f"Set-ItemProperty -Path '{key}' -Name Neighbour -Value 'keepme'"
+    )
+    assert _powershell(setup).returncode == 0
+
+    result = _powershell(
+        f"New-Item -Path '{key}' -Force | Out-Null\n"
+        f"$v = (Get-ItemProperty -Path '{key}' -ErrorAction SilentlyContinue).Neighbour\n"
+        "if ($null -eq $v) { 'GONE' } else { $v }"
+    )
+    assert result.stdout.strip() == "GONE", (
+        "New-Item -Force preserved the value — the premise of this fix no longer holds"
+    )
+
+
+@pytest.mark.parametrize("command", REGISTRY_COMMANDS)
+def test_a_real_failure_is_not_swallowed(command):
+    # An invalid root fails identically for every identity and cannot mutate any
+    # hive. Targeting a real-but-protected key such as HKLM:\SECURITY would
+    # succeed under LocalSystem and leave a machine-wide key behind.
+    result = _powershell(command.replace('"HKLM\\', '"HKXX\\'))
+    assert result.returncode != 0, "a failed write exited 0"
+    assert "reg.exe add failed" in (result.stderr + result.stdout), (
+        "the exit-code check did not fire; a denied write would look like success"
+    )

--- a/tests/test_remediation_commands.py
+++ b/tests/test_remediation_commands.py
@@ -166,29 +166,54 @@ class TestDestructiveRuleCoversMoreThanReboots:
             ], safe
 
 
-class TestUnguardedNewItemForceRule:
+class TestRegistryNewItemForceRule:
     """`New-Item -Force` on the registry provider REPLACES the key.
 
     It deletes every value and subkey underneath. On a shared policy container
     that means destroying unrelated policy the operator never asked to touch.
+
+    A `Test-Path` guard used to clear this rule. It no longer does: the test and
+    the create are two operations, so a key created in the window between them
+    is still replaced, losing exactly the values the guard existed to protect.
     """
 
     _REG = r"$key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Foo'" + "\n"
 
     def test_unguarded_registry_new_item_is_flagged(self) -> None:
         planted = [Command("fake.py", 1, self._REG + "New-Item -Path $key -Force | Out-Null")]
-        assert [v for v in lint_commands(planted) if v.rule == "unguarded-new-item-force"]
+        assert [v for v in lint_commands(planted) if v.rule == "registry-new-item-force"]
 
-    def test_test_path_guard_clears_it(self) -> None:
+    def test_test_path_guard_no_longer_clears_it(self) -> None:
+        # The racy form the rule used to prescribe.
         planted = [Command(
             "fake.py", 1,
             self._REG + "if (-not (Test-Path $key)) { New-Item -Path $key -Force | Out-Null }",
         )]
-        assert not [v for v in lint_commands(planted) if v.rule == "unguarded-new-item-force"]
+        assert [v for v in lint_commands(planted) if v.rule == "registry-new-item-force"]
+
+    def test_backtick_continuation_does_not_hide_force(self) -> None:
+        # A trailing backtick continues the statement onto the next physical
+        # line. A per-line rule that stops at the newline never sees the -Force.
+        planted = [Command(
+            "fake.py", 1,
+            self._REG + "New-Item -Path $key `\n  -Force | Out-Null",
+        )]
+        assert [v for v in lint_commands(planted) if v.rule == "registry-new-item-force"]
+
+    def test_reg_exe_add_is_accepted(self) -> None:
+        # The prescribed remedy: writes the value, creates missing parents,
+        # touches nothing else, and runs under Constrained Language Mode.
+        planted = [Command(
+            "fake.py", 1,
+            'reg.exe add "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows\\Foo" '
+            "/v Enabled /t REG_DWORD /d 1 /f\n"
+            'if ($LASTEXITCODE -ne 0) { throw "reg.exe add failed ($LASTEXITCODE)" }',
+        )]
+        assert not lint_commands(planted)
 
     def test_commented_new_item_is_not_flagged(self) -> None:
         planted = [Command("fake.py", 1, self._REG + "# New-Item -Path $key -Force")]
-        assert not [v for v in lint_commands(planted) if v.rule == "unguarded-new-item-force"]
+        assert not [v for v in lint_commands(planted) if v.rule == "registry-new-item-force"]
 
     def test_filesystem_new_item_is_not_flagged(self) -> None:
         # On the filesystem provider -Force creates parents; that is the
@@ -196,14 +221,48 @@ class TestUnguardedNewItemForceRule:
         planted = [Command(
             "fake.py", 1, r'New-Item -Path "$env:TEMP\apotrope" -ItemType Directory -Force',
         )]
-        assert not [v for v in lint_commands(planted) if v.rule == "unguarded-new-item-force"]
+        assert not [v for v in lint_commands(planted) if v.rule == "registry-new-item-force"]
 
-    def test_every_shipped_registry_create_is_guarded(self) -> None:
-        # The real inventory, not a planted case: this is what would have caught
-        # the AutoPlay block before it shipped.
+    def test_no_shipped_command_creates_a_registry_key_with_new_item(self) -> None:
+        # The real inventory, not a planted case.
         violations = [
             v for v in lint_commands(collect_commands())
-            if v.rule == "unguarded-new-item-force"
+            if v.rule == "registry-new-item-force"
+        ]
+        assert not violations, [f"{v.module}:{v.line}" for v in violations]
+
+
+class TestConstrainedLanguageRule:
+    """Constrained Language Mode refuses .NET method invocation.
+
+    Apotrope scores a machine in Constrained Language as a hardened PASS, so a
+    remediation needing full language fails on exactly the hosts it praised.
+    Static property reads remain legal — the distinction is the call, not the
+    type: even `[Math]::Floor(1.5)` is refused, while
+    `[System.Environment]::OSVersion.Version` is fine.
+    """
+
+    def test_method_call_is_flagged(self) -> None:
+        planted = [Command(
+            "fake.py", 1,
+            r"[void][Microsoft.Win32.Registry]::LocalMachine.CreateSubKey('SOFTWARE\Foo')",
+        )]
+        assert [v for v in lint_commands(planted)
+                if v.rule == "constrained-language-method-call"]
+
+    def test_static_property_read_is_not_flagged(self) -> None:
+        planted = [Command("fake.py", 1, "$v = [System.Environment]::OSVersion.Version")]
+        assert not [v for v in lint_commands(planted)
+                    if v.rule == "constrained-language-method-call"]
+
+    def test_commented_method_call_is_not_flagged(self) -> None:
+        planted = [Command("fake.py", 1, "# [System.IO.File]::ReadAllText('x')")]
+        assert not lint_commands(planted)
+
+    def test_no_shipped_command_invokes_a_dotnet_method(self) -> None:
+        violations = [
+            v for v in lint_commands(collect_commands())
+            if v.rule == "constrained-language-method-call"
         ]
         assert not violations, [f"{v.module}:{v.line}" for v in violations]
 

--- a/tools/command_audit.py
+++ b/tools/command_audit.py
@@ -154,6 +154,26 @@ def collect_commands() -> list[Command]:
                     if isinstance(tgt, ast.Name) and tgt.id == "command":
                         exprs.append(node.value)
 
+        # Module-level `_CMD_*` constants are inventory members in their own
+        # right, whether or not a `command=` reference resolves back to them.
+        # A check that assembles its command at runtime — Audit Policy expands
+        # one line per confirmed-disabled subcategory — would otherwise drop out
+        # of the inventory entirely and ship unlinted and unparsed. Declaring the
+        # template under this name keeps one representative form in scope.
+        # Every existing `_CMD_*` is already reachable through a `command=`
+        # reference, and collection dedupes on (module, text), so this adds no
+        # duplicates.
+        for node in tree.body:
+            target: str | None = None
+            value: ast.expr | None = None
+            if isinstance(node, ast.Assign) and len(node.targets) == 1:
+                if isinstance(node.targets[0], ast.Name):
+                    target, value = node.targets[0].id, node.value
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                target, value = node.target.id, node.value
+            if target is not None and value is not None and target.startswith("_CMD_"):
+                exprs.append(value)
+
         for expr in exprs:
             for text in _resolve_branches(expr, consts):
                 if not text or not text.strip():
@@ -203,12 +223,45 @@ _DESTRUCTIVE = re.compile(
 # absent and destructive for a shared policy container — ...\Policies\Explorer
 # carries NoRecentDocsHistory, NoActiveDesktop and friends alongside the value
 # being set. `Set-ItemProperty -Force` cannot create a missing key, so the
-# New-Item is legitimate; it just has to be guarded by a Test-Path.
+# New-Item is legitimate — but `-Force` on it never is.
+#
+# A `Test-Path` guard is NOT an acceptable remedy, and this rule used to accept
+# one. The test and the create are two operations: anything that creates the key
+# in the window between them — a Group Policy refresh, an installer, another
+# admin — is then replaced, losing exactly the values the guard existed to
+# protect.
+#
+# Dropping -Force is no good either: on the registry provider New-Item cannot
+# create a key whose parents are missing, and a policy key is absent precisely
+# when its parents are too. Write the value with reg.exe instead, which creates
+# the parents, touches only the named value, needs no separate create step, and
+# runs under Constrained Language Mode:
+#
+#     reg.exe add "HKLM\<path>" /v <Name> /t REG_DWORD /d <n> /f
+#     if ($LASTEXITCODE -ne 0) { throw "reg.exe add failed ($LASTEXITCODE)" }
+#
+# reg.exe signals failure through the exit code, not a PowerShell error, so the
+# check is what stops a denied write looking identical to a successful one.
 #
 # Filesystem New-Item is NOT flagged — there `-Force` creates parents and
 # overwrites a file, which is the documented, expected behaviour. The registry
 # gate below keys off the hive reference in the surrounding command.
-_NEW_ITEM_FORCE = re.compile(r"\bNew-Item\b[^\n]*?-Force\b", re.IGNORECASE)
+#
+# `[^\n]` would let a backtick line continuation carry -Force onto the next
+# physical line and slip past; continuations are folded out before matching.
+_NEW_ITEM_FORCE = re.compile(r"\bNew-Item\b.*?-Force\b", re.IGNORECASE | re.DOTALL)
+
+# PowerShell Constrained Language Mode blocks .NET *method invocation* — the
+# error is MethodInvocationNotSupportedInConstrainedLanguage — while still
+# permitting static property reads, so `[System.Environment]::OSVersion.Version`
+# is fine and `[Microsoft.Win32.Registry]::LocalMachine.CreateSubKey(...)` is
+# not. Both were measured; the distinction is the call, not the type, and even
+# `[Math]::Floor(1.5)` is refused.
+#
+# This matters more here than in ordinary code: Apotrope scores a machine in
+# Constrained Language as a hardened PASS, so remediation that needs full
+# language fails on exactly the hosts the tool has just praised.
+_CLM_METHOD_CALL = re.compile(r"\[[\w.]+\]::[\w.]*\w+\s*\(")
 
 # A BitLocker recovery password the operator never sees is worse than no
 # encryption advice at all. Enable-BitLocker / Add-BitLockerKeyProtector return a
@@ -284,7 +337,6 @@ _SURFACES_RECOVERY_PASSWORD = re.compile(
     r"|\bmanage-bde\b[^\n]*-protectors\b",
     re.IGNORECASE,
 )
-_TEST_PATH_GUARD = re.compile(r"^\s*if\s*\(\s*-not\s*\(\s*Test-Path\b", re.IGNORECASE)
 _REGISTRY_HIVE = re.compile(r"\b(?:HKLM|HKCU|HKCR|HKU|HKCC)\s*:|Registry::|\bHKEY_", re.IGNORECASE)
 # -DisplayGroup selects an EXISTING firewall rule by its resolved MUI string
 # ('Remote Desktop' is @FirewallAPI.dll,-28752 rendered in the display
@@ -309,6 +361,18 @@ _UNRESOLVED_EXPR = re.compile(r"\{expr\}")
 
 def _uncommented_lines(text: str) -> list[str]:
     return [ln for ln in text.splitlines() if not ln.lstrip().startswith("#")]
+
+
+# A trailing backtick continues a PowerShell statement onto the next physical
+# line, so `New-Item -Path $k `\n  -Force` is one command wearing two lines.
+# Per-line rules must see the joined statement or a continuation hides the
+# argument they exist to find.
+_CONTINUATION = re.compile(r"`[ \t]*\r?\n[ \t]*")
+
+
+def _logical_lines(text: str) -> list[str]:
+    """Uncommented lines with backtick continuations folded into one line each."""
+    return _uncommented_lines(_CONTINUATION.sub(" ", text))
 
 
 def lint_commands(commands: list[Command]) -> list[Violation]:
@@ -389,6 +453,19 @@ def lint_commands(commands: list[Command]) -> list[Violation]:
                 "after a step that shows the current membership and `whoami`",
                 text,
             ))
+        for line in _logical_lines(text):
+            if _CLM_METHOD_CALL.search(line):
+                violations.append(Violation(
+                    cmd.module, cmd.line, "constrained-language-method-call",
+                    "invokes a .NET method, which PowerShell Constrained Language Mode "
+                    "refuses (MethodInvocationNotSupportedInConstrainedLanguage). "
+                    "Apotrope scores a machine in Constrained Language as a hardened "
+                    "PASS, so this fails on exactly the hosts it has just praised. Use "
+                    "a cmdlet or a native tool such as reg.exe. Static property reads "
+                    "like [System.Environment]::OSVersion.Version are still fine",
+                    text,
+                ))
+                break
         if _REGISTRY_HIVE.search(active):
             for line in _uncommented_lines(text):
                 if _SILENCED_REGISTRY_MUTATION.search(line):
@@ -401,13 +478,17 @@ def lint_commands(commands: list[Command]) -> list[Violation]:
                         text,
                     ))
                     break
-            for line in _uncommented_lines(text):
-                if _NEW_ITEM_FORCE.search(line) and not _TEST_PATH_GUARD.match(line):
+            for line in _logical_lines(text):
+                if _NEW_ITEM_FORCE.search(line):
                     violations.append(Violation(
-                        cmd.module, cmd.line, "unguarded-new-item-force",
+                        cmd.module, cmd.line, "registry-new-item-force",
                         "New-Item -Force on a registry key REPLACES it, deleting every "
-                        "value and subkey under it. Guard the create with "
-                        "`if (-not (Test-Path <key>)) { New-Item ... }`",
+                        "value and subkey under it. A Test-Path guard does not fix this "
+                        "— the test and the create are two operations, and a key created "
+                        "in between is still replaced — and dropping -Force cannot "
+                        "create missing parents. Write the value with reg.exe instead: "
+                        '`reg.exe add \"HKLM\\<path>\" /v <Name> /t REG_DWORD /d <n> /f` '
+                        'followed by `if ($LASTEXITCODE -ne 0) { throw ... }`',
                         text,
                     ))
                     break

--- a/tools/verify_commands.py
+++ b/tools/verify_commands.py
@@ -35,6 +35,9 @@ _PLACEHOLDERS = {
     "{mount}": "D:",
     "{name}": "SampleAdmin",
     "{count}": "3",
+    # Deliberately a name containing a space: auditpol subcategories all do, and
+    # an unquoted expansion would parse as two arguments.
+    "{subcategory}": "Sensitive Privilege Use",
 }
 
 # PowerShell that parses each command and resolves every invoked command name.


### PR DESCRIPTION
Two defects in shipped remediation commands. Both affect every user, not just the published sample.

## 1. Audit Policy remediated a subcategory it had not found

`misc.py` emitted the literal `auditpol /set /subcategory:'Logon' ...` regardless of the finding, while `details` listed whatever was actually missing. On a host where only `Sensitive Privilege Use` had auditing off — the case in the published sample — the operator pasted an elevated command that succeeded, changed nothing relevant, and saw the same WARN next scan.

Now one enable line per **confirmed-disabled** subcategory, sorted so the command is stable between scans.

Subcategories `auditpol` never reported get **no command**. They were not observed disabled — usually the name came back localized and the check could not match it — and enabling auditing nobody asked for is a change the operator did not consent to. Those get verification guidance, worded distinctly from the confirmed-disabled case.

## 2. Four commands replaced registry keys instead of writing to them

AutoPlay, LLMNR, script-block logging and module logging created their policy key first, across five create operations:

```powershell
if (-not (Test-Path $key)) { New-Item -Path $key -Force | Out-Null }
```

On the registry provider `-Force` **replaces** the key, deleting every value under it — and `...\Policies\Explorer` is shared with `NoRecentDocsHistory`, `NoActiveDesktop` and friends. The `Test-Path` guard does not prevent this: the test and the create are two operations, so a key created in the window between them by a Group Policy refresh, an installer or another admin is replaced anyway.

Measured on a live key rather than assumed:

```
sentinel after New-Item -Force: DESTROYED
```

Each command now makes one write per value:

```powershell
reg.exe add "HKLM\<path>" /v <Name> /t REG_DWORD /d <n> /f
if ($LASTEXITCODE -ne 0) { throw "reg.exe add failed ($LASTEXITCODE)" }
```

That creates any missing parents, touches only the named value, and folds the create and the set into one operation with no window between them. `reg.exe` reports failure through the exit code rather than a PowerShell error, so the check is what stops a denied write reading as success.

### Two other forms do not work here

Both established by measurement, not argument:

| Form | Why not |
|---|---|
| `New-Item` without `-Force` | Cannot create a key whose parents are missing — and a policy key is absent exactly when its parents are too (`...\Policies\Microsoft\Windows NT\DNSClient` on a machine that never had that policy) |
| `[Microsoft.Win32.Registry]::…CreateSubKey()` | Refused by PowerShell **Constrained Language Mode**: `MethodInvocationNotSupportedInConstrainedLanguage`. Apotrope scores a Constrained Language machine as a hardened PASS (`powershell.py:182`), so this would fail on precisely the hosts the tool has just praised |

## Lint changes

`unguarded-new-item-force` prescribed the racy `Test-Path` form as its remedy, and matched per physical line — so a backtick continuation before `-Force` slipped past it. It is now `registry-new-item-force`, folds continuations before matching, and points at `reg.exe`.

A new `constrained-language-method-call` rule rejects .NET invocation in remediation, so a command that cannot run on a hardened host fails the build. Static property reads stay legal — `[System.Environment]::OSVersion.Version` already ships in `os_info.py`. Constrained Language blocks the call, not the type; even `[Math]::Floor(1.5)` is refused.

## Keeping the Audit Policy command in the lint inventory

It is assembled with a `join` the AST resolver cannot follow, which would drop it from `collect_commands()` — taking the inventory 44 → 43 and leaving a shipped command unlinted and unparsed. Module-level `_CMD_*` constants are now collected in their own right, so the template stays covered. All six pre-existing `_CMD_*` constants were already reachable via `command=` references and collection dedupes on `(module, text)`, so this adds no duplicates.

`{subcategory}` was added to `verify_commands.py`'s substitutions, deliberately with a value containing a space.

## Testing

`tests/test_registry_create.py` (new, Windows-only) drives the **real command text**, retargeted only in hive and key, parametrized across all four remediations. Against a throwaway `HKCU` path it asserts each command:

- creates the key **and its missing parents**
- leaves an unrelated named value, the default value and an existing child subkey intact
- runs under `ConstrainedLanguage`
- surfaces a genuine failure

Plus a counter-example proving `New-Item -Force` really does destroy neighbouring state — without it the survival assertions could pass vacuously. The failure case uses an invalid root rather than a real protected key, so it fails identically for every identity and cannot mutate any hive.

`verify_commands.py` parses commands and resolves cmdlet names; it cannot observe registry behaviour, language mode, or quoting. An unquoted `/subcategory:Sensitive Privilege Use` parses fine and reaches auditpol as three arguments, so a unit test asserts the exact quoted argument.

Audit Policy coverage in `tests/test_checks/test_misc.py`: one disabled; several in deterministic order with no missing, extra or duplicated lines; missing-only → no command; mixed → only confirmed-disabled named; PASS branch still emits nothing; and the emitted command clears `lint_commands`.

## Validation

- `pytest tests/ -q --cov --cov-fail-under=95` → **1121 passed, 1 skipped, 98.96%**
- `ruff check src tests tools` (0.16.0) and `mypy src/apotrope tools` (1.19.1) → clean
- `git diff --check` → clean
- `python tools/verify_commands.py` on Windows → **FAILURES=0 TOTAL=44** (inventory unchanged, as intended)

## Follow-ups

Next: bring `services.py`'s `_RISKY` commands into the inventory — four `Stop-Service` / `Set-Service` commands `collect_commands()` cannot see, so no lint or PowerShell parse has ever covered them. Then #122 rebases onto both and regenerates the sample, whose AutoPlay and Audit Policy commands this PR changes.
