### PR TITLE
fix(services): bring the risky-service commands into the lint inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Four shipped remediation commands are now covered by the lint and the
+  PowerShell parser.** `services.py` held them in a dict of positional tuples,
+  which `tools/command_audit.py` cannot read — it collects `command=` keywords,
+  not tuple positions. The effect was quiet and total: `services.py` contributed
+  exactly one command to a 44-command inventory, and it was the
+  unquoted-`ImagePath` block. The `Stop-Service` / `Set-Service` commands for
+  Remote Registry, Telnet Server, Telnet and SNMP had never been linted by
+  `tests/test_remediation_commands.py` nor parsed by `tools/verify_commands.py`.
+
+  The dict values are now a `RiskyService` `NamedTuple` built with keyword
+  arguments, which is what puts them in front of both. Naming the fields is the
+  whole mechanism — no change to the collector was needed. The inventory goes
+  44 → 48, the existing 44 are byte-identical, and all four new entries are lint
+  clean and parse on Windows.
+
+  No behaviour change: `tests/test_checks/test_services.py` passes untouched.
+
 - **The Audit Policy remediation now names the subcategories that are actually
   disabled.** It emitted the literal `auditpol /set /subcategory:'Logon'`
   regardless of the finding, while the finding itself listed whatever was

--- a/src/apotrope/checks/services.py
+++ b/src/apotrope/checks/services.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import NamedTuple
 
 from apotrope.exceptions import ApotropeError
 from apotrope.models import CheckResult, Severity, Status
@@ -34,39 +35,55 @@ _PS_UNQUOTED = (
     "| ConvertTo-Json -Compress"
 )
 
