### PR TITLE
docs: score is Apotrope's own metric; CIS mapped on applicable findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Public copy and the executive report now describe the score as Apotrope's
+  own 0–100 posture metric.** CIS Benchmark recommendation IDs are shown on
+  applicable findings — not every check has a CIS mapping — and remediation is
+  described as provided for failed and warning checks. The executive report's
+  "% compliant" and "compliant configuration" wording is replaced with
+  pass-count language. No scoring logic changed. A public-claims lint
+  (`tools/public_claims.py`, `tests/test_public_claims.py`) now guards this
+  wording: ten prohibited phrasings, one path-bound exception for the sentence
+  whose subject is CIS-CAT, and exact-count assertions on the approved copy.
+
 ### Fixed
 
 - **Four shipped remediation commands are now covered by the lint and the

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **Portable Windows security posture auditor. A Lynis for Windows.** A single
 executable (or `pip install apotrope`, MIT-licensed) that runs entirely on the
-machine it audits, talks to no network, and is read-only. It checks 50+ controls
-across 14 categories against CIS Microsoft Windows Benchmarks (Windows 11 v5.0.0,
+machine it audits, talks to no network, and is read-only. It runs 50+ checks
+across 14 categories and maps applicable findings to CIS Microsoft Windows Benchmark recommendations (Windows 11 v5.0.0,
 Windows 10 v4.0.0), scores the box 0 to 100, and hands back a scored terminal
 report or a self-contained HTML report you can send to someone who wasn't in the
 room.
@@ -389,8 +389,7 @@ INFO and ERROR results do not affect the score.
 
 Where applicable, findings are mapped to CIS Microsoft Windows Benchmark control
 IDs. These references appear as blue badges in the HTML report's detailed findings
-section, making Apotrope useful for compliance documentation and audit
-preparation. Mappings are based on the CIS Microsoft Windows 11 Enterprise
+section, making Apotrope useful as supporting evidence for audits. Mappings are based on the CIS Microsoft Windows 11 Enterprise
 Benchmark v5.0.0 and CIS Microsoft Windows 10 Enterprise Benchmark v4.0.0.
 The correct version is selected automatically based on the OS build number at
 scan time.
@@ -549,8 +548,9 @@ either direction, so you will hear about it before release rather than after.
 
 Different job. [Harden Windows Security](https://github.com/HotCakeX/Harden-Windows-Security)
 changes your machine to a hardened baseline — it's excellent at that. Apotrope
-never changes anything; it's a read-only assessor that scores any box against
-CIS Benchmarks. Audit with Apotrope, harden with Harden Windows Security or
+never changes anything; it's a read-only assessor that gives any box its own 0–100
+posture score and cites CIS Benchmark recommendations on applicable findings.
+Audit with Apotrope, harden with Harden Windows Security or
 Group Policy, then re-audit. They compose.
 
 ### How do I verify that my download is legitimate?

--- a/docs/exec-report.html
+++ b/docs/exec-report.html
@@ -302,7 +302,7 @@ hr.rule { border: none; border-top: 1px solid var(--rule); margin: 14pt 0; }
     
     <div class="tiles">
       <div class="tile accent"><div class="k">Overall score</div><div class="v tnum">75<small>/100</small></div><div class="note">Grade C — Fair</div></div>
-      <div class="tile"><div class="k">Controls passed</div><div class="v tnum">34<small>/53</small></div><div class="note">64% compliant</div></div>
+      <div class="tile"><div class="k">Controls passed</div><div class="v tnum">34<small>/53</small></div><div class="note">64% of checks passed</div></div>
       <div class="tile"><div class="k">Open findings</div><div class="v tnum">6</div><div class="note">3 failed · 3 warnings</div></div>
       <div class="tile"><div class="k">High-severity</div><div class="v tnum">1</div><div class="note">Priority-1 item</div></div>
     </div>
@@ -502,7 +502,7 @@ hr.rule { border: none; border-top: 1px solid var(--rule); margin: 14pt 0; }
     <div class="sec-h"><span class="n">A</span><h2>Attestation — controls passed</h2><span class="tag">34 controls</span></div>
 
     
-    <p class="muted" style="font-size:9.6pt;margin-bottom:10pt;">The following controls were evaluated and passed. This record can serve as evidence of the endpoint's compliant configuration at the time of assessment.</p>
+    <p class="muted" style="font-size:9.6pt;margin-bottom:10pt;">The following controls were evaluated and passed. This is a record of which checks passed at the time of assessment.</p>
 
     <table class="attest">
       <thead>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Free, offline Windows security auditor, like Lynis but for Windows. One .exe scores your box against CIS controls with plain-English fixes. No cloud, no agent." />
+  <meta name="description" content="Free, offline Windows security auditor, like Lynis but for Windows. One .exe scores your box 0–100, maps applicable findings to CIS Benchmark recommendations, and gives plain-English fixes. No cloud, no agent." />
   <meta name="google-site-verification" content="N68F_sJSRaPAUmW1m4vSVKj0BwJBtOEP6m9mwE1SAwA" />
   <title>Apotrope — Windows Security Posture Auditor</title>
 
@@ -19,7 +19,7 @@
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Apotrope" />
   <meta property="og:title" content="Apotrope — Windows Security Posture Auditor" />
-  <meta property="og:description" content="Offline Windows security auditor. One .exe scores your box against CIS controls and gives plain-English fixes." />
+  <meta property="og:description" content="Free, offline Windows security auditor, like Lynis but for Windows. One .exe scores your box 0–100, maps applicable findings to CIS Benchmark recommendations, and gives plain-English fixes. No cloud, no agent." />
   <meta property="og:url" content="https://apotrope.sh/" />
   <meta property="og:image" content="https://apotrope.sh/og-image.png" />
   <meta property="og:image:type" content="image/png" />
@@ -30,7 +30,7 @@
   <!-- Twitter / X Card -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Apotrope — Windows Security Posture Auditor" />
-  <meta name="twitter:description" content="Offline Windows security auditor. One .exe scores your box against CIS controls and gives plain-English fixes." />
+  <meta name="twitter:description" content="Free, offline Windows security auditor, like Lynis but for Windows. One .exe scores your box 0–100, maps applicable findings to CIS Benchmark recommendations, and gives plain-English fixes. No cloud, no agent." />
   <meta name="twitter:image" content="https://apotrope.sh/og-image.png" />
   <meta name="twitter:image:alt" content="Apotrope — security posture auditing for Windows, entirely offline." />
 
@@ -42,7 +42,7 @@
     "name": "Apotrope",
     "applicationCategory": "SecurityApplication",
     "operatingSystem": "Windows 10, Windows 11",
-    "description": "Portable, offline Windows security posture auditor. 50+ checks across 14 categories mapped to CIS Microsoft Windows Benchmarks (Windows 11 v5.0.0, Windows 10 v4.0.0), with a 0-100 score and a self-contained HTML report. Single executable, no cloud, no agent, read-only.",
+    "description": "Portable, offline Windows security posture auditor. 50+ checks across 14 categories with a 0-100 score, applicable findings mapped to CIS Microsoft Windows Benchmark recommendations (Windows 11 v5.0.0, Windows 10 v4.0.0), and a self-contained HTML report. Single executable, no cloud, no agent, read-only.",
     "url": "https://apotrope.sh/",
     "downloadUrl": "https://github.com/hexorcist404/apotrope/releases/latest",
     "softwareVersion": "0.2.0",
@@ -354,8 +354,8 @@
         <span class="badge"><span class="dot"></span>Open source · Windows 10/11 · Offline</span>
         <h1>Security posture auditing for Windows, <span class="g">entirely offline.</span></h1>
         <p class="lead">
-          A single executable that scores your Windows security configuration against
-          CIS Benchmark controls and gives you plain-English remediation steps —
+          A single executable that scores your Windows security configuration 0–100, cites
+          CIS Benchmark recommendations on applicable findings, and gives you plain-English remediation steps —
           no cloud, no agent, no license.
         </p>
         <div class="cta-row">
@@ -414,7 +414,7 @@
         <div class="feat" data-reveal>
           <span class="idx">03</span>
           <h3>CIS Benchmark Mapping</h3>
-          <p>Every finding is annotated with its CIS Benchmark control ID — v5.0.0 for Windows 11, v4.0.0 for Windows 10 — detected automatically at scan time.</p>
+          <p>Applicable findings are annotated with their CIS Benchmark recommendation ID — v5.0.0 for Windows 11, v4.0.0 for Windows 10 — detected automatically at scan time.</p>
         </div>
         <div class="feat" data-reveal>
           <span class="idx">04</span>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # Apotrope
 
-> Apotrope is a portable, offline Windows security posture auditor. A single executable (or `pip install apotrope`) audits the local machine against CIS Microsoft Windows Benchmark controls, scores it 0-100 with an A-F grade, and writes a self-contained HTML report. It is read-only, makes no network connections, and has no agent, telemetry, or license key.
+> Apotrope is a portable, offline Windows security posture auditor. A single executable (or `pip install apotrope`) audits the local machine, scores it 0-100 with an A-F grade, maps applicable findings to CIS Microsoft Windows Benchmark recommendations, and writes a self-contained HTML report. It is read-only, makes no network connections, and has no agent, telemetry, or license key.
 
 ## Key facts
 

--- a/docs/lynis-for-windows/index.html
+++ b/docs/lynis-for-windows/index.html
@@ -84,7 +84,7 @@
 
   <main class="content">
     <div class="wrap prose">
-      <p class="short-answer"><b>Short answer:</b> not exactly. Lynis runs on Linux, macOS, and BSD, not Windows. The closest equivalent for Windows is <b>Apotrope</b>: a single executable that audits the local machine against CIS Benchmark controls, scores it 0-100, and writes a self-contained HTML report. Offline, read-only, no agent, MIT-licensed.</p>
+      <p class="short-answer"><b>Short answer:</b> not exactly. Lynis runs on Linux, macOS, and BSD, not Windows. The closest equivalent for Windows is <b>Apotrope</b>: a single executable that audits the local machine, scores it 0-100, maps applicable findings to CIS Benchmark recommendations, and writes a self-contained HTML report. Offline, read-only, no agent, MIT-licensed.</p>
 
       <p>Lynis earned its reputation by being simple and honest: one command, runs locally, no agent, tells you what's weak and how to harden it. There's never been a clean Windows counterpart. The options have been a Java assessor behind a signup, a pile of one-off PowerShell scripts, or reading a 40-tab CIS PDF by hand.</p>
 

--- a/docs/vs-cis-cat/index.html
+++ b/docs/vs-cis-cat/index.html
@@ -84,7 +84,7 @@
 
   <main class="content">
     <div class="wrap prose">
-      <p class="short-answer"><b>Short answer:</b> both score a Windows machine against CIS Benchmarks and produce a report. CIS-CAT Lite is CIS's own free assessor. <b>Apotrope</b> is a single executable with no account, no Java runtime, plain-English remediation on every finding, and an MIT license. If you want a CIS-style score on a Windows box without signing up for anything or installing a runtime, Apotrope is the lighter path.</p>
+      <p class="short-answer"><b>Short answer:</b> CIS-CAT Lite is CIS's own free assessor and scores a machine against the CIS Benchmarks; <b>Apotrope</b> produces its own 0–100 posture score and cites CIS recommendations on applicable findings. It is a single executable with no account, no Java runtime, plain-English remediation for failed and warning checks, and an MIT license. If you want a quick posture read on a Windows box without signing up for anything or installing a runtime, Apotrope is the lighter path.</p>
 
       <p>CIS-CAT is the reference assessor from the Center for Internet Security itself, so its benchmark coverage is authoritative. The full version, CIS-CAT Pro, sits behind a paid CIS SecureSuite membership. The free Lite tier covers a select subset of benchmarks and runs on a Java runtime.</p>
 

--- a/docs/vs-harden-windows-security/index.html
+++ b/docs/vs-harden-windows-security/index.html
@@ -15,7 +15,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:site_name" content="Apotrope" />
   <meta property="og:title" content="Apotrope vs Harden Windows Security (HotCakeX)" />
-  <meta property="og:description" content="Different jobs that compose: Harden Windows Security applies a hardened baseline; Apotrope audits read-only against CIS Benchmarks. Audit, harden, re-audit." />
+  <meta property="og:description" content="Harden Windows Security applies a hardened baseline; Apotrope is a read-only auditor with its own 0–100 score and CIS Benchmark references on applicable findings. Different jobs — they compose." />
   <meta property="og:url" content="https://apotrope.sh/vs-harden-windows-security/" />
   <meta property="og:image" content="https://apotrope.sh/og-image.png" />
   <meta property="og:image:width" content="1200" />
@@ -25,7 +25,7 @@
   <!-- Twitter / X Card -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Apotrope vs Harden Windows Security (HotCakeX)" />
-  <meta name="twitter:description" content="Harden Windows Security applies a hardened baseline; Apotrope audits read-only against CIS Benchmarks. Different jobs — they compose." />
+  <meta name="twitter:description" content="Harden Windows Security applies a hardened baseline; Apotrope is a read-only auditor with its own 0–100 score and CIS Benchmark references on applicable findings. Different jobs — they compose." />
   <meta name="twitter:image" content="https://apotrope.sh/og-image.png" />
   <meta name="twitter:image:alt" content="Apotrope — security posture auditing for Windows, entirely offline." />
 
@@ -35,8 +35,8 @@
     "@context": "https://schema.org",
     "@type": "FAQPage",
     "mainEntity": [
-      { "@type": "Question", "name": "Should I use Apotrope or Harden Windows Security?", "acceptedAnswer": { "@type": "Answer", "text": "Both, if you like — they do different jobs. Harden Windows Security applies a hardened baseline to your machine; Apotrope is a read-only auditor that scores any Windows box against CIS Benchmarks. Audit with Apotrope, harden with Harden Windows Security or Group Policy, then re-audit." } },
-      { "@type": "Question", "name": "Does Apotrope apply fixes like Harden Windows Security does?", "acceptedAnswer": { "@type": "Answer", "text": "No. Apotrope never changes the machine. Every finding ships with a copy-paste PowerShell fix you review and apply yourself. If you want a tool that applies a full hardened baseline for you, HotCakeX's Harden System Security is the best free option." } },
+      { "@type": "Question", "name": "Should I use Apotrope or Harden Windows Security?", "acceptedAnswer": { "@type": "Answer", "text": "Both, if you like — they do different jobs. Harden Windows Security applies a hardened baseline to your machine; Apotrope is a read-only auditor that gives any Windows box its own 0–100 posture score and cites CIS Benchmark recommendations on applicable findings. Audit with Apotrope, harden with Harden Windows Security or Group Policy, then re-audit." } },
+      { "@type": "Question", "name": "Does Apotrope apply fixes like Harden Windows Security does?", "acceptedAnswer": { "@type": "Answer", "text": "No. Apotrope never changes the machine. Failed and warning checks ship with a copy-paste PowerShell fix you review and apply yourself. If you want a tool that applies a full hardened baseline for you, HotCakeX's Harden System Security is the best free option." } },
       { "@type": "Question", "name": "Is Apotrope affiliated with HotCakeX, Microsoft, or CIS?", "acceptedAnswer": { "@type": "Answer", "text": "No. Apotrope is an independent, MIT-licensed open-source project. Harden Windows Security is an unrelated project by Violet Hansen (HotCakeX). Apotrope references CIS Benchmark control IDs for informational purposes and is not affiliated with or endorsed by CIS." } }
     ]
   }
@@ -84,7 +84,7 @@
 
   <main class="content">
     <div class="wrap prose">
-      <p class="short-answer"><b>Short answer:</b> different job. <b>Harden Windows Security</b> <i>changes</i> your machine — it applies a hardened baseline using only official Microsoft features, and it's excellent at that. <b>Apotrope</b> never changes anything: it's a read-only assessor that scores any Windows box against CIS Benchmarks and hands you a report with plain-English fixes. Audit with Apotrope, harden with Harden Windows Security or Group Policy, then re-audit. They compose.</p>
+      <p class="short-answer"><b>Short answer:</b> different job. <b>Harden Windows Security</b> <i>changes</i> your machine — it applies a hardened baseline using only official Microsoft features, and it's excellent at that. <b>Apotrope</b> never changes anything: it's a read-only assessor that gives any Windows box its own 0–100 posture score, cites CIS Benchmark recommendations on applicable findings, and hands you a report with plain-English fixes. Audit with Apotrope, harden with Harden Windows Security or Group Policy, then re-audit. They compose.</p>
 
       <p><a href="https://github.com/HotCakeX/Harden-Windows-Security">Harden Windows Security</a>, by Microsoft MVP Violet Hansen (HotCakeX), ships two signed MSIX apps on the Microsoft Store. <b>Harden System Security</b> applies hardening to Windows using only built-in Microsoft features, then verifies workstation compliance against its baseline and reports a security score. <b>AppControl Manager</b> is the deepest free WDAC / App Control for Business tooling around. Its supply-chain posture — SLSA build attestations, signed releases, a relentless release cadence — is a genuine strength.</p>
 
@@ -99,7 +99,7 @@
         </thead>
         <tbody>
           <tr><th>Maker</th><td>Violet Hansen (HotCakeX), Microsoft MVP</td><td class="col-ap">Independent (hexorcist404)</td></tr>
-          <tr><th>What it does</th><td><b>Applies</b> a hardened baseline; verifies compliance against its baseline</td><td class="col-ap"><b>Audits</b> read-only against CIS Benchmarks</td></tr>
+          <tr><th>What it does</th><td><b>Applies</b> a hardened baseline; verifies compliance against its baseline</td><td class="col-ap"><b>Audits</b> read-only; own 0–100 score; CIS references where applicable</td></tr>
           <tr><th>Install</th><td>Microsoft Store (signed MSIX apps)</td><td class="col-ap">None — single portable <code>.exe</code>, or pip</td></tr>
           <tr><th>Benchmark frame</th><td>Its own baseline, built on official Microsoft features</td><td class="col-ap">CIS Win11 v5.0.0 / Win10 v4.0.0, auto-selected</td></tr>
           <tr><th>System changes</th><td>Yes — that's the job</td><td class="col-ap">None — no writes, no network</td></tr>
@@ -114,11 +114,11 @@
       <div class="faq-list">
         <details class="faq-item" open>
           <summary>Should I use Apotrope or Harden Windows Security?</summary>
-          <p>Both, if you like — they do different jobs. Harden Windows Security applies a hardened baseline to your machine; Apotrope is a read-only auditor that scores any Windows box against CIS Benchmarks. Audit with Apotrope, harden with Harden Windows Security or Group Policy, then re-audit.</p>
+          <p>Both, if you like — they do different jobs. Harden Windows Security applies a hardened baseline to your machine; Apotrope is a read-only auditor that gives any Windows box its own 0–100 posture score and cites CIS Benchmark recommendations on applicable findings. Audit with Apotrope, harden with Harden Windows Security or Group Policy, then re-audit.</p>
         </details>
         <details class="faq-item">
           <summary>Does Apotrope apply fixes like Harden Windows Security does?</summary>
-          <p>No. Apotrope never changes the machine. Every finding ships with a copy-paste PowerShell fix you review and apply yourself. If you want a tool that applies a full hardened baseline for you, HotCakeX's Harden System Security is the best free option.</p>
+          <p>No. Apotrope never changes the machine. Failed and warning checks ship with a copy-paste PowerShell fix you review and apply yourself. If you want a tool that applies a full hardened baseline for you, HotCakeX's Harden System Security is the best free option.</p>
         </details>
         <details class="faq-item">
           <summary>Is Apotrope affiliated with HotCakeX, Microsoft, or CIS?</summary>

--- a/docs/vs-harden-windows-security/index.html
+++ b/docs/vs-harden-windows-security/index.html
@@ -36,7 +36,7 @@
     "@type": "FAQPage",
     "mainEntity": [
       { "@type": "Question", "name": "Should I use Apotrope or Harden Windows Security?", "acceptedAnswer": { "@type": "Answer", "text": "Both, if you like — they do different jobs. Harden Windows Security applies a hardened baseline to your machine; Apotrope is a read-only auditor that gives any Windows box its own 0–100 posture score and cites CIS Benchmark recommendations on applicable findings. Audit with Apotrope, harden with Harden Windows Security or Group Policy, then re-audit." } },
-      { "@type": "Question", "name": "Does Apotrope apply fixes like Harden Windows Security does?", "acceptedAnswer": { "@type": "Answer", "text": "No. Apotrope never changes the machine. Failed and warning checks ship with a copy-paste PowerShell fix you review and apply yourself. If you want a tool that applies a full hardened baseline for you, HotCakeX's Harden System Security is the best free option." } },
+      { "@type": "Question", "name": "Does Apotrope apply fixes like Harden Windows Security does?", "acceptedAnswer": { "@type": "Answer", "text": "No. Apotrope never changes the machine. Failed and warning checks include remediation guidance, with copy-paste PowerShell commands where applicable. If you want a tool that applies a full hardened baseline for you, HotCakeX's Harden System Security is the best free option." } },
       { "@type": "Question", "name": "Is Apotrope affiliated with HotCakeX, Microsoft, or CIS?", "acceptedAnswer": { "@type": "Answer", "text": "No. Apotrope is an independent, MIT-licensed open-source project. Harden Windows Security is an unrelated project by Violet Hansen (HotCakeX). Apotrope references CIS Benchmark control IDs for informational purposes and is not affiliated with or endorsed by CIS." } }
     ]
   }