-# Known-risky service names → (status, severity, details, remediation, command)
-_RISKY: dict[str, tuple[Status, Severity, str, str, str]] = {
-    "RemoteRegistry": (
-        Status.WARN,
-        Severity.HIGH,
-        "Remote Registry service is running — allows remote modification of the registry.",
-        "Stop and disable the Remote Registry service.",
-        "Stop-Service -Name 'RemoteRegistry' -Force\n"
-        "Set-Service -Name 'RemoteRegistry' -StartupType Disabled",
+
+class RiskyService(NamedTuple):
+    """The finding a known-risky service produces when it is found running."""
+
+    status: Status
+    severity: Severity
+    details: str
+    remediation: str
+    command: str
+
+
+# The keyword arguments below are load-bearing, not house style.
+# tools/command_audit.py collects every `command=` keyword on any call, so
+# naming the fields is what puts these four commands into the lint inventory and
+# in front of tools/verify_commands.py's PowerShell parser. As a positional
+# tuple they were invisible to both: services.py contributed exactly one command
+# to a 44-command inventory, and it was the unquoted-ImagePath block.
+_RISKY: dict[str, RiskyService] = {
+    "RemoteRegistry": RiskyService(
+        status=Status.WARN,
+        severity=Severity.HIGH,
+        details="Remote Registry service is running — allows remote modification of the registry.",
+        remediation="Stop and disable the Remote Registry service.",
+        command="Stop-Service -Name 'RemoteRegistry' -Force\n"
+                "Set-Service -Name 'RemoteRegistry' -StartupType Disabled",
     ),
-    "TlntSvr": (
-        Status.FAIL,
-        Severity.CRITICAL,
-        "Telnet Server is running — all traffic (including credentials) is sent in cleartext.",
-        "Stop and disable the Telnet Server service immediately.",
-        "Stop-Service -Name 'TlntSvr' -Force\n"
-        "Set-Service -Name 'TlntSvr' -StartupType Disabled",
+    "TlntSvr": RiskyService(
+        status=Status.FAIL,
+        severity=Severity.CRITICAL,
+        details="Telnet Server is running — all traffic (including credentials) is sent in cleartext.",
+        remediation="Stop and disable the Telnet Server service immediately.",
+        command="Stop-Service -Name 'TlntSvr' -Force\n"
+                "Set-Service -Name 'TlntSvr' -StartupType Disabled",
     ),
-    "Telnet": (
-        Status.FAIL,
-        Severity.CRITICAL,
-        "Telnet service is running — cleartext credential exposure.",
-        "Stop and disable the Telnet service immediately.",
-        "Stop-Service -Name 'Telnet' -Force\n"
-        "Set-Service -Name 'Telnet' -StartupType Disabled",
+    "Telnet": RiskyService(
+        status=Status.FAIL,
+        severity=Severity.CRITICAL,
+        details="Telnet service is running — cleartext credential exposure.",
+        remediation="Stop and disable the Telnet service immediately.",
+        command="Stop-Service -Name 'Telnet' -Force\n"
+                "Set-Service -Name 'Telnet' -StartupType Disabled",
     ),
-    "SNMP": (
-        Status.WARN,
-        Severity.MEDIUM,
-        "SNMP service is running. SNMPv1/v2 uses weak community-string authentication.",
-        "Disable SNMP if it is not required; if it is, restrict access and use SNMPv3.",
-        "Stop-Service -Name 'SNMP' -Force\n"
-        "Set-Service -Name 'SNMP' -StartupType Disabled",
+    "SNMP": RiskyService(
+        status=Status.WARN,
+        severity=Severity.MEDIUM,
+        details="SNMP service is running. SNMPv1/v2 uses weak community-string authentication.",
+        remediation="Disable SNMP if it is not required; if it is, restrict access and use SNMPv3.",
+        command="Stop-Service -Name 'SNMP' -Force\n"
+                "Set-Service -Name 'SNMP' -StartupType Disabled",
     ),
 }
 
@@ -94,18 +111,18 @@ def _check_risky_services() -> list[CheckResult]:
     running_names = {str(s.get("Name", "")).lower(): str(s.get("Name", "")) for s in services}
 
     results: list[CheckResult] = []
-    for svc_name, (status, severity, details, remediation, command) in _RISKY.items():
+    for svc_name, risky in _RISKY.items():
         if svc_name.lower() in running_names:
             display = running_names[svc_name.lower()]
             results.append(CheckResult(
                 category=CATEGORY,
                 check_name=f"Risky Service — {display}",
-                status=status,
-                severity=severity,
+                status=risky.status,
+                severity=risky.severity,
                 description=f"Checks whether the {display} service is running.",
-                details=details,
-                remediation=remediation,
-                command=command,
+                details=risky.details,
+                remediation=risky.remediation,
+                command=risky.command,
             ))
 
     if not results:

--- a/tests/test_remediation_commands.py
+++ b/tests/test_remediation_commands.py
@@ -232,6 +232,52 @@ class TestRegistryNewItemForceRule:
         assert not violations, [f"{v.module}:{v.line}" for v in violations]
 
 
+class TestRiskyServiceInventory:
+    """The risky-service commands must stay inside the inventory.
+
+    They lived in a dict of positional tuples, which the AST collector cannot
+    read: `services.py` contributed exactly one command to a 44-command
+    inventory, and it was the unquoted-ImagePath block. The four
+    Stop-Service/Set-Service commands were therefore never linted here and never
+    PowerShell-parsed by tools/verify_commands.py.
+
+    Naming the NamedTuple fields is what fixes that — `collect_commands()`
+    collects every `command=` keyword on any call. Revert those to positional
+    arguments and the commands silently vanish again, which is what these tests
+    exist to prevent.
+    """
+
+    _EXPECTED = {"RemoteRegistry", "TlntSvr", "Telnet", "SNMP"}
+
+    def test_every_risky_service_command_is_collected(self) -> None:
+        collected = [
+            c for c in collect_commands()
+            if c.module == "services.py" and "Stop-Service" in c.text
+        ]
+        named = {
+            svc for svc in self._EXPECTED
+            if any(f"'{svc}'" in c.text for c in collected)
+        }
+        assert named == self._EXPECTED, f"missing from the inventory: {self._EXPECTED - named}"
+
+    def test_collected_text_matches_what_the_check_emits(self) -> None:
+        # Not merely "a command mentioning the service" — the exact text the
+        # module ships, so a drifting copy in the inventory is a failure.
+        from apotrope.checks.services import _RISKY
+
+        inventory = {c.text for c in collect_commands() if c.module == "services.py"}
+        for svc, risky in _RISKY.items():
+            assert risky.command in inventory, f"{svc}: emitted command is not in the inventory"
+
+    def test_risky_service_commands_are_lint_clean(self) -> None:
+        from apotrope.checks.services import _RISKY
+
+        planted = [
+            Command("services.py", 0, risky.command) for risky in _RISKY.values()
+        ]
+        assert lint_commands(planted) == []
+
+
 class TestConstrainedLanguageRule:
     """Constrained Language Mode refuses .NET method invocation.
 


### PR DESCRIPTION
## Problem

`services.py` held four remediation commands inside a dict of positional tuples:

```python
_RISKY: dict[str, tuple[Status, Severity, str, str, str]] = {
    "RemoteRegistry": (Status.WARN, Severity.HIGH, "...", "...",
                       "Stop-Service -Name 'RemoteRegistry' -Force\n"
                       "Set-Service -Name 'RemoteRegistry' -StartupType Disabled"),
    ...
}
```

`tools/command_audit.py` collects `command=` **keywords**, not tuple positions, so it could not see them. The effect was quiet and total:

```
services.py contributes: 1   (of a 44-command inventory)
```

— and that one was the unquoted-`ImagePath` block. The `Stop-Service` / `Set-Service` commands for Remote Registry, Telnet Server, Telnet and SNMP had **never** been linted by `tests/test_remediation_commands.py`, and `tools/verify_commands.py` had never parsed them on Windows.

## Fix

The dict values become a `RiskyService` `NamedTuple` built with keyword arguments. Naming the fields is the entire mechanism — `collect_commands()` already gathers every `command=` keyword on any call, so **the collector is unchanged**.

## Inventory gate

Measured against the post-#123 baseline, captured before any edit:

```
inventory:                48   (was 44)
services.py contributes:   5   (was 1)
baseline byte-identical:  44 / 44    MISSING: 0
ADDED:                     4
  services.py | Stop-Service -Name 'RemoteRegistry' -Force ; Set-Service ...
  services.py | Stop-Service -Name 'SNMP' -Force ; Set-Service ...
  services.py | Stop-Service -Name 'Telnet' -Force ; Set-Service ...
  services.py | Stop-Service -Name 'TlntSvr' -Force ; Set-Service ...
lint violations:           0
```

`python tools/verify_commands.py` on Windows → **FAILURES=0 TOTAL=48**, with `services.py:61`, `:69`, `:77`, `:85` passing the PowerShell parser for the first time.

## No behaviour change

The tuple was only ever unpacked into a `CheckResult`. `tests/test_checks/test_services.py` passes **untouched** — it is not modified by this PR.

## Keeping them in

`TestRiskyServiceInventory` asserts each service is present, that the inventory text equals what the check actually emits (not merely a command mentioning the service), and that all four are lint clean.

Reverting the fields to positional arguments fails all three:

```
FAILED ...::test_every_risky_service_command_is_collected
FAILED ...::test_collected_text_matches_what_the_check_emits
FAILED ...::test_risky_service_commands_are_lint_clean
```

## Validation

- `pytest tests/ -q --cov --cov-fail-under=95` → **1124 passed, 1 skipped, 98.97%**
- `ruff check src tests tools` (0.16.0) and `mypy src/apotrope tools` (1.19.1) → clean
- `git diff --check` → clean
- `python tools/verify_commands.py` on Windows → 48/48

## Follow-up

#122 rebases onto this and #123 next, hardens the freshness guard, and regenerates the sample once. Its result-template collection will need to accept `RiskyService` alongside `CheckResult` so these rows are covered there too.