@@ -118,7 +118,7 @@
         </details>
         <details class="faq-item">
           <summary>Does Apotrope apply fixes like Harden Windows Security does?</summary>
-          <p>No. Apotrope never changes the machine. Failed and warning checks ship with a copy-paste PowerShell fix you review and apply yourself. If you want a tool that applies a full hardened baseline for you, HotCakeX's Harden System Security is the best free option.</p>
+          <p>No. Apotrope never changes the machine. Failed and warning checks include remediation guidance, with copy-paste PowerShell commands where applicable. If you want a tool that applies a full hardened baseline for you, HotCakeX's Harden System Security is the best free option.</p>
         </details>
         <details class="faq-item">
           <summary>Is Apotrope affiliated with HotCakeX, Microsoft, or CIS?</summary>

--- a/src/apotrope/templates/exec_report.html.j2
+++ b/src/apotrope/templates/exec_report.html.j2
@@ -296,7 +296,7 @@ hr.rule { border: none; border-top: 1px solid var(--rule); margin: 14pt 0; }
     {% set pass_pct = ((pass_count * 100 / total_checks) | round | int) if total_checks else 0 %}
     <div class="tiles">
       <div class="tile accent"><div class="k">Overall score</div><div class="v tnum">{{ score }}<small>/100</small></div><div class="note">Grade {{ grade_letter }} — {{ grade_label }}</div></div>
-      <div class="tile"><div class="k">Controls passed</div><div class="v tnum">{{ pass_count }}<small>/{{ total_checks }}</small></div><div class="note">{{ pass_pct }}% compliant</div></div>
+      <div class="tile"><div class="k">Controls passed</div><div class="v tnum">{{ pass_count }}<small>/{{ total_checks }}</small></div><div class="note">{{ pass_pct }}% of checks passed</div></div>
       <div class="tile"><div class="k">Open findings</div><div class="v tnum">{{ open_total }}</div><div class="note">{{ fail_count }} failed · {{ warn_count }} warning{{ 's' if warn_count != 1 }}</div></div>
       <div class="tile"><div class="k">High-severity</div><div class="v tnum">{{ p1_count }}</div><div class="note">Priority-1 item{{ 's' if p1_count != 1 }}</div></div>
     </div>
@@ -393,7 +393,7 @@ hr.rule { border: none; border-top: 1px solid var(--rule); margin: 14pt 0; }
     <div class="sec-h"><span class="n">A</span><h2>Attestation — controls passed</h2><span class="tag">{{ pass_count }} control{{ 's' if pass_count != 1 }}</span></div>
 
     {% if attestation_groups %}
-    <p class="muted" style="font-size:9.6pt;margin-bottom:10pt;">The following controls were evaluated and passed. This record can serve as evidence of the endpoint's compliant configuration at the time of assessment.</p>
+    <p class="muted" style="font-size:9.6pt;margin-bottom:10pt;">The following controls were evaluated and passed. This is a record of which checks passed at the time of assessment.</p>
 
     <table class="attest">
       <thead>

--- a/tests/test_public_claims.py
+++ b/tests/test_public_claims.py
@@ -292,9 +292,10 @@ REQUIRED_FRAGMENTS = [
     ("docs/vs-harden-windows-security/index.html", "CIS references where applicable", 1),
     (
         "docs/vs-harden-windows-security/index.html",
-        "Failed and warning checks ship with a copy-paste PowerShell fix",
+        "Failed and warning checks include remediation guidance, with copy-paste PowerShell commands where applicable.",
         2,
     ),
+    ("docs/vs-harden-windows-security/index.html", "ship with a copy-paste PowerShell fix", 0),
     ("docs/vs-harden-windows-security/index.html", "Every finding ships with", 0),
     ("src/apotrope/templates/exec_report.html.j2", "% of checks passed", 1),
     ("src/apotrope/templates/exec_report.html.j2", RECORD_SENTENCE, 1),

--- a/tests/test_public_claims.py
+++ b/tests/test_public_claims.py
@@ -1,0 +1,383 @@
+"""Public-claims policy: the public copy never overstates what Apotrope does.
+
+Apotrope produces its own 0-100 posture score. CIS references are optional
+mappings on *applicable* findings, and remediation exists for failed and warning
+checks. ``tools/public_claims.py`` holds the prohibited phrasings and the single
+authorised exception; this module proves the rules fire on every intended
+variant, stay quiet on the near misses, and that the shipped copy is clean.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+import public_claims
+from public_claims import PROHIBITED, PolicyError, discover, repo_root, scan
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOLS = ROOT / "tools"
+
+INDEX_META = (
+    "Free, offline Windows security auditor, like Lynis but for Windows. One .exe scores your box "
+    "0–100, maps applicable findings to CIS Benchmark recommendations, and gives plain-English "
+    "fixes. No cloud, no agent."
+)
+INDEX_JSONLD_DESCRIPTION = (
+    "Portable, offline Windows security posture auditor. 50+ checks across 14 categories with a "
+    "0-100 score, applicable findings mapped to CIS Microsoft Windows Benchmark recommendations "
+    "(Windows 11 v5.0.0, Windows 10 v4.0.0), and a self-contained HTML report. Single executable, "
+    "no cloud, no agent, read-only."
+)
+HWS_META = (
+    "Harden Windows Security applies a hardened baseline; Apotrope is a read-only auditor with its "
+    "own 0–100 score and CIS Benchmark references on applicable findings. Different jobs "
+    "— they compose."
+)
+HWS_FAQ = (
+    "Both, if you like — they do different jobs. Harden Windows Security applies a hardened "
+    "baseline to your machine; Apotrope is a read-only auditor that gives any Windows box its own "
+    "0–100 posture score and cites CIS Benchmark recommendations on applicable findings. Audit "
+    "with Apotrope, harden with Harden Windows Security or Group Policy, then re-audit."
+)
+HWS_QUESTION = "Should I use Apotrope or Harden Windows Security?"
+CISCAT_ALLOWED = "CIS-CAT Lite is CIS's own free assessor and scores a machine against the CIS Benchmarks"
+CISCAT_REMEDIATION = "plain-English remediation for failed and warning checks"
+RECORD_SENTENCE = "This is a record of which checks passed at the time of assessment."
+
+DASHES = ("-", "‐", "‑", "‒", "–", "—")
+RULES = {rule.name: rule for rule in PROHIBITED}
+EXAMPLES = [(rule.name, example) for rule in PROHIBITED for example in rule.bad_examples]
+NEGATIVES = (
+    "plain-English remediation for failed and warning checks",
+    "remediation for each failing check",
+    "remediation where available",
+    "every finding shows a severity",
+    "remediation on the finding",
+    "verifies compliance against its baseline",
+)
+INNOCUOUS = "Nothing to see here.\n"
+
+
+def _tree(tmp_path: Path, files: dict[str, str] | None = None, *, seed: bool = True) -> Path:
+    """Build a synthetic checkout. Seeded trees are policy-valid by default."""
+    root = tmp_path / "repo"
+    root.mkdir(exist_ok=True)
+    seeded = {
+        "pyproject.toml": '[project]\nname = "apotrope"\n',
+        "README.md": INNOCUOUS,
+        "docs/index.html": INNOCUOUS,
+        "docs/llms.txt": INNOCUOUS,
+        "src/apotrope/templates/report.html.j2": INNOCUOUS,
+        "docs/vs-cis-cat/index.html": f"<p>{CISCAT_ALLOWED}.</p>\n",
+    }
+    contents = {**seeded, **(files or {})} if seed else dict(files or {})
+    for rel, text in contents.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+    return root
+
+
+def _rule_hits(text: str) -> set[str]:
+    return {rule.name for rule in PROHIBITED if rule.pattern.search(text)}
+
+
+# --- module identity and policy shape ----------------------------------------------------------
+
+
+def test_imports_the_intended_module() -> None:
+    assert Path(public_claims.__file__).resolve() == (TOOLS / "public_claims.py").resolve()
+
+
+def test_exactly_ten_rules_each_with_examples() -> None:
+    assert len(PROHIBITED) == 10
+    assert len(RULES) == 10
+    for rule in PROHIBITED:
+        assert rule.bad_examples, rule.name
+
+
+@pytest.mark.parametrize(("name", "example"), EXAMPLES)
+def test_every_example_matches_its_own_rule(name: str, example: str) -> None:
+    assert RULES[name].pattern.search(example), f"{name!r} misses {example!r}"
+
+
+@pytest.mark.parametrize(("name", "example"), EXAMPLES)
+def test_case_variants_match(name: str, example: str) -> None:
+    for variant in (example.upper(), example.lower(), example.title()):
+        assert RULES[name].pattern.search(variant), f"{name!r} misses {variant!r}"
+
+
+@pytest.mark.parametrize(("name", "example"), EXAMPLES)
+def test_whitespace_variants_match(name: str, example: str) -> None:
+    for sep in ("  ", "\t", "\n"):
+        variant = example.replace(" ", sep)
+        assert RULES[name].pattern.search(variant), f"{name!r} misses {variant!r}"
+
+
+@pytest.mark.parametrize("dash", DASHES)
+def test_dash_variants_match(dash: str) -> None:
+    assert RULES["cis_style_score"].pattern.search(f"a CIS{dash}style score")
+    assert RULES["every_finding_mapped"].pattern.search(f"every finding cross{dash}referenced")
+
+
+@pytest.mark.parametrize("the", ("", "the "))
+def test_optional_the_before_cis(the: str) -> None:
+    assert RULES["against_cis"].pattern.search(f"against {the}CIS Benchmarks")
+    assert RULES["scores_against_cis"].pattern.search(f"scores against {the}CIS Benchmarks")
+    assert RULES["audits_against_cis"].pattern.search(f"audits against {the}CIS Benchmarks")
+
+
+@pytest.mark.parametrize("text", NEGATIVES)
+def test_near_misses_match_no_rule(text: str) -> None:
+    assert _rule_hits(text) == set(), text
+
+
+def test_multiline_match_reports_its_starting_line(tmp_path: Path) -> None:
+    body = "one\ntwo\nthree\nfour\nmaps every\nfinding to CIS\n"
+    root = _tree(tmp_path, {"docs/multi.html": body})
+    findings = scan(root)
+    assert findings, "expected the wrapped claim to be found"
+    assert {f.line for f in findings if f.path.name == "multi.html"} == {5}
+
+
+# --- exception semantics ------------------------------------------------------------------------
+
+
+def test_default_tree_is_policy_valid(tmp_path: Path) -> None:
+    assert scan(_tree(tmp_path)) == []
+
+
+def test_allowed_fragment_in_wrong_path_is_a_finding(tmp_path: Path) -> None:
+    root = _tree(tmp_path, {"docs/other.html": f"<p>{CISCAT_ALLOWED}.</p>\n"})
+    rules = {f.rule for f in scan(root) if f.path.name == "other.html"}
+    assert {"against_cis", "scores_against_cis"} <= rules
+
+
+def test_duplicate_allowed_fragment_is_rejected(tmp_path: Path) -> None:
+    root = _tree(tmp_path, {"docs/vs-cis-cat/index.html": f"{CISCAT_ALLOWED}. {CISCAT_ALLOWED}.\n"})
+    with pytest.raises(PolicyError, match="expected 1 occurrence"):
+        scan(root)
+
+
+def test_missing_allowed_fragment_is_rejected(tmp_path: Path) -> None:
+    root = _tree(tmp_path, {"docs/vs-cis-cat/index.html": INNOCUOUS})
+    with pytest.raises(PolicyError, match="found 0"):
+        scan(root)
+
+
+def test_missing_exception_path_is_rejected(tmp_path: Path) -> None:
+    root = _tree(tmp_path)
+    (root / "docs/vs-cis-cat/index.html").unlink()
+    with pytest.raises(PolicyError, match="not discovered"):
+        scan(root)
+
+
+def test_changed_subject_is_not_silently_suppressed(tmp_path: Path) -> None:
+    apotrope_claim = "Apotrope is CIS's own free assessor and scores a machine against the CIS Benchmarks"
+    root = _tree(tmp_path, {"docs/vs-cis-cat/index.html": f"<p>{apotrope_claim}.</p>\n"})
+    with pytest.raises(PolicyError):
+        scan(root)
+    root = _tree(tmp_path, {"docs/vs-cis-cat/index.html": f"<p>{CISCAT_ALLOWED}.</p>\n<p>{apotrope_claim}.</p>\n"})
+    text = (root / "docs/vs-cis-cat/index.html").read_text(encoding="utf-8")
+    allowed_end = text.index(CISCAT_ALLOWED) + len(CISCAT_ALLOWED)
+    findings = [f for f in scan(root) if f.path.name == "index.html"]
+    assert findings
+    assert all(f.start >= allowed_end for f in findings)
+
+
+def test_same_line_allowed_plus_bad_reports_only_the_bad_span(tmp_path: Path) -> None:
+    line = f"{CISCAT_ALLOWED}; Apotrope scores your box against CIS controls.\n"
+    root = _tree(tmp_path, {"docs/vs-cis-cat/index.html": line})
+    findings = scan(root)
+    assert findings
+    assert all(f.start >= len(CISCAT_ALLOWED) for f in findings)
+
+
+def test_same_line_with_only_the_allowed_fragment_is_clean(tmp_path: Path) -> None:
+    root = _tree(tmp_path, {"docs/vs-cis-cat/index.html": f"{CISCAT_ALLOWED}; nothing else.\n"})
+    assert scan(root) == []
+
+
+def test_match_crossing_the_span_edge_is_reported(tmp_path: Path) -> None:
+    root = _tree(tmp_path, {"docs/vs-cis-cat/index.html": f"{CISCAT_ALLOWED} controls\n"})
+    assert {f.rule for f in scan(root)} >= {"against_cis"}
+
+
+def test_hws_baseline_sentence_is_not_flagged() -> None:
+    assert _rule_hits("verifies compliance against its baseline") == set()
+
+
+# --- discovery contract -------------------------------------------------------------------------
+
+
+def test_repo_root_is_the_apotrope_checkout() -> None:
+    root = repo_root()
+    assert root == ROOT
+    assert 'name = "apotrope"' in (root / "pyproject.toml").read_text(encoding="utf-8")
+
+
+def test_real_repo_discovery_is_complete(record_property: Any) -> None:
+    files = discover(ROOT)
+    names = {p.relative_to(ROOT).as_posix() for p in files}
+    for anchor in (
+        "README.md",
+        "docs/index.html",
+        "docs/report.html",
+        "docs/exec-report.html",
+        "docs/llms.txt",
+        "src/apotrope/templates/report.html.j2",
+        "src/apotrope/templates/exec_report.html.j2",
+    ):
+        assert anchor in names, anchor
+    assert len(files) == len(set(files))
+    assert all(p.resolve().is_relative_to(ROOT) for p in files)
+    record_property("public_claims_files_scanned", len(files))
+    assert len(files) >= 8, f"only {len(files)} public-copy files discovered"
+
+
+def test_nested_docs_html_is_discovered(tmp_path: Path) -> None:
+    root = _tree(tmp_path, {"docs/nested/deeper/page.html": INNOCUOUS})
+    assert (root / "docs/nested/deeper/page.html").resolve() in {p.resolve() for p in discover(root)}
+
+
+def test_missing_category_fails_discovery(tmp_path: Path) -> None:
+    root = _tree(tmp_path)
+    (root / "docs/llms.txt").unlink()
+    with pytest.raises(RuntimeError, match="docs_llms"):
+        discover(root)
+
+
+def test_broken_root_fails_discovery(tmp_path: Path) -> None:
+    root = _tree(tmp_path, seed=False)
+    with pytest.raises(RuntimeError, match="pyproject"):
+        discover(root)
+
+
+def test_path_resolving_outside_root_fails_discovery(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = _tree(tmp_path)
+    (tmp_path / "escape.md").write_text(INNOCUOUS, encoding="utf-8")
+    monkeypatch.setattr(public_claims, "CATEGORIES", {**public_claims.CATEGORIES, "escape": ("../escape.md",)})
+    with pytest.raises(RuntimeError, match="outside"):
+        discover(root)
+
+
+def test_foreign_project_root_fails_discovery(tmp_path: Path) -> None:
+    root = _tree(tmp_path, {"pyproject.toml": '[project]\nname = "somethingelse"\n'})
+    with pytest.raises(RuntimeError, match="does not name apotrope"):
+        discover(root)
+
+
+# --- positive targets in the shipped copy -------------------------------------------------------
+
+
+REQUIRED_FRAGMENTS = [
+    ("README.md", "maps applicable findings to CIS Microsoft Windows Benchmark recommendations", 1),
+    ("README.md", "useful as supporting evidence for audits", 1),
+    ("docs/index.html", "Applicable findings are annotated with their CIS Benchmark recommendation ID", 1),
+    ("docs/llms.txt", "maps applicable findings to CIS Microsoft Windows Benchmark recommendations", 1),
+    ("docs/lynis-for-windows/index.html", "maps applicable findings to CIS Benchmark recommendations", 1),
+    ("docs/vs-cis-cat/index.html", "cites CIS recommendations on applicable findings", 1),
+    ("docs/vs-cis-cat/index.html", CISCAT_ALLOWED, 1),
+    ("docs/vs-cis-cat/index.html", CISCAT_REMEDIATION, 1),
+    ("docs/vs-cis-cat/index.html", "remediation on every finding", 0),
+    ("docs/vs-harden-windows-security/index.html", "cites CIS Benchmark recommendations on applicable findings", 3),
+    ("docs/vs-harden-windows-security/index.html", "CIS references where applicable", 1),
+    (
+        "docs/vs-harden-windows-security/index.html",
+        "Failed and warning checks ship with a copy-paste PowerShell fix",
+        2,
+    ),
+    ("docs/vs-harden-windows-security/index.html", "Every finding ships with", 0),
+    ("src/apotrope/templates/exec_report.html.j2", "% of checks passed", 1),
+    ("src/apotrope/templates/exec_report.html.j2", RECORD_SENTENCE, 1),
+    ("docs/exec-report.html", "% of checks passed", 1),
+    ("docs/exec-report.html", RECORD_SENTENCE, 1),
+]
+
+
+@pytest.mark.parametrize(("rel", "fragment", "count"), REQUIRED_FRAGMENTS)
+def test_required_fragment_count(rel: str, fragment: str, count: int) -> None:
+    text = (ROOT / rel).read_text(encoding="utf-8")
+    assert text.count(fragment) == count, f"{rel}: {fragment!r} occurs {text.count(fragment)} times, expected {count}"
+
+
+class _Head(HTMLParser):
+    """Collects meta descriptions and JSON-LD blocks."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.meta: dict[str, list[str]] = {}
+        self.ld: list[str] = []
+        self._in_ld = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        a = dict(attrs)
+        if tag == "meta":
+            key = a.get("name") or a.get("property")
+            if key in {"description", "og:description", "twitter:description"} and a.get("content") is not None:
+                self.meta.setdefault(key, []).append(str(a["content"]))
+        if tag == "script" and a.get("type") == "application/ld+json":
+            self._in_ld = True
+
+    def handle_data(self, data: str) -> None:
+        if self._in_ld:
+            self.ld.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "script":
+            self._in_ld = False
+
+
+def _parse_head(rel: str) -> _Head:
+    parser = _Head()
+    parser.feed((ROOT / rel).read_text(encoding="utf-8"))
+    return parser
+
+
+def _ld_objects(parser: _Head) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for block in parser.ld:
+        data = json.loads(block)
+        items = data.get("@graph", [data]) if isinstance(data, dict) else data
+        out.extend(item for item in items if isinstance(item, dict))
+    return out
+
+
+def test_index_meta_descriptions_are_identical_and_approved() -> None:
+    head = _parse_head("docs/index.html")
+    for key in ("description", "og:description", "twitter:description"):
+        assert head.meta.get(key) == [INDEX_META], key
+
+
+def test_index_jsonld_description_is_approved() -> None:
+    apps = [o for o in _ld_objects(_parse_head("docs/index.html")) if o.get("@type") == "SoftwareApplication"]
+    assert len(apps) == 1
+    assert apps[0]["description"] == INDEX_JSONLD_DESCRIPTION
+
+
+def test_hws_meta_descriptions_are_identical_and_approved() -> None:
+    head = _parse_head("docs/vs-harden-windows-security/index.html")
+    for key in ("og:description", "twitter:description"):
+        assert head.meta.get(key) == [HWS_META], key
+
+
+def test_hws_jsonld_faq_answer_is_approved() -> None:
+    head = _parse_head("docs/vs-harden-windows-security/index.html")
+    faqs = [o for o in _ld_objects(head) if o.get("@type") == "FAQPage"]
+    assert len(faqs) == 1
+    answers = [q["acceptedAnswer"]["text"] for q in faqs[0]["mainEntity"] if q.get("name") == HWS_QUESTION]
+    assert answers == [HWS_FAQ]
+
+
+def test_shipped_copy_has_no_prohibited_claims() -> None:
+    findings = scan(ROOT)
+    report = "\n".join(f"{f.path.relative_to(ROOT).as_posix()}:{f.line} {f.rule} - {f.excerpt}" for f in findings)
+    assert findings == [], report

--- a/tools/public_claims.py
+++ b/tools/public_claims.py
@@ -1,0 +1,216 @@
+"""Public-claims policy: what Apotrope's public copy may say about scoring and CIS.
+
+The invariant: Apotrope produces its own 0-100 posture score; CIS references are
+optional mappings on *applicable* findings; remediation exists for failed and
+warning checks. Nothing public may describe an official CIS score, a compliance
+verdict, or "every finding" being mapped or remediated.
+
+``PROHIBITED`` holds the phrasings that break that invariant, each with the
+examples that prove the pattern fires. ``ALLOWED`` holds the single authorised
+exception - a sentence whose subject is CIS-CAT, not Apotrope - bound to one
+path and exactly one occurrence. ``scan`` reads every public-copy file once and
+reports each unsuppressed match with its original line number.
+
+``tests/test_public_claims.py`` exercises every branch here and asserts the
+shipped copy is clean.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class PolicyError(Exception):
+    """The exception table cannot be applied as written (wrong path or count)."""
+
+
+@dataclass(frozen=True)
+class Rule:
+    """A prohibited phrasing and the examples that must trip it."""
+
+    name: str
+    pattern: re.Pattern[str]
+    bad_examples: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Allowed:
+    """One authorised fragment, bound to a repository-relative path and an exact count."""
+
+    path: str
+    fragment: str
+    count: int
+
+
+@dataclass(frozen=True)
+class Finding:
+    """An unsuppressed match. ``line`` is computed from the original file offset."""
+
+    path: Path
+    line: int
+    rule: str
+    start: int
+    end: int
+    excerpt: str
+
+
+# ASCII hyphen, hyphen, non-breaking hyphen, figure dash, en dash, em dash.
+DASH = "[-" + "".join(chr(c) for c in (0x2010, 0x2011, 0x2012, 0x2013, 0x2014)) + "]"
+THE = r"(?:the\s+)?"
+_DASHES = tuple(chr(c) for c in (0x2D, 0x2010, 0x2011, 0x2012, 0x2013, 0x2014))
+
+
+def _rule(name: str, pattern: str, *bad_examples: str) -> Rule:
+    return Rule(name, re.compile(pattern, re.IGNORECASE), bad_examples)
+
+
+PROHIBITED: tuple[Rule, ...] = (
+    _rule(
+        "scores_against_cis",
+        rf"\bscor(?:e|es|ed|ing)\b\s+(?:\S+\s+){{0,4}}against\s+{THE}CIS\b",
+        "score against CIS",
+        "scores your box against CIS controls",
+        "scored against CIS",
+        "scoring against CIS",
+        "scores a machine against the CIS Benchmarks",
+    ),
+    _rule("cis_score", r"\bCIS\s+score\b", "a CIS score of 80"),
+    _rule(
+        "cis_style_score",
+        rf"\bCIS{DASH}style\s+score\b",
+        *(f"a CIS{dash}style score" for dash in _DASHES),
+    ),
+    _rule("percent_compliant", r"(?:%|\bpercent)\s*compliant\b", "64% compliant", "64 percent compliant"),
+    _rule("compliant_configuration", r"\bcompliant\s+configuration\b", "evidence of a compliant configuration"),
+    _rule(
+        "audits_against_cis",
+        rf"\baudit(?:s|ed|ing|or)?\b\s+(?:\S+\s+){{0,4}}against\s+{THE}CIS\b",
+        "audit against CIS",
+        "audits the local machine against CIS controls",
+        "audited against CIS",
+        "auditing against CIS",
+        "auditor against CIS",
+        "audits read-only against the CIS Benchmarks",
+    ),
+    _rule(
+        "against_cis",
+        rf"\bagainst\s+{THE}CIS\s+(?:\S+\s+){{0,4}}(?:controls?|benchmarks?)\b",
+        "against CIS control",
+        "against CIS controls",
+        "against CIS benchmark",
+        "against CIS Benchmarks",
+        "against the CIS Benchmarks",
+        "against CIS Microsoft Windows Benchmarks",
+    ),
+    _rule(
+        "maps_every_finding",
+        r"\bmap(?:s|ped|ping)?\s+(?:every|each)\s+finding\b",
+        "map every finding",
+        "maps each finding",
+        "mapped every finding",
+        "mapping each finding",
+    ),
+    _rule(
+        "every_finding_mapped",
+        rf"\b(?:every|each)\s+finding\s+(?:is\s+|gets\s+)?(?:mapped|annotated|linked|tagged|cross{DASH}referenced)\b",
+        "every finding mapped",
+        "each finding is annotated",
+        "every finding gets linked",
+        "each finding tagged",
+        *(f"every finding cross{dash}referenced" for dash in _DASHES),
+    ),
+    _rule(
+        "remediation_every_finding",
+        r"\bremediation\b\s+(?:\S+\s+){0,2}(?:on|for)\s+(?:every|each)\s+(?:finding|check)\b",
+        "remediation on every finding",
+        "remediation for each check",
+        "remediation on each check",
+        "remediation for every finding",
+        "remediation guidance for every finding",
+        "remediation guidance provided on each check",
+    ),
+)
+
+ALLOWED: tuple[Allowed, ...] = (
+    Allowed(
+        "docs/vs-cis-cat/index.html",
+        "CIS-CAT Lite is CIS's own free assessor and scores a machine against the CIS Benchmarks",
+        1,
+    ),
+)
+
+CATEGORIES: dict[str, tuple[str, ...]] = {
+    "readme": ("README.md",),
+    "docs_html": ("docs/**/*.html",),
+    "docs_llms": ("docs/llms.txt",),
+    "templates": ("src/apotrope/templates/*.j2",),
+}
+
+
+def _require_root(root: Path) -> None:
+    pyproject = root / "pyproject.toml"
+    if not pyproject.is_file():
+        raise RuntimeError(f"pyproject.toml not found under {root}")
+    if not re.search(r'^name\s*=\s*"apotrope"', pyproject.read_text(encoding="utf-8"), re.MULTILINE):
+        raise RuntimeError(f"pyproject.toml under {root} does not name apotrope")
+
+
+def repo_root() -> Path:
+    """The apotrope checkout this module lives in, validated by its pyproject."""
+    root = Path(__file__).resolve().parents[1]
+    _require_root(root)
+    return root
+
+
+def discover(root: Path) -> list[Path]:
+    """Every public-copy file under ``root``. Each category must find at least one file."""
+    root = root.resolve()
+    _require_root(root)
+    found: set[Path] = set()
+    for category, patterns in CATEGORIES.items():
+        hits = {p.resolve() for pattern in patterns for p in root.glob(pattern) if p.is_file()}
+        if not hits:
+            raise RuntimeError(f"discovery category {category!r} found no files under {root}")
+        found |= hits
+    files = sorted(found)
+    for path in files:
+        if not path.is_relative_to(root):
+            raise RuntimeError(f"{path} resolves outside {root}")
+    return files
+
+
+def _suppressed_spans(root: Path, discovered: set[Path]) -> dict[Path, list[tuple[int, int]]]:
+    spans: dict[Path, list[tuple[int, int]]] = {}
+    for allowed in ALLOWED:
+        path = (root / allowed.path).resolve()
+        if path not in discovered:
+            raise PolicyError(f"exception path {allowed.path!r} not discovered under {root}")
+        text = path.read_text(encoding="utf-8")
+        starts = [m.start() for m in re.finditer(re.escape(allowed.fragment), text)]
+        if len(starts) != allowed.count:
+            raise PolicyError(
+                f"expected {allowed.count} occurrence(s) of {allowed.fragment!r} in {allowed.path}, found {len(starts)}"
+            )
+        spans[path] = [(s, s + len(allowed.fragment)) for s in starts]
+    return spans
+
+
+def scan(root: Path) -> list[Finding]:
+    """Report every prohibited match in the public copy that is not inside an authorised span."""
+    root = root.resolve()
+    files = discover(root)
+    spans = _suppressed_spans(root, set(files))
+    findings: list[Finding] = []
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        file_spans = spans.get(path, [])
+        for rule in PROHIBITED:
+            for match in rule.pattern.finditer(text):
+                if any(s <= match.start() and match.end() <= e for s, e in file_spans):
+                    continue
+                line = text.count("\n", 0, match.start()) + 1
+                findings.append(Finding(path, line, rule.name, match.start(), match.end(), match.group(0)))
+    findings.sort(key=lambda f: (str(f.path), f.line, f.start, f.rule))
+    return findings


### PR DESCRIPTION
## Summary

Public copy and the executive report now describe the score as Apotrope's own 0-100 posture metric. CIS Benchmark recommendation IDs are shown on applicable findings - not every check has a CIS mapping - and remediation is described as provided for failed and warning checks.

## Invariant (now enforced by `tools/public_claims.py` + `tests/test_public_claims.py`)

- Apotrope produces its own 0-100 posture score.
- CIS references are optional mappings on applicable findings.
- Never imply every finding has a CIS mapping or carries remediation.
- Never describe Apotrope as producing an official CIS score, a CIS compliance verdict, or a formal compliance artifact.

## Files

- README.md, docs/index.html, docs/llms.txt, docs/lynis-for-windows/index.html, docs/vs-cis-cat/index.html, docs/vs-harden-windows-security/index.html - public copy (including two claims that wrapped across lines and one "every finding ships with a fix" sentence the scanner surfaced)
- src/apotrope/templates/exec_report.html.j2 - "% compliant" -> "% of checks passed"; "compliant configuration" -> record of checks passed
- docs/exec-report.html - regenerated from tools/fixtures/sample_report.json (docs/report.html unchanged)
- tools/public_claims.py, tests/test_public_claims.py - ten prohibited-claim rules, one path-scoped exception (count exactly 1), discovery contract, positive target assertions; 100% branch coverage of the scanner
- CHANGELOG.md - [Unreleased] Changed entry

No scoring logic changed. No remediation command changed.

## Maintainer note

Required-status-checks change completed 2026-09-05: ruleset 14016817 now requires the six `test.yml` contexts; canary run 33969113200 on this branch verified E1/E2/E4 with the final live attestation equal to the intended state at 2026-09-05T13:36:47Z (E3 pending-state observation not captured; recorded in issue #108, comment 5552285749). **Canary-related merge hold cleared; merge remains subject to passing required checks on the new head.**